### PR TITLE
Fail can fail just a keyword and be used in Wait Until Keywords Succeeds

### DIFF
--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -434,6 +434,10 @@ class _Verify:
         | Fail | OS not supported | -regression | | # Removes tag 'regression'.        |
         | Fail | My message       | tag    | -t*  | # Removes all tags starting with 't' except the newly added 'tag'. |
 
+        If `Fail` is called from a keyword, the failure can be caught by
+        the caller (e.g. with `Wait Until Keyword Succeeds`) and test will
+        continue.
+        
         See `Fatal Error` if you need to stop the whole test execution.
 
         Support for modifying tags was added in Robot Framework 2.7.4 and
@@ -1501,7 +1505,10 @@ class _RunKeyword:
         | ${result} = | Wait Until Keyword Succeeds | 30 s | 1 s | My keyword |
 
         Errors caused by invalid syntax, test or keyword timeouts, or fatal
-        exceptions are not caught by this keyword.
+        exceptions are not caught by this keyword. 
+        
+        Errors caused by `fail` keyword are caught whereas those caused by
+        `fatal error` are not.
 
         Running the same keyword multiple times inside this keyword can create
         lots of output and considerably increase the size of the generated


### PR DESCRIPTION
I was looking for a "fail keyword" keyword because I thought that "fail" would terminate my test totally, whereas in fact it fails "gently" and can be caught in a wait until keyword succeeds. So I am trying to share this by putting it in the doc.

Context:
- In a test I call a "wait until keyword succeeds  my_keyword_that_may_fail"
- in my_keyword_that_may_fail I compute a return value that I want to send back. But sometimes this computation does not return a proper value because my SUT is not ready. In that case I want to quit my keyword with a status=failed. Before I used to do a dummy "run keyword if  ${sut_not_ready}  should be equal  1  2" but a  "run keyword if  ${sut_not_ready} fail try_again" is nicer.
