### PR TITLE
Fixed typos in user guide

### DIFF
--- a/doc/userguide/src/CreatingTestData/CreatingUserKeywords.rst
+++ b/doc/userguide/src/CreatingTestData/CreatingUserKeywords.rst
@@ -101,7 +101,7 @@ first row of the documentation is shown as a keyword documentation in
 Sometimes keywords need to be removed, replaced with new ones, or
 deprecated for other reasons.  User keywords can be marked deprecated
 by starting the documentation with `*DEPRECATED*`, which will
-cause a warning when the keyoword is used. For more information, see
+cause a warning when the keyword is used. For more information, see
 `Deprecating keywords`_ section.
 
 User keyword arguments
@@ -126,7 +126,7 @@ given and then argument names are defined in the subsequent
 cells. Each argument is in its own cell, using the same syntax as with
 variables. The keyword must be used with as many arguments as there
 are argument names in its signature. The actual argument names do not
-matter to the framework, but from users' perspective they should should
+matter to the framework, but from users' perspective they should
 be as descriptive as possible. It is recommended
 to use lower-case letters in variable names, either as
 `${my_arg}`, `${my arg}` or `${myArg}`.

--- a/doc/userguide/src/ExecutingTestCases/OutputFiles.rst
+++ b/doc/userguide/src/ExecutingTestCases/OutputFiles.rst
@@ -340,7 +340,7 @@ Configuring displayed suite statistics
 
 When a deeper suite structure is executed, showing all the test suite
 levels in the :name:`Statistics by Suite` table may make the table
-somewhat difficult to read. Bt default all suites are shown, but you can
+somewhat difficult to read. By default all suites are shown, but you can
 control this with the command line option :option:`--suitestatlevel` which
 takes the level of suites to show as an argument::
 

--- a/doc/userguide/src/ExtendingRobotFramework/CreatingTestLibraries.rst
+++ b/doc/userguide/src/ExtendingRobotFramework/CreatingTestLibraries.rst
@@ -848,7 +848,7 @@ Argument types
 Normally keyword arguments come to Robot Framework as strings. If
 keywords require some other types, it is possible to either use
 variables_ or convert strings to required types inside keywords. With
-`Java keywords`__ base types are also coerced automatically.
+`Java keywords`__ base types are also conversed automatically.
 
 __ `Argument types with Java`_
 
@@ -873,15 +873,15 @@ Argument types with Java
 
 Arguments to Java methods have types, and all the base types are
 handled automatically. This means that arguments that are normal
-strings in the test data are coerced to correct type at runtime. The
-types that can be coerced are:
+strings in the test data are conversed to correct type at runtime. The
+types that can be conversed are:
 
 - integer types (`byte`, `short`, `int`, `long`)
 - floating point types (`float` and `double`)
 - the `boolean` type
 - object versions of the above types e.g. `java.lang.Integer`
 
-The coercion is done for arguments that have the same or compatible
+The conversion is done for arguments that have the same or compatible
 type across all the signatures of the keyword method. In the following
 example, the conversion can be done for keywords `doubleArgument`
 and `compatibleTypes`, but not for `conflictingTypes`.
@@ -896,7 +896,7 @@ and `compatibleTypes`, but not for `conflictingTypes`.
    public void conflictingTypes(String arg1, int arg2) {}
    public void conflictingTypes(int arg1, String arg2) {}
 
-The coercion works with the numeric types if the test data has a
+The conversion works with the numeric types if the test data has a
 string containing a number, and with the boolean type the data must
 contain either string `true` or `false`. Coercion is only
 done if the original value was a string from the test data, but it is
@@ -904,7 +904,7 @@ of course still possible to use variables containing correct types with
 these keywords. Using variables is the only option if keywords have
 conflicting signatures.
 
-.. table:: Using automatic type coercion
+.. table:: Using automatic type conversion
    :class: example
 
    ===========  =================  =============  ==========  =====================
@@ -920,7 +920,7 @@ conflicting signatures.
    \            Conflicting Types  ${1}           2
    ===========  =================  =============  ==========  =====================
 
-Starting from Robot Framework 2.8, argument type coercion works also with
+Starting from Robot Framework 2.8, argument type conversion works also with
 `Java library constructors`__.
 
 __ `Providing arguments to test libraries`_


### PR DESCRIPTION
Typos corrected in local copy and verified that html user guide could be created accoording to instructions.
