### PR TITLE
robot.utils: PYTHON2/3 checks and common types and type checks for future py3 support

### DIFF
--- a/src/robot/utils/__init__.py
+++ b/src/robot/utils/__init__.py
@@ -51,7 +51,7 @@ from .match import eq, Matcher, MultiMatcher
 from .misc import (isatty, getdoc, plural_or_not, printable_name,
                    seq2str, seq2str2)
 from .normalizing import lower, normalize, NormalizedDict
-from .platform import IRONPYTHON, JYTHON, UNIXY, WINDOWS
+from .platform import PYTHON2, PYTHON3, IRONPYTHON, JYTHON, UNIXY, WINDOWS
 from .recommendations import RecommendationFinder
 from .robotenv import get_env_var, set_env_var, del_env_var, get_env_vars
 from .robotinspect import is_java_init, is_java_method
@@ -60,7 +60,13 @@ from .robottime import (elapsed_time_to_string, format_time, get_elapsed_time,
                         get_time, get_timestamp, secs_to_timestamp,
                         secs_to_timestr, timestamp_to_secs, timestr_to_secs,
                         parse_time)
-from .robottypes import is_dict_like, is_list_like, is_str_like, type_name
+from .robottypes import (long, bytes, unicode,
+                         UserString, UserList, UserDict,
+                         is_integer, is_number,
+                         is_bytes, is_bytes_like,
+                         is_string, is_string_like,
+                         is_unicode, is_unicode_like,
+                         is_dict_like, is_list_like, is_str_like, type_name)
 from .setter import setter
 from .text import (cut_long_message, format_assign_message,
                    pad_console_length, get_console_length)

--- a/src/robot/utils/platform.py
+++ b/src/robot/utils/platform.py
@@ -16,6 +16,8 @@ import os
 import sys
 
 
+PYTHON2 = sys.version_info[0] == 2
+PYTHON3 = not PYTHON2
 JYTHON = sys.platform.startswith('java')
 IRONPYTHON = sys.platform == 'cli'
 UNIXY = os.sep == '/'

--- a/src/robot/utils/robottypes.py
+++ b/src/robot/utils/robottypes.py
@@ -12,9 +12,22 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from .platform import PYTHON3, IRONPYTHON
 from collections import Mapping
-from UserDict import UserDict
-from UserString import UserString
+if PYTHON3:
+    from collections import UserList, UserDict, UserString
+else:
+    from UserList import UserList
+    from UserDict import UserDict
+    from UserString import UserString, MutableString
+if PYTHON3:
+    long = int
+    bytes = bytes
+    unicode = str
+else:
+    long = long
+    bytes = str if not IRONPYTHON else bytes
+    unicode = unicode
 try:
     from java.lang import String
 except ImportError:
@@ -31,6 +44,50 @@ def type_name(item):
 
 def is_str_like(item):
     return isinstance(item, (basestring, UserString, String))
+
+
+if PYTHON3:
+    _integer = int
+    _number = int, float
+    _bytes = bytes
+    _bytes_like = bytes, bytearray
+    _string = str
+    _string_like = str, UserString
+else:
+    _integer = int, long
+    _number = int, long, float
+    _bytes = str
+    _bytes_like = str, bytearray, UserString, MutableString, String
+    _string = basestring
+    _string_like = basestring, UserString, MutableString, String
+
+
+def is_integer(item):
+    return isinstance(item, _integer)
+
+def is_number(item):
+    return isinstance(item, _number)
+
+def is_bytes(item):
+    return isinstance(item, _bytes)
+
+def is_bytes_like(item):
+    return isinstance(item, _bytes_like)
+
+def is_string(item):
+    return isinstance(item, _string)
+
+def is_string_like(item):
+    return isinstance(item, _string_like)
+
+if PYTHON3:
+    is_unicode = is_string
+    is_unicode_like = is_string_like
+else:
+    def is_unicode(item):
+        return isinstance(item, unicode)
+
+    is_unicode_like = is_unicode
 
 
 def is_list_like(item):


### PR DESCRIPTION
As discussed in #1506 I started adding `PYTHON2/3` check vars and `is_<type>/<type>_like` check functions to `robot.utils`. I also added common `long`, `bytes` and `unicode` definitions and common `UserString/List/Dict` imports. If that stuff is ok this way I will add tests...