### PR TITLE
check for detached stream buffer in utils.misc.isatty()

### DIFF
--- a/src/robot/utils/misc.py
+++ b/src/robot/utils/misc.py
@@ -110,6 +110,9 @@ def getdoc(item):
 if not IRONPYTHON:
 
     def isatty(stream):
+        # first check if buffer was detached
+        if hasattr(stream, 'buffer') and stream.buffer is None:
+            return False
         return hasattr(stream, 'isatty') and stream.isatty()
 
 else:


### PR DESCRIPTION
If the `.buffer` of an `io` module based stream was detached, the `stream.isatty()` method called in `utils.misc.isatty()` will raise a `ValueError`. As `utils.misc.isatty()` is usually only applied to `sys.stdout` and `sys.stderr` it most likely won't happen in __Python 2__. But who knows what other streams this function might be used with or what other projects might do with `sys.std...` before importing `robot`. And the buffer check is definitely needed for __Python 3__ compatibility. I encountered it recently on adding __Sphinx__ based docs to my __robotframework-tools__ project and running `setup.py build_sphinx` with __Python 3__, using a _conf.py_ which imports `robot`. And just imprting `robot` is enough, because the creation of `robot.output.logger.LOGGER` leads to the use of `isatty()`. Maybe my fix is not at the best place and streams should be checked earlier...