### PR TITLE
Support list of instances at ROBOT_LIBRARY_LISTENER

### DIFF
--- a/src/robot/output/librarylisteners.py
+++ b/src/robot/output/librarylisteners.py
@@ -48,9 +48,10 @@ class LibraryListeners(Listeners):
         from robot.running import EXECUTION_CONTEXTS
         if not EXECUTION_CONTEXTS.current:
             return []
-        listeners = [_LibraryListenerProxy(library) for library in
-                     EXECUTION_CONTEXTS.current.namespace.libraries
-                     if library.has_listener]
+        listeners = [_LibraryListenerProxy(library, listener)
+                     for library in EXECUTION_CONTEXTS.current.namespace.libraries
+                     if library.has_listener
+                     for listener in library.listeners]
         for listener in listeners:
             if listener.library_scope == 'GLOBAL':
                 self._global_listeners[listener.logger] = listener
@@ -59,10 +60,10 @@ class LibraryListeners(Listeners):
 
 class _LibraryListenerProxy(ListenerProxy):
 
-    def __init__(self, library):
-        AbstractLoggerProxy.__init__(self, library.listener)
-        self.name = library.__class__.__name__
-        self.version = self._get_version(library.listener)
+    def __init__(self, library, listener):
+        AbstractLoggerProxy.__init__(self, listener)
+        self.name = listener.__class__.__name__
+        self.version = self._get_version(listener)
         self.library_scope = library.scope
 
     def _get_method_names(self, name):

--- a/src/robot/running/testlibraries.py
+++ b/src/robot/running/testlibraries.py
@@ -91,13 +91,17 @@ class _BaseTestLibrary(object):
         return self._doc
 
     @property
-    def listener(self):
+    def listeners(self):
         if self.has_listener:
-            return self._get_listener(self.get_instance())
+            return self._get_listeners(self.get_instance())
         return None
 
-    def _get_listener(self, inst):
-        return getattr(inst, 'ROBOT_LIBRARY_LISTENER', None)
+    def _get_listeners(self, inst):
+        try:
+            listeners = getattr(inst, 'ROBOT_LIBRARY_LISTENER')
+            return listeners if isinstance(listeners, list) else [listeners]
+        except AttributeError:
+            return None
 
     def create_handlers(self):
         self._create_handlers(self.get_instance())
@@ -163,7 +167,7 @@ class _BaseTestLibrary(object):
         if self._libinst is None:
             self._libinst = self._get_instance(self._libcode)
         if self.has_listener is None:
-            self.has_listener = self._get_listener(self._libinst) is not None
+            self.has_listener = self._get_listeners(self._libinst) is not None
         return self._libinst
 
     def _get_instance(self, libcode):
@@ -298,7 +302,7 @@ class _ModuleLibrary(_BaseTestLibrary):
 
     def get_instance(self):
         if self.has_listener is None:
-            self.has_listener = self._get_listener(self._libcode) is not None
+            self.has_listener = self._get_listeners(self._libcode) is not None
         return self._libcode
 
     def _create_init_handler(self, libcode):


### PR DESCRIPTION
This is a pull request for issue #1970.

Are missing tests and docs, but wanted to get this checked before moving on.

I've locally executed the tests at ```atests/robot/output/listener_interface/``` using Python (2.6.5) and Jython (was only able to run with 2.7rc2) to be sure this did not break anything.