### PR TITLE
switch code samples in the User Guide from HTML format to Plain text format #1972

### DIFF
--- a/doc/userguide/src/Appendices/DocumentationFormatting.rst
+++ b/doc/userguide/src/Appendices/DocumentationFormatting.rst
@@ -22,70 +22,14 @@ __ `Documenting libraries`_
 Representing newlines
 ---------------------
 
-Adding newlines manually in test data
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The documentation of test suites, test cases and keywords as well as
-the test suite metadata are subject to `general parsing rules`__ of the
-test data. This means that normal newlines are not preserved and
-dividing documentation into lines and paragraphs generally requires
-using a `literal newline character sequence`__ (`\n`). This is
-shown in the example below.
-
-__ `Test data syntax`_
-__ `Handling whitespace`_
-
-.. raw:: html
-
-   <table class="example docutils">
-     <caption>Adding newlines manually</caption>
-     <tr>
-       <th>Setting</th>
-       <th>Value</th>
-       <th>Value</th>
-     </tr>
-     <tr>
-       <td>Documentation</td>
-       <td>
-         First line.\n<br>\n<br>
-         Second paragraph, this time\n<br>with multiple lines.
-       </td>
-       <td>&nbsp;</td>
-     </tr>
-     <tr>
-       <td>Metadata</td>
-       <td>Example</td>
-       <td>Value\n<br>in two lines</td>
-     </tr>
-   </table>
-
 Automatic newlines in test data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Adding newlines manually to a long documentation takes some effort and
-extra characters also make the documentation in the test data slightly
-harder to read. Starting from Robot Framework 2.7, this is not always
-required as newlines are inserted automatically between `continued
-documentation and metadata lines`__. In practice this means that the
-above example could be written also as follows.
-
-.. table:: Automatic newlines
-   :class: example
-
-   =============  ===========================
-      Setting                Value
-   =============  ===========================
-   Documentation  First line.
-   ...
-   ...            Second paragraph, this time
-   ...            with multiple lines.
-   Metadata       Example
-   ...            Value
-   ...            in two lines
-   =============  ===========================
-
-This style works especially well in the `plain text format`_ where the
-same example could be written like this:
+Adding newlines in the documentation of test suites, test cases and
+keywords as well as the test suite metadata can be done using a literal
+newline character sequence (`\n`). Starting from Robot Framework 2.7, 
+newlines are inserted automatically between `continued documentation 
+and metadata lines`__  as illustrated in the following examples.
 
 .. sourcecode:: robotframework
 
@@ -110,22 +54,21 @@ the same two line documentation.
 __ `Dividing test data to several rows`_
 __ Escaping_
 
-.. table:: Multiline documentation examples
-   :class: example
+.. sourcecode:: robotframework
 
-   =========  ===============  ================  ==============  ==============
-   Test Case      Action           Argument         Argument       Argument
-   =========  ===============  ================  ==============  ==============
-   Example 1  [Documentation]  First line\\n     Second line in  multiple parts
-   \          No Operation
-   Example 2  [Documentation]  First line
-   \          ...              Second line in    multiple parts
-   \          No Operation
-   Example 3  [Documentation]  First line\\n
-   \          ...              Second line in\\
-   \          ...              multiple parts
-   \          No Operation
-   =========  ===============  ================  ==============  ==============
+  *** Test Cases ***
+   Example 1  
+       [Documentation]    First line\n    Second line in    multiple parts
+       No Operation
+   Example 2
+       [Documentation]   First line
+       ...               Second line in    multiple parts
+       No Operation
+   Example 3 
+       [Documentation]    First line\n
+       ...                Second line in\n
+       ...                multiple parts
+       No Operation
 
 Documentation in test libraries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/userguide/src/CreatingTestData/AdvancedFeatures.rst
+++ b/doc/userguide/src/CreatingTestData/AdvancedFeatures.rst
@@ -144,44 +144,40 @@ occurs, because they are normally engaged in important clean-up
 activities. If necessary, it is possible to interrupt also these
 keywords with `user keyword timeouts`_.
 
-.. table:: Test timeout examples
-   :class: example
+.. sourcecode:: robotframework
 
-   ============  =========  =======  =======
-     Setting       Value     Value    Value
-   ============  =========  =======  =======
-   Test Timeout  2 minutes
-   ============  =========  =======  =======
+   *** Settings ***
+   Test Timeout    2 minutes
 
-.. table::
-   :class: example
-
-   ===============  ===============  ========================================  ==========================  ==================
-      Test Case         Action                      Argument                           Argument                 Argument
-   ===============  ===============  ========================================  ==========================  ==================
-   Default Timeout  [Documentation]  Timeout from the Setting table is used
-   \                Some Keyword     argument
-   \
-   Override         [Documentation]  Override default, use 10 seconds timeout
-   \                [Timeout]        10
-   \                Some Keyword     argument
-   \
-   Custom Message   [Documentation]  Override default and use custom message
-   \                [Timeout]        1min 10s                                  This is my custom error.    It continues here.
-   \                Some Keyword     argument
-   \
-   Variables        [Documentation]  It is possible to use variables too
-   \                [Timeout]        ${TIMEOUT}
-   \                Some Keyword     argument
-   \
-   No Timeout       [Documentation]  Empty timeout means no timeout even when  Test Timeout has been used
-   \                [Timeout]
-   \                Some Keyword     argument
-   \
-   No Timeout 2     [Documentation]  Empty timeout using NONE, works           as well
-   \                [Timeout]        NONE
-   \                Some Keyword     argument
-   ===============  ===============  ========================================  ==========================  ==================
+   *** Test Cases ***
+   Default Timeout
+       [Documentation]    Timeout from the Setting table is used
+       Some Keyword    argument
+   
+   Override
+       [Documentation]    Override default, use 10 seconds timeout
+       [Timeout]    10
+       Some Keyword    argument
+   
+   Custom Message
+       [Documentation]    Override default and use custom message
+       [Timeout]    1min 10s    This is my custom error
+       Some Keyword    argument
+   
+   Variables
+       [Documentation]    It is possible to use variables too
+       [Timeout]    ${TIMEOUT}
+       Some Keyword    argument
+   
+   No Timeout
+       [Documentation]    Empty timeout means no timeout even when Test Timeout has been used
+       [Timeout]
+       Some Keyword    argument
+   
+   No Timeout 2
+       [Documentation]    Empty timeout using NONE, works as well
+       [Timeout]    NONE
+       Some Keyword    argument
 
 User keyword timeout
 ~~~~~~~~~~~~~~~~~~~~
@@ -193,22 +189,20 @@ identical to the syntax used with `test case timeouts`_. If no custom
 message is provided, the default error message `Keyword timeout
 <time> exceeded` is used if a timeout occurs.
 
-.. table:: User keyword timeout examples
-   :class: example
+.. sourcecode:: robotframework
 
-   =================  =================  ==========================  ===========================================
-        Keyword             Action                 Argument                           Argument
-   =================  =================  ==========================  ===========================================
-   Timed Keyword      [Documentation]    Set only the timeout value  and not the custom message.
-   \                  [Timeout]          1 minute 42 seconds
-   \                  Do Something
-   \                  Do Something Else
-   \
-   Timed-out Wrapper  [Arguments]        @{args}
-   \                  [Documentation]    This keyword is a wrapper   that adds a timeout to another keyword.
-   \                  [Timeout]          2 minutes                   Original Keyword didn't finish in 2 minutes
-   \                  Original Keyword   @{args}
-   =================  =================  ==========================  ===========================================
+   *** Keywords ***
+   Timed Keyword
+       [Documentation]    Set only the timeout value and not the custom message.
+       [Timeout]    1 minute 42 seconds
+       Do Something
+       Do Something Else
+   
+   Timed-out Wrapper
+       [Arguments]    @{args}
+       [Documentation]    This keyword is a wrapper that adds a timeout to another keyword.
+       [Timeout]    2 minutes    Original Keyword didn't finish in 2 minutes
+       Original Keyword    @{args}
 
 A user keyword timeout is applicable during the execution of that user
 keyword. If the total time of the whole keyword is longer than the
@@ -253,26 +247,25 @@ next cell contains the loop variable, the subsequent cell must have
 These values can contain variables_, including `list variables`_.
 
 The keywords used in the for loop are on the next rows and they must
-be indented one cell to the right. The for loop ends when the indentation
-returns back to normal or the table ends. Having nested for loops
-directly is not supported, but it is possible to use a user keyword
-inside a for loop and have another for loop there.
+be indented one cell to the right (remember to escape__ the indented
+cell using a backslash). The for loop ends when the indentation returns 
+back to normal or the table ends. Having nested for loops directly is
+not supported, but it is possible to use a user keyword inside a for
+loop and have another for loop there.
 
-.. table:: Simple for loops
-   :class: example
+.. sourcecode:: robotframework
 
-   ===========  ========  ============  ===========  ==========  ===========
-    Test Case    Action     Argument     Argument     Argument    Arguments
-   ===========  ========  ============  ===========  ==========  ===========
-   Example 1    :FOR      ${animal}     IN           cat         dog
-   \                      Log           ${animal}
-   \                      Log           2nd keyword
-   \            Log       Outside loop
-   \
-   Example 2    :FOR      ${var}        IN           one         two
-   \            ...       ${3}          four         ${last}
-   \                      Log           ${var}
-   ===========  ========  ============  ===========  ==========  ===========
+   *** Test Cases ***
+   Example 1
+       :FOR    ${animal}    IN    cat    dog
+       \    Log    ${animal}
+       \    Log    2nd keyword
+       Log    Outside loop
+       
+   Example 2
+       :FOR    ${var}    IN    one    two
+       ...     ${3}    four    ${last}
+       \    Log    ${var}
 
 The for loop in :name:`Example 1` above is executed twice, so that first
 the loop variable `${animal}` has the value `cat` and then
@@ -280,32 +273,17 @@ the loop variable `${animal}` has the value `cat` and then
 second example, loop values are `split into two rows`__ and the
 loop is run altogether five times.
 
-.. tip:: If you use for loops in `plain text format`_ files, remember to
-         escape__ the indented cell using a backslash:
-
-         .. sourcecode:: robotframework
-
-              *** Test Case ***
-              Example 1
-                  :FOR    ${animal}    IN    cat    dog
-                  \    Log    ${animal}
-                  \    Log    2nd keyword
-                  Log    Outside loop
-
 It is often convenient to use for loops with `list variables`_. This is
 illustrated by the example below, where `@{ELEMENTS}` contains
 an arbitrarily long list of elements and keyword :name:`Start Element` is
 used with all of them one by one.
 
-.. table:: For loop with a list variable
-   :class: example
+.. sourcecode:: robotframework
 
-   ===========  ========  =============  ==========  ===========  ===========
-    Test Case    Action     Argument      Argument    Argument     Arguments
-   ===========  ========  =============  ==========  ===========  ===========
-   Example      :FOR      ${element}     IN          @{ELEMENTS}
-   \                      Start Element  ${element}
-   ===========  ========  =============  ==========  ===========  ===========
+   *** Test Cases ***
+   Example
+       :FOR    ${element}    IN    @{ELEMENTS}
+       \    Start Element  ${element}
 
 __ `Dividing test data to several rows`_
 __ Escaping_
@@ -322,21 +300,18 @@ variables.
 If there are lot of values to iterate, it is often convenient to organize
 them below the loop variables, as in the first loop of the example below:
 
-.. table:: Using multiple loop variables
-   :class: example
+.. sourcecode:: robotframework
 
-   ===========  ========  ===========  ==========  ==========  ============
-    Test Case    Action     Argument    Argument    Argument    Arguments
-   ===========  ========  ===========  ==========  ==========  ============
-   Example      :FOR      ${index}     ${english}  ${finnish}  IN
-   \            ...       1            cat         kissa
-   \            ...       2            dog         koira
-   \            ...       3            horse       hevonen
-   \                      Do X         ${english}
-   \                      Y Should Be  ${finnish}  ${index}
-   \            :FOR      ${name}      ${id}       IN          @{EMPLOYERS}
-   \                      Create       ${name}     ${id}
-   ===========  ========  ===========  ==========  ==========  ============
+   *** Test Cases ***
+   Example      
+       :FOR    ${index}    ${english}    ${finnish}    IN
+       ...     1           cat           kissa
+       ...     2           dog           koira
+       ...     3           horse         hevonen
+       \    Do X    ${english}
+       \    Y Should Be    ${finnish}    ${index}
+       :FOR    ${name}    ${id}    IN    @{EMPLOYERS}
+       \    Create    ${name}    ${id}
 
 For in range
 ~~~~~~~~~~~~
@@ -368,36 +343,38 @@ specified with variables.
 Starting from Robot Framework 2.8.7, it is possible to use float values for
 lower limit, upper limit and step.
 
-.. table:: For in range examples
-   :class: example
+.. sourcecode:: robotframework
 
-   ================  ===============  ===========  =========  ===========  ========  =======
-      Test Case          Action        Argument     Argument    Arg          Arg       Arg
-   ================  ===============  ===========  =========  ===========  ========  =======
-   Only upper limit  [Documentation]  Loops over   values     from 0       to 9
-   \                 :FOR             ${index}     IN RANGE   10
-   \                                  Log          ${index}
-   \
-   Start and end     [Documentation]  Loops over   values     from 1       to 10
-   \                 :FOR             ${index}     IN RANGE   1            11
-   \                                  Log          ${index}
-   \
-   Also step given   [Documentation]  Loops over   values     5, 15,       and 25
-   \                 :FOR             ${index}     IN RANGE   5            26        10
-   \                                  Log          ${index}
-   \
-   Negative step     [Documentation]  Loops over   values     13, 3,       and -7
-   \                 :FOR             ${index}     IN RANGE   13           -13       -10
-   \                                  Log          ${index}
-   \
-   Arithmetics       [Documentation]  Arithmetics  with       variable
-   \                 :FOR             ${index}     IN RANGE   ${var}+1
-   \                                  Log          ${index}
-   \
-   Float parameters  [Documentation]  Loops over   values     3.14, 4.34,  and 5.34
-   \                 :FOR             ${index}     IN RANGE   3.14         6.09      1.2
-   \                                  Log          ${index}
-   ================  ===============  ===========  =========  ===========  ========  =======
+   *** Test Cases ***
+   Only upper limit  
+       [Documentation]    Loops over values from 0 to 9
+       :FOR    ${index}    IN RANGE    10
+       \    Log    ${index}
+   
+   Start and end
+       [Documentation]  Loops over values from 1 to 10
+       :FOR    ${index}    IN RANGE    1    11
+       \    Log    ${index}
+   
+   Also step given
+       [Documentation]  Loops over values 5, 15, and 25
+       :FOR    ${index}    IN RANGE    5    26    10
+       \    Log    ${index}
+   
+   Negative step
+       [Documentation]  Loops over values 13, 3, and -7
+       :FOR    ${index}    IN RANGE    13    -13    -10
+       \    Log    ${index}
+   
+   Arithmetics
+       [Documentation]  Arithmetics with variable
+       :FOR    ${index}    IN RANGE    ${var}+1
+       \    Log    ${index}
+   
+   Float parameters
+       [Documentation]  Loops over values 3.14, 4.34, and 5.34
+       :FOR    ${index}    IN RANGE    3.14    6.09    1.2
+       \    Log    ${index}
 
 Exiting for loop
 ~~~~~~~~~~~~~~~~
@@ -413,25 +390,22 @@ directly inside a for loop or in a keyword that the loop uses. In both cases
 test execution continues after the loop. It is an error to use these keywords
 outside a for loop.
 
-.. table:: Exit for loop example
-   :class: example
+.. sourcecode:: robotframework
 
-   ============  ===============  ==============  =================  =============  ========
-     Test Case     Action           Argument        Argument          Argument      Argument
-   ============  ===============  ==============  =================  =============  ========
-   Exit Example  ${text}=         Set Variable    ${EMPTY}
-   \             :FOR             ${var}          IN                 one            two
-   \                              Run Keyword If  '${var}' == 'two'  Exit For Loop
-   \                              ${text}=        Set Variable       ${text}${var}
-   \             Should Be Equal  ${text}         one
-   ============  ===============  ==============  =================  =============  ========
+   *** Test Cases ***
+   Exit Example
+       ${text} =    Set Variable    ${EMPTY}
+       :FOR    ${var}    IN    one    two
+       \    Run Keyword If    '${var}' == 'two'    Exit For Loop
+       \    ${text} =    Set Variable    ${text}${var}
+       Should Be Equal    ${text}    one
 
 In the above example it would be possible to use :name:`Exit For Loop If`
 instead of using :name:`Exit For Loop` with :name:`Run Keyword If`.
 For more information about these keywords, including more usage examples,
 see their documentation in the BuiltIn_ library.
 
-.. note:: :name:`Exit For Loop If` keyword was added Robot Framework 2.8.
+.. note:: :name:`Exit For Loop If` keyword was added in Robot Framework 2.8.
 
 Continuing for loop
 ~~~~~~~~~~~~~~~~~~~
@@ -449,18 +423,15 @@ from the next iteration. If these keywords are used on the last iteration,
 execution continues after the loop. It is an error to use these keywords
 outside a for loop.
 
-.. table:: Continue for loop example
-   :class: example
+.. sourcecode:: robotframework
 
-   ================  ===============  ====================  =================  =============  ========  ========
-       Test Case         Action             Argument             Argument        Argument     Argument  Argument
-   ================  ===============  ====================  =================  =============  ========  ========
-   Continue Example  ${text}=         Set Variable          ${EMPTY}
-   \                 :FOR             ${var}                IN                 one            two       three
-   \                                  Continue For Loop If  '${var}' == 'two'
-   \                                  ${text} =             Set Variable       ${text}${var}
-   \                 Should Be Equal  ${text}               onethree
-   ================  ===============  ====================  =================  =============  ========  ========
+   *** Test Cases ***
+   Continue Example
+       ${text} =    Set Variable    ${EMPTY}
+       :FOR    ${var}    IN    one    two    three
+       \    Continue For Loop If    '${var}' == 'two'
+       \    ${text} =    Set Variable    ${text}${var}
+       Should Be Equal    ${text}    onethree
 
 For more information about these keywords, including usage examples, see their
 documentation in the BuiltIn_ library.
@@ -489,16 +460,13 @@ keyword and how many times to repeat it as arguments. The times to
 repeat the keyword can have an optional postfix `times` or `x`
 to make the syntax easier to read.
 
-.. table:: Repeat Keyword examples
-   :class: example
+.. sourcecode:: robotframework
 
-   ===========  ==============  ============  ============  ========  ========
-    Test Case       Action        Argument      Argument    Argument  Argument
-   ===========  ==============  ============  ============  ========  ========
-   Example      Repeat Keyword  5             Some Keyword  arg1      arg2
-   \            Repeat Keyword  42 times      My Keyword
-   \            Repeat Keyword  ${var}        Another KW    argument
-   ===========  ==============  ============  ============  ========  ========
+   *** Test Cases ***
+   Example
+       Repeat Keyword    5    Some Keyword    arg1    arg2
+       Repeat Keyword    42 times    My Keyword
+       Repeat Keyword    ${var}    Another Keyword    argument
 
 Conditional execution
 ---------------------

--- a/doc/userguide/src/CreatingTestData/CreatingTestCases.rst
+++ b/doc/userguide/src/CreatingTestData/CreatingTestCases.rst
@@ -37,22 +37,20 @@ contain possible arguments to the specified keyword.
 .. _setting variables from keyword return values: `User keyword return values`_
 
 .. _example-tests:
-.. table:: Example test cases
-   :class: example
+.. sourcecode:: robotframework
 
-   ==================  ===========================  ==================  ===============
-       Test Case                  Action                 Argument          Argument
-   ==================  ===========================  ==================  ===============
-   Valid Login         Open Login Page
-   \                   Input Name                   demo
-   \                   Input Password               mode
-   \                   Submit Credentials
-   \                   Welcome Page Should Be Open
-   \
-   Setting Variables   Do Something                 first argument      second argument
-   \                   ${value} =                   Get Some Value      \
-   \                   Should Be Equal              ${value}            Expected value
-   ==================  ===========================  ==================  ===============
+   *** Test Cases ***
+   Valid Login
+       Open Login Page
+       Input Name        demo
+       Input Password    mode
+       Submit Credentials
+       Welcome Page Should Be Open
+  
+   Setting Variables
+       Do Something    first argument    second argument
+       ${value} =    Get Some Value
+       Should Be Equal    ${value}    Expected value 
 
 Settings in the Test Case table
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -82,17 +80,15 @@ below and explained later in this section.
    Used for setting a `test case timeout`_. Timeouts_ are discussed in
    their own section.
 
+Example test case with settings:
 
-.. table:: Example test case with settings
-   :class: example
+.. sourcecode:: robotframework
 
-   ==================  ===========================  ==================  ===============
-       Test Case                  Action                 Argument          Argument
-   ==================  ===========================  ==================  ===============
-   Test With Settings  [Documentation]              Another dummy test
-   \                   [Tags]                       dummy               owner-johndoe
-   \                   Log                          Hello, world!
-   ==================  ===========================  ==================  ===============
+   *** Test Cases ***
+   Test With Settings
+       [Documentation]    Another dummy test
+       [Tags]    dummy    owner-johndoe
+       Log    Hello, world!
 
 Test case related settings in the Setting table
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -155,16 +151,13 @@ specified as `path` and `source, destination`, which means
 that they take one and two arguments, respectively. The last keyword,
 :name:`No Operation` from BuiltIn_, takes no arguments.
 
-.. table:: Keywords with positional arguments
-   :class: example
+.. sourcecode:: robotframework
 
-   =============  ================  ==================  ==================
-     Test Case         Action            Argument            Argument
-   =============  ================  ==================  ==================
-   Example        Create Directory  ${TEMPDIR}/stuff
-   \              Copy File         ${CURDIR}/file.txt  ${TEMPDIR}/stuff
-   \              No Operation
-   =============  ================  ==================  ==================
+   *** Test Cases ***
+   Example
+       Create Directory    ${TEMPDIR}/stuff
+       Copy File    ${CURDIR}/file.txt    ${TEMPDIR}/stuff
+       No Operation
 
 Default values
 ~~~~~~~~~~~~~~
@@ -185,16 +178,13 @@ Using default values is illustrated by the example below that uses
 encoding=UTF-8`. Trying to use it without any arguments or more than
 three arguments would not work.
 
-.. table:: Keywords with arguments having default values
-   :class: example
+.. sourcecode:: robotframework
 
-   =============  ================  =========================  ====================  ============
-     Test Case         Action               Argument                 Argument          Argument
-   =============  ================  =========================  ====================  ============
-   Example        Create File       ${TEMPDIR}/empty.txt
-   \              Create File       ${TEMPDIR}/utf-8.txt       Hyvä esimerkki
-   \              Create File       ${TEMPDIR}/iso-8859-1.txt  Hyvä esimerkki        ISO-8859-1
-   =============  ================  =========================  ====================  ============
+   *** Test Cases ***
+   Example
+       Create File    ${TEMPDIR}/empty.txt
+       Create File    ${TEMPDIR}/utf-8.txt         Hyvä esimerkki
+       Create File    ${TEMPDIR}/iso-8859-1.txt    Hyvä esimerkki    ISO-8859-1
 
 .. _varargs:
 
@@ -215,16 +205,13 @@ example below have arguments `*paths` and `base, *parts`,
 respectively. The former can be used with any number of arguments, but
 the latter requires at least one argument.
 
-.. table:: Keywords with variable number of arguments
-   :class: example
+.. sourcecode:: robotframework
 
-   =============  ================  =================  =================  =================
-     Test Case         Action            Argument           Argument           Argument
-   =============  ================  =================  =================  =================
-   Example        Remove Files      ${TEMPDIR}/f1.txt  ${TEMPDIR}/f2.txt  ${TEMPDIR}/f3.txt
-   \              @{paths} =        Join Paths         ${TEMPDIR}         f1.txt
-   \              ...               f2.txt             f3.txt             f4.txt
-   =============  ================  =================  =================  =================
+   *** Test Cases ***
+   Example
+       Remove Files    ${TEMPDIR}/f1.txt    ${TEMPDIR}/f2.txt    ${TEMPDIR}/f3.txt
+       @{paths} =    Join Paths    ${TEMPDIR}    f1.txt
+       ...           f2.txt    f3.txt    f4.txt
 
 .. _Named argument syntax:
 
@@ -285,31 +272,23 @@ matching them against argument names. This is a new feature in Robot Framework
 
 The named argument syntax requires the equal sign to be written literally
 in the keyword call. This means that variable alone can never trigger the
-named argument syntax, not even if it has a value like like `foo=bar`. This is
+named argument syntax, not even if it has a value like `foo=bar`. This is
 important to remember especially when wrapping keywords into other keywords.
 If, for example, a keyword takes a `variable number of arguments`_ like
 `@{args}` and passes all of them to another keyword using the same `@{args}`
 syntax, possible `named=arg` syntax used in the calling side is not recognized.
 This is illustrated by the example below.
 
-.. table:: Named arguments are not recognized from variable values
-   :class: example
+.. sourcecode:: robotframework
 
-   =============  ============  ============  ============
-     Test Case       Action       Argument      Argument
-   =============  ============  ============  ============
-   Example        Run Program   shell=True    # This will not come as a named argument to Run Process
-   =============  ============  ============  ============
+   *** Test Cases ***
+   Example        
+       Run Program    shell=True    # This will not come as a named argument to Run Process
 
-.. table::
-   :class: example
-
-   =============  ============  ============  ============  ============
-      Keyword        Action       Argument      Argument      Argument
-   =============  ============  ============  ============  ============
-   Run Program    [Arguments]   @{args}
-   \              Run Process   program.py    @{args}       # Named arguments are not recognized from inside @{args}
-   =============  ============  ============  ============  ============
+   *** Keywords ***
+   Run Program    
+       [Arguments]    @{args}
+       Run Process    program.py    @{args}    # Named arguments are not recognized from inside @{args}
 
 If keyword needs to accept and pass forward any named arguments, it must be
 changed to accept `free keyword arguments`_. See `kwargs examples`_ for
@@ -354,35 +333,22 @@ Named arguments example
 The following example demonstrates using the named arguments syntax with
 library keywords, user keywords, and when importing the Telnet_ test library.
 
-.. table:: Named argument example
-   :class: example
+.. sourcecode:: robotframework
 
-   =============  ===========  ===========  =======================
-      Setting        Value        Value             Value
-   =============  ===========  ===========  =======================
-   Library        Telnet       prompt=$     default_log_level=DEBUG
-   =============  ===========  ===========  =======================
+   *** Settings ***
+   Library    Telnet    prompt=$    default_log_level=DEBUG
 
-.. table::
-   :class: example
+   *** Test Cases ***
+   Example
+       Open connection    10.0.0.42    port=${PORT}    alias=example
+       List files    options=-lh
+       List files    path=/tmp    options=-l
 
-   =============  ================  ============  ============  =============
-     Test Case          Action        Argument      Argument      Argument
-   =============  ================  ============  ============  =============
-   Example        Open connection   10.0.0.42     port=${PORT}  alias=example
-   \              List files        options=-lh
-   \              List files        path=/tmp     options=-l
-   =============  ================  ============  ============  =============
-
-.. table::
-   :class: example
-
-   =============  =================  =====================  ============  ============
-     Keyword            Action              Argument          Argument      Argument
-   =============  =================  =====================  ============  ============
-   List files     [Arguments]        ${path}=.              ${options}=
-   \              Execute command    ls ${options} ${path}
-   =============  =================  =====================  ============  ============
+   *** Keywords ***
+   List files
+       [Arguments]    ${path}=.    ${options}=
+       List files    options=-lh
+       Execute command    ls ${options} ${path}
 
 Free keyword arguments
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -421,15 +387,12 @@ arguments (`**configuration`). The example below also shows that variables
 work with free keyword arguments exactly like when `using the named argument
 syntax`__.
 
-.. table:: Free keyword arguments with library keyword
-   :class: example
+.. sourcecode:: robotframework
 
-   =============  ============  ============  ============  ============  ==============
-     Test Case       Action       Argument      Argument      Argument       Argument
-   =============  ============  ============  ============  ============  ==============
-   Using Kwargs   Run Process   program.py    arg1          arg2          cwd=/home/user
-   \              Run Process   program.py    argument      shell=True    env=${ENVIRON}
-   =============  ============  ============  ============  ============  ==============
+   *** Test Cases ***
+   Using Kwargs
+       Run Process    program.py    arg1        arg2          cwd=/home/user
+       Run Process    program.py    argument    shell=True    env=${ENVIRON}
 
 See `Free keyword arguments (**kwargs)`_ section under `Creating test
 libraries`_ for more information about using the kwargs syntax in
@@ -440,25 +403,17 @@ As the second example, let's create a wrapper `user keyword`_ for running the
 accepts any number of arguments and kwargs, and passes them forward for
 :name:`Run Process` along with the name of the command to execute.
 
-.. table:: Free keyword arguments with user keyword
-   :class: example
+.. sourcecode:: robotframework
 
-   =============  ============  ============  ============  ==============
-     Test Case       Action       Argument      Argument      Argument
-   =============  ============  ============  ============  ==============
-   Using Kwargs   Run Program   arg1          arg2          cwd=/home/user
-   \              Run Program   argument      shell=True    env=${ENVIRON}
-   =============  ============  ============  ============  ==============
+   *** Test Cases ***
+   Using Kwargs
+       Run Program    arg1        arg2          cwd=/home/user
+       Run Program    argument    shell=True    env=${ENVIRON}
 
-.. table::
-   :class: example
-
-   =============  =================  ================  ================  ================
-      Keyword          Action            Argument          Argument          Argument
-   =============  =================  ================  ================  ================
-   Run Program    [Arguments]        @{arguments}      &{configuration}
-   \              Run Process        program.py        @{arguments}      &{configuration}
-   =============  =================  ================  ================  ================
+   *** Keywords ***
+   Run Program
+       [Arguments]    @{arguments}    &{configuration}
+       Run Process    program.py    @{arguments}    &{configuration}
 
 __ `Named arguments with variables`_
 
@@ -503,20 +458,15 @@ is enabled by starting the error message with marker string `*HTML*`.
 This marker will be removed from the final error message shown in reports
 and logs. Using HTML in a custom message is shown in the second example below.
 
-.. table:: Keyword error messages
-   :class: example
+.. sourcecode:: robotframework
 
-   +--------------+-----------------+---------------------+----------+-------------------------+
-   |  Test Case   |     Action      |       Argument      | Argument |        Argument         |
-   +==============+=================+=====================+==========+=========================+
-   | Normal Error | Fail            | This is a rather    |          |                         |
-   |              |                 | boring example...   |          |                         |
-   +--------------+-----------------+---------------------+----------+-------------------------+
-   | HTML Error   | ${number}=      | Get Number          |          |                         |
-   +--------------+-----------------+---------------------+----------+-------------------------+
-   |              | Should Be Equal | ${number}           | 42       | \*HTML\* Number is not  |
-   |              |                 |                     |          | my <b>MAGIC</b> number. |
-   +--------------+-----------------+---------------------+----------+-------------------------+
+   *** Test Cases ***
+   Normal Error
+       Fail    This is a rather boring example...
+       
+   HTML Error
+       ${number} =    Get Number
+       Should Be Equal    ${number}    42    \*HTML\* Number is not my <b>MAGIC</b> number.
 
 __ `Continue on failure`_
 __ `HTML in error messages`_
@@ -548,37 +498,30 @@ __ `Dividing test data to several rows`_
 __ `Automatic newlines in test data`_
 __ `Escaping`_
 
-.. table:: Test case documentation examples
-   :class: example
+.. sourcecode:: robotframework
 
-   +--------------+-----------------+----------------------+----------------------------+
-   |  Test Case   |     Action      |       Argument       |           Argument         |
-   +==============+=================+======================+============================+
-   | Simple       | [Documentation] | Simple documentation |                            |
-   +--------------+-----------------+----------------------+----------------------------+
-   |              | No Operation    |                      |                            |
-   +--------------+-----------------+----------------------+----------------------------+
-   | Splitting    | [Documentation] | This documentation   | it has been split into     |
-   |              |                 | is a bit longer and  | several columns.           |
-   +--------------+-----------------+----------------------+----------------------------+
-   |              | No Operation    |                      |                            |
-   +--------------+-----------------+----------------------+----------------------------+
-   | Many lines   | [Documentation] | Here we have         |                            |
-   +--------------+-----------------+----------------------+----------------------------+
-   |              | ...             | an automatic newline |                            |
-   +--------------+-----------------+----------------------+----------------------------+
-   |              | No Operation    |                      |                            |
-   +--------------+-----------------+----------------------+----------------------------+
-   | Formatting   | [Documentation] | \*This is bold\*,    | here is a link:            |
-   |              |                 | \_this italic\_  and | \http://robotframework.org |
-   +--------------+-----------------+----------------------+----------------------------+
-   |              | No Operation    |                      |                            |
-   +--------------+-----------------+----------------------+----------------------------+
-   | Variables    | [Documentation] | Executed at ${HOST}  |                            |
-   |              |                 | by ${USER}           |                            |
-   +--------------+-----------------+----------------------+----------------------------+
-   |              | No Operation    |                      |                            |
-   +--------------+-----------------+----------------------+----------------------------+
+   *** Test Cases ***
+   Simple
+       [Documentation]    Simple documentation
+       No Operation
+
+   Splitting
+       [Documentation]    This documentation is a bit longer and    it has been split into several parts.
+       No Operation
+
+   Many lines
+       [Documentation]    Here we have 
+       ...                an automatic newline
+       No Operation
+
+   Formatting
+       [Documentation]    *This is bold*, _this is italic_  and here is a link: http://robotframework.org
+       No Operation
+
+   Variables
+       [Documentation]    Executed at ${HOST} by ${USER} 
+       No Operation
+
 
 It is important that test cases have clear and descriptive names, and
 in that case they normally do not need any documentation. If the logic
@@ -640,72 +583,39 @@ to lowercase and all spaces are removed. If a test case gets the same tag
 several times, other occurrences than the first one are removed. Tags
 can be created using variables, assuming that those variables exist.
 
-.. table:: Tagging example
-   :class: example
+.. sourcecode:: robotframework
 
-   ============  ==========  =======  =======
-     Setting       Value      Value    Value
-   ============  ==========  =======  =======
-   Force Tags    req-42
-   Default Tags  owner-john  smoke
-   ============  ==========  =======  =======
+   *** Settings ***
+   Force Tags      req-42
+   Default Tags    owner-john    smoke
 
-.. table::
-   :class: example
+   *** Variables ***
+   ${HOST}    10.0.1.42
 
-   ==========  =========  =======  =======
-    Variable     Value     Value    Value
-   ==========  =========  =======  =======
-   ${HOST}     10.0.1.42
-   ==========  =========  =======  =======
+   *** Test Cases ***
+   No own tags
+       [Documentation]    This test has tags    owner-john, smoke, req-42
+       No Operation
 
-.. table::
-   :class: example
+   With own tags
+       [Documentation]    This test has tags    not_ready, owner-mrx, req-42
+       [Tags]    owner-mrx    not_ready
+       No Operation
 
-   +---------------+-----------------+---------------------+------------------------+
-   |   Test Case   |     Action      |       Argument      |         Argument       |
-   +===============+=================+=====================+========================+
-   | No own tags   | [Documentation] | This test has tags  | owner-john, smoke,     |
-   |               |                 |                     | req-42                 |
-   +---------------+-----------------+---------------------+------------------------+
-   |               | No Operation    |                     |                        |
-   +---------------+-----------------+---------------------+------------------------+
-   |               |                 |                     |                        |
-   +---------------+-----------------+---------------------+------------------------+
-   | With own tags | [Documentation] | This test has tags  | not_ready, owner-mrx,  |
-   |               |                 |                     | req-42                 |
-   +---------------+-----------------+---------------------+------------------------+
-   |               | [Tags]          | owner-mrx           | not_ready              |
-   +---------------+-----------------+---------------------+------------------------+
-   |               | No Operation    |                     |                        |
-   +---------------+-----------------+---------------------+------------------------+
-   |               |                 |                     |                        |
-   +---------------+-----------------+---------------------+------------------------+
-   | Own tags with | [Documentation] | This test has tags  | host-10.0.1.42, req-42 |
-   | variables     |                 |                     |                        |
-   +---------------+-----------------+---------------------+------------------------+
-   |               | [Tags]          | host-${HOST}        |                        |
-   +---------------+-----------------+---------------------+------------------------+
-   |               | No Operation    |                     |                        |
-   +---------------+-----------------+---------------------+------------------------+
-   |               |                 |                     |                        |
-   +---------------+-----------------+---------------------+------------------------+
-   | Empty own tags| [Documentation] | This test has tags  | req-42                 |
-   +---------------+-----------------+---------------------+------------------------+
-   |               | [Tags]          |                     |                        |
-   +---------------+-----------------+---------------------+------------------------+
-   |               | No Operation    |                     |                        |
-   +---------------+-----------------+---------------------+------------------------+
-   |               |                 |                     |                        |
-   +---------------+-----------------+---------------------+------------------------+
-   | Set Tags and  | [Documentation] | This test has tags  | mytag, owner-john      |
-   | Remove Tags   |                 |                     |                        |
-   | Keywords      |                 |                     |                        |
-   +---------------+-----------------+---------------------+------------------------+
-   |               | Set Tags        | mytag               |                        |
-   +---------------+-----------------+---------------------+------------------------+
-   |               | Remove Tags     | smoke               | req-*                  |
-   +---------------+-----------------+---------------------+------------------------+
+   Own tags with variables
+       [Documentation]    This test has tags    host-10.0.1.42, req-42
+       [Tags]    host-${HOST}
+       No Operation
+
+   Empty own tags
+       [Documentation]    This test has tags    req-42
+       [Tags]
+       No Operation
+
+   Set Tags and Remove Tags Keywords
+       [Documentation]    This test has tags    mytag, owner-john
+       Set Tags    mytag
+       Remove Tags    smoke    req-*
 
 Reserved tags
 ~~~~~~~~~~~~~
@@ -753,42 +663,37 @@ table and they override possible :setting:`Test Setup` and
 setup or teardown. It is also possible to use value `NONE` to indicate that
 a test has no setup/teardown.
 
-.. table:: Test setup and teardown examples
-   :class: example
+.. sourcecode:: robotframework
 
-   =============  =================  =======  =======
-      Setting            Value        Value    Value
-   =============  =================  =======  =======
-   Test Setup     Open Application   App A
-   Test Teardown  Close Application
-   =============  =================  =======  =======
+   *** Settings ***
+   Test Setup    Open Application    App A
+   Test Teardown    Close Application
 
-.. table::
-   :class: example
+   *** Test Cases ***
+   Default values
+       [Documentation]    Setup and teardown from setting table
+       Do Something
 
-   ==================  ===============  ===================  ==================
-       Test Case           Action            Argument            Argument
-   ==================  ===============  ===================  ==================
-   Default values      [Documentation]  Setup and teardown   from setting table
-   \                   Do Something
-   \
-   Overridden setup    [Documentation]  Own setup, teardown  from setting table
-   \                   [Setup]          Open Application     App B
-   \                   Do Something
-   \
-   No teardown         [Documentation]  Default setup, no    teardown at all
-   \                   Do Something
-   \                   [Teardown]
-   \
-   No teardown 2       [Documentation]  Using special NONE,  works as well
-   \                   Do Something
-   \                   [Teardown]       NONE
-   \
-   Using variables     [Documentation]  Setup and teardown   given as variables
-   \                   [Setup]          ${SETUP}
-   \                   Do Something
-   \                   [Teardown]       ${TEARDOWN}
-   ==================  ===============  ===================  ==================
+   Overridden setup
+       [Documentation]    Own setup, teardown from setting table
+       [Setup]    Open Application    App B
+       Do Something
+
+   No teardown
+       [Documentation]    Default setup, no teardown at all
+       Do Something
+       [Teardown]
+
+   No teardown 2
+       [Documentation]    Using special NONE, works as well
+       Do Something
+       [Teardown]    NONE
+
+   Using variables
+       [Documentation]    Setup and teardown  given as variables
+       [Setup]    ${SETUP}
+       Do Something
+       [Teardown]    ${TEARDOWN}
 
 Often when creating use-case-like test cases, the terms *precondition*
 and *postcondition* are preferred over the terms setup and
@@ -895,7 +800,7 @@ arguments. This is best illustrated with an example:
 
 .. sourcecode:: robotframework
 
-   *** Test Case ***
+   *** Test Cases ***
    Normal test case with embedded arguments
        The result of 1 + 1 should be 2
        The result of 1 + 2 should be 3
@@ -917,7 +822,7 @@ though, and it is also possible to use different arguments altogether:
 
 .. sourcecode:: robotframework
 
-   *** Test Case ***
+   *** Test Cases ***
    Different argument names
        [Template]    The result of ${foo} should be ${bar}
        1 + 1    2
@@ -946,18 +851,15 @@ all the steps inside the loop. The continue on failure mode is in use
 also in this case, which means that all the steps are executed with
 all the looped elements even if there are failures.
 
-.. table:: Using test template with for loops
-   :class: example
+.. sourcecode:: robotframework
 
-   ==================  ===============  ===============  ==========  ==========
-       Test Case            Action          Argument      Argument    Argument
-   ==================  ===============  ===============  ==========  ==========
-   Template and for    [Template]       Example keyword
-   \                   :FOR             ${item}          IN          @{ITEMS}
-   \                                    ${item}          2nd arg
-   \                   :FOR             ${index}         IN RANGE    42
-   \                                    1st arg          ${index}
-   ==================  ===============  ===============  ==========  ==========
+   *** Test Cases ***
+   Template and for
+       [Template]    Example keyword
+       :FOR    ${item}     IN    @{ITEMS}
+       \       ${item}     2nd arg
+       :FOR    ${index}    IN RANGE    42
+       \       1st arg     ${index}
 
 Different test case styles
 --------------------------
@@ -992,40 +894,18 @@ different input and/or output data. It would be possible to repeat the
 same keyword with every test, but the `test template`_ functionality
 allows specifying the keyword to use only once.
 
-.. table:: Data-driven testing example
-   :class: example
+.. sourcecode:: robotframework
 
-   +-------------------+-------------------------+---------+---------+
-   |     Setting       |           Value         |  Value  |  Value  |
-   +===================+=========================+=========+=========+
-   | Test Template     | Login with invalid      |         |         |
-   |                   | credentials should fail |         |         |
-   +-------------------+-------------------------+---------+---------+
+   *** Settings ***
+   Test Template    Login with invalid credentials should fail
 
-.. table::
-   :class: example
-
-   +-------------------+-----------+-----------+---------+
-   |     Test Case     | User Name | Password  |         |
-   +===================+===========+===========+=========+
-   | Invalid User Name | invalid   | ${VALID   |         |
-   |                   |           | PASSWORD} |         |
-   +-------------------+-----------+-----------+---------+
-   | Invalid Password  | ${VALID   | invalid   |         |
-   |                   | USER}     |           |         |
-   +-------------------+-----------+-----------+---------+
-   | Invalid User Name | invalid   | whatever  |         |
-   | And Password      |           |           |         |
-   +-------------------+-----------+-----------+---------+
-   | Empty User Name   | ${EMPTY}  | ${VALID   |         |
-   |                   |           | PASSWORD} |         |
-   +-------------------+-----------+-----------+---------+
-   | Empty Password    | ${VALID   | ${EMPTY}  |         |
-   |                   | USER}     |           |         |
-   +-------------------+-----------+-----------+---------+
-   | Empty User Name   | ${EMPTY}  | ${EMPTY}  |         |
-   | And Password      |           |           |         |
-   +-------------------+-----------+-----------+---------+
+   *** Test Cases ***
+   Invalid User Name                 invalid          ${VALID_PASSWORD}
+   Invalid Password                  ${VALID_USER}    invalid
+   Invalid User Name and Password    invalid          invalid
+   Empty User Name                   ${EMPTY}         ${VALID_PASSWORD}
+   Empty Password                    ${VALID_USER}    ${EMPTY}
+   Empty User Name and Password      ${EMPTY}         ${EMPTY}
 
 The above example has six separate tests, one for each invalid
 user/password combination, and the example below illustrates how to
@@ -1037,34 +917,17 @@ easier to see what they test, but having potentially large number of
 these tests may mess-up statistics. Which style to use depends on the
 context and personal preferences.
 
-.. table:: Data-driven test with multiple data variations
-   :class: example
+.. sourcecode:: robotframework
 
-   +-------------------+---------------+-------------------+---------+
-   |     Test Case     |   User Name   |      Password     |         |
-   +===================+===============+===================+=========+
-   | Invalid Password  | [Template]    | Login with invalid|         |
-   |                   |               | credentials should|         |
-   |                   |               | fail              |         |
-   +-------------------+---------------+-------------------+---------+
-   |                   | invalid       | ${VALID PASSWORD} |         |
-   +-------------------+---------------+-------------------+---------+
-   |                   | ${VALID USER} | invalid           |         |
-   +-------------------+---------------+-------------------+---------+
-   |                   | invalid       | whatever          |         |
-   +-------------------+---------------+-------------------+---------+
-   |                   | ${EMPTY}      | ${VALID PASSWORD} |         |
-   +-------------------+---------------+-------------------+---------+
-   |                   | ${VALID USER} | ${EMPTY}          |         |
-   +-------------------+---------------+-------------------+---------+
-   |                   | ${EMPTY}      | ${EMPTY}          |         |
-   +-------------------+---------------+-------------------+---------+
-
-.. tip:: In both of the above examples, column headers have been
-         changed to match the data. This is possible because on the
-         first row other cells except the first one `are ignored`__.
-
-__ `Ignored data`_
+   *** Test Cases ***
+   Invalid Password
+       [Template]    Login with invalid credentials should fail
+       invalid          ${VALID PASSWORD} 
+       ${VALID USER}    invalid   
+       invalid          whatever
+       ${EMPTY}         ${VALID PASSWORD} 
+       ${VALID USER}    ${EMPTY}       
+       ${EMPTY}         ${EMPTY}
 
 Behavior-driven style
 ~~~~~~~~~~~~~~~~~~~~~
@@ -1082,17 +945,14 @@ word :name:`Given`, the actions are described with keyword starting with
 Keyword starting with :name:`And` or :name:`But` may be used if a step has more
 than one action.
 
-.. table:: Example test cases using behavior-driven style
-   :class: example
+.. sourcecode:: robotframework
 
-   ==================  ===========================
-       Test Case                  Step
-   ==================  ===========================
-   Valid Login         Given login page is open
-   \                   When valid username and password are inserted
-   \                   and credentials are submitted
-   \                   Then welcome page should be open
-   ==================  ===========================
+   *** Test Cases ***
+   Valid Login
+       Given login page is open
+       When valid username and password are inserted
+       and credentials are submitted
+       Then welcome page should be open
 
 __ http://testobsessed.com/2008/12/08/acceptance-test-driven-development-atdd-an-overview
 __ http://en.wikipedia.org/wiki/Specification_by_example

--- a/doc/userguide/src/CreatingTestData/CreatingTestSuites.rst
+++ b/doc/userguide/src/CreatingTestData/CreatingTestSuites.rst
@@ -111,38 +111,23 @@ initialization files is explained below.
    Robot Framework 2.7.
 `Default Tags`:setting:, `Test Template`:setting:
    Not supported in initialization files.
+   
+.. sourcecode:: robotframework
 
-.. table:: An example test suite initialization file
-   :class: example
-
-   =============  =============  =============
-      Setting         Value          Value
-   =============  =============  =============
-   Documentation  Example suite
+   *** Settings ***
+   Documentation    Example suite
    Suite Setup    Do Something   ${MESSAGE}
-   Force Tags     example
-   Library        SomeLibrary
-   =============  =============  =============
+   Force Tags    example
+   Library    SomeLibrary
+   
+   *** Variables ***
+   ${MESSAGE}    Hello, world!
 
-.. table::
-   :class: example
-
-   =============  =============  =============
-      Variable        Value          Value
-   =============  =============  =============
-   ${MESSAGE}     Hello, world!
-   =============  =============  =============
-
-.. table::
-   :class: example
-
-   =============  ===============  ================  ================
-      Keyword          Action          Argument          Argument
-   =============  ===============  ================  ================
-   Do Something   [Arguments]      ${arg}
-   \              Some Keyword     ${arg}
-   \              Another Keyword
-   =============  ===============  ================  ================
+   *** Keywords ***
+   Do Something
+       [Arguments]    ${args}
+       Some Keyword    ${arg}
+       Another Keyword
 
 __ `Test case related settings in the Setting table`_
 
@@ -170,15 +155,11 @@ suite documentation has exactly the same characteristics regarding to where
 it is shown and how it can be created as `test case
 documentation`_.
 
-.. table:: Test suite documentation example
-   :class: example
+.. sourcecode:: robotframework
 
-   =============  ======================  ======================  ======================
-      Setting             Value                   Value                   Value
-   =============  ======================  ======================  ======================
-   Documentation  An example test suite   documentation with      \*some\* _formatting_.
-   ...            See test documentation  for more documentation  examples.
-   =============  ======================  ======================  ======================
+   *** Settings ***
+   Documentation    An example test suite documentation with *some* _formatting_.
+   ...              See test documentation for more documentation examples.
 
 Both the name and documentation of the top-level test suite can be
 overridden in test execution. This can be done with the command line
@@ -201,16 +182,12 @@ simple `HTML formatting`_ works and even variables_ can be used.
 __ `Dividing test data to several rows`_
 __ `Automatic newlines in test data`_
 
-.. table:: Metadata examples
-   :class: example
+.. sourcecode:: robotframework
 
-   =========  ===========  ====================  =========================  ==============================
-    Setting      Value            Value                   Value                          Value
-   =========  ===========  ====================  =========================  ==============================
-   Metadata   Version      2.0
-   Metadata   More Info    For more information  about \*Robot Framework\*  see \http://robotframework.org
-   Metadata   Executed At  ${HOST}
-   =========  ===========  ====================  =========================  ==============================
+   *** Settings ***
+   Metadata    Version        2.0
+   Metadata    More Info      For more information about *Robot Framework* see http://robotframework.org
+   Metadata    Executed At    ${HOST}
 
 For top-level test suites, it is possible to set metadata also with the
 :option:`--metadata` command line option. This is discussed in more

--- a/doc/userguide/src/CreatingTestData/CreatingUserKeywords.rst
+++ b/doc/userguide/src/CreatingTestData/CreatingUserKeywords.rst
@@ -27,19 +27,17 @@ from keywords in test libraries or other user keywords. Keyword names
 are normally in the second column, but when setting variables from
 keyword return values, they are in the subsequent columns.
 
-.. table:: User keyword examples
-   :class: example
+.. sourcecode:: robotframework
 
-   =======================  =================  =======================  ===========
-           Keyword               Action               Argument           Argument
-   =======================  =================  =======================  ===========
-   Open Login Page          Open Browser       \http://host/login.html
-   \                        Title Should Be    Login Page
-   \
-   Title Should Start With  [Arguments]        ${expected}
-   \                        ${title} =         Get Title
-   \                        Should Start With  ${title}                 ${expected}
-   =======================  =================  =======================  ===========
+   *** Keywords ***
+   Open Login Page
+       Open Browser    http://host/login.html
+       Title Should Be    Login Page
+   
+   Title Should Start With
+       [Arguments]    ${expected}
+       ${title} =    Get Title
+       Should Start With    ${title}    ${expected}
 
 Most user keywords take some arguments. This important feature is used
 already in the second example above, and it is explained in detail
@@ -159,20 +157,18 @@ be as descriptive as possible. It is recommended
 to use lower-case letters in variable names, either as
 `${my_arg}`, `${my arg}` or `${myArg}`.
 
-.. table:: User keyword taking different number of arguments
-   :class: example
+.. sourcecode:: robotframework
 
-   ===============  ===========  ========================  ==========  ==========
-       Keyword        Action             Argument           Argument    Argument
-   ===============  ===========  ========================  ==========  ==========
-   One Argument     [Arguments]  ${arg_name}
-   \                Log          Got argument ${arg_name}
-   \
-   Three Arguments  [Arguments]  ${arg1}                   ${arg2}     ${arg3}
-   \                Log          1st argument: ${arg1}
-   \                Log          2nd argument: ${arg2}
-   \                Log          3rd argument: ${arg3}
-   ===============  ===========  ========================  ==========  ==========
+   *** Keywords ***
+   One Argument
+       [Arguments]    ${arg_name}
+       Log    Got argument ${arg_name}
+   
+   Three Arguments
+       [Arguments]    ${arg1}    ${arg2}    ${arg3}
+       Log    1st argument: ${arg1}
+       Log    2nd argument: ${arg2}
+       Log    3rd argument: ${arg3}
 
 Default values with user keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -193,26 +189,25 @@ created on `suite or global scope`__.
           before the `=` sign are not allowed, and possible spaces
           after it are considered part of the default value itself.
 
-.. table:: User keyword with default values for arguments
-   :class: example
+.. sourcecode:: robotframework
 
-   =================================  ===============  =====================  ===================
-                 Keyword                   Action             Argument              Argument
-   =================================  ===============  =====================  ===================
-   One Argument With Default Value    [Arguments]      ${arg}=default value
-   \                                  [Documentation]  This keyword takes     0-1 arguments
-   \                                  Log              Got argument ${arg}
-   \
-   Two Arguments With Defaults        [Arguments]      ${arg1}=default 1      ${arg2}=${VARIABLE}
-   \                                  [Documentation]  This keyword takes     0-2 arguments
-   \                                  Log              1st argument ${arg1}
-   \                                  Log              2nd argument ${arg2}
-   \
-   One Required And One With Default  [Arguments]      ${required}            ${optional}=default
-   \                                  [Documentation]  This keyword takes     1-2 arguments
-   \                                  Log              Required: ${required}
-   \                                  Log              Optional: ${optional}
-   =================================  ===============  =====================  ===================
+   *** Keywords ***
+   One Argument With Default Value
+       [Arguments]    ${arg}=default value
+       [Documentation]    This keyword takes 0-1 arguments
+       Log    Got argument ${arg}
+   
+   Two Arguments With Defaults
+       [Arguments]    ${arg1}=default 1    ${arg2}=${VARIABLE}
+       [Documentation]    This keyword takes    0-2 arguments
+       Log    1st argument ${arg1}
+       Log    2nd argument ${arg2}
+   
+   One Required And One With Default
+       [Arguments]    ${required}    ${optional}=default
+       [Documentation]    This keyword takes    1-2 arguments
+       Log    Required: ${required}
+       Log    Optional: ${optional}
 
 When a keyword accepts several arguments with default values and only
 some of them needs to be overridden, it is often handy to use the
@@ -221,14 +216,11 @@ keywords, the arguments are specified without the `${}`
 decoration. For example, the second keyword above could be used like
 below and `${arg1}` would still get its default value.
 
-.. table:: User keyword and named arguments syntax
-   :class: example
+.. sourcecode:: robotframework
 
-   =============  ===========================  ==============  ============
-     Test Case               Action               Argument       Argument
-   =============  ===========================  ==============  ============
-   Example        Two Arguments With Defaults  arg2=new value
-   =============  ===========================  ==============  ============
+   *** Test Cases ***
+   Example
+       Two Arguments With Defaults    arg2=new value
 
 As all Pythonistas must have already noticed, the syntax for
 specifying default arguments is heavily inspired by Python syntax for
@@ -247,25 +239,24 @@ This syntax can be combined with the previously described default values, and
 at the end the list variable gets all the leftover arguments that do not match
 other arguments. The list variable can thus have any number of items, even zero.
 
-.. table:: User keywords accepting variable number of arguments
-   :class: example
+.. sourcecode:: robotframework
 
-   ===========================  =============  ================  ============  ============
-              Keyword               Action         Argument        Argument      Argument
-   ===========================  =============  ================  ============  ============
-   Any Number Of Arguments      [Arguments]    @{varargs}
-   \                            Log Many       @{varargs}
-   \
-   One Or More Arguments        [Arguments]    ${required}       @{rest}
-   \                            Log Many       ${required}       @{rest}
-   \
-   Required, Default, Varargs   [Arguments]    ${req}            ${opt}=42     @{others}
-   \                            Log            Required: ${req}
-   \                            Log            Optional: ${opt}
-   \                            Log            Others:
-   \                            : FOR          ${item}           IN            @{others}
-   \                                           Log               ${item}
-   ===========================  =============  ================  ============  ============
+   *** Keywords ***
+   Any Number Of Arguments
+       [Arguments]    @{varargs}
+       Log Many    @{varargs}
+   
+   One Or More Arguments
+       [Arguments]    ${required}    @{rest}
+       Log Many    ${required}    @{rest}
+   
+   Required, Default, Varargs
+       [Arguments]    ${req}    ${opt}=42    @{others}
+       Log    Required: ${req}
+       Log    Optional: ${opt}
+       Log    Others:
+       : FOR    ${item}    IN    @{others}
+       \    Log    ${item}
 
 Notice that if the last keyword above is used with more than one
 argument, the second argument `${opt}` always gets the given
@@ -289,22 +280,21 @@ arguments and varargs. When the keyword is called, this variable will get all
 `named arguments`_ that do not match any positional argument in the keyword
 signature.
 
-.. table:: User keywords accepting free keyword arguments
-   :class: example
+.. sourcecode:: robotframework
 
-   ===========================  =============  ============  ============  ============
-              Keyword               Action       Argument      Argument      Argument
-   ===========================  =============  ============  ============  ============
-   Kwargs Only                  [Arguments]    &{kwargs}
-   \                            Log            ${kwargs}
-   \                            Log Many       @{kwargs}
-   \
-   Positional And Kwargs        [Arguments]    ${required}   &{extra}
-   \                            Log Many       ${required}   @{extra}
-   \
-   Run Program                  [Arguments]    @{varargs}    &{kwargs}
-   \                            Run Process    program.py    @{varargs}    &{kwargs}
-   ===========================  =============  ============  ============  ============
+   *** Keywords ***
+   Kwargs Only
+       [Arguments]    &{kwargs}
+       Log         ${kwargs}
+       Log Many    @{kwargs}
+   
+   Positional And Kwargs
+       [Arguments]    ${required}    &{extra}
+       Log Many    ${required}    @{extra}
+   
+   Run Program
+       [Arguments]    @{varargs}    &{kwargs}
+       Run Process    program.py    @{varargs}    &{kwargs}
 
 The last example above shows how to create a wrapper keyword that
 accepts any positional or named argument and passes them forward.
@@ -334,15 +324,12 @@ must have been implemented separately. The idea of embedding arguments
 into the keyword name is that all you need is a keyword with name like
 :name:`Select ${animal} from list`.
 
-.. table:: An example keyword with arguments embedded into its name
-   :class: example
+.. sourcecode:: robotframework
 
-   ===========================  =====================  =============  ============
-              Keyword                   Action            Argument      Argument
-   ===========================  =====================  =============  ============
-   Select ${animal} from list   Open Page              Pet Selection
-   \                            Select Item From List  animal_list    ${animal}
-   ===========================  =====================  =============  ============
+   *** Keywords ***
+   Select ${animal} from list
+       Open Page    Pet Selection
+       Select Item From List    animal_list    ${animal}
 
 Keywords using embedded arguments cannot take any "normal" arguments
 (specified with :setting:`[Arguments]` setting) but otherwise they are
@@ -407,25 +394,18 @@ text can help but, for example, the test below fails because keyword
 :name:`I execute "ls" with "-lh"` matches both of the defined
 keywords.
 
-.. table:: Embedded arguments match too much
-   :class: example
+.. sourcecode:: robotframework
 
-   ============================  ===============================
-             Test Case                         Step
-   ============================  ===============================
-   Example                       I execute "ls"
-   \                             I execute "ls" with "-lh"
-   ============================  ===============================
+   *** Test Cases ***   
+   Example
+       I execute "ls"
+       I execute "ls" with "-lh"
 
-.. table::
-   :class: example
-
-   =================================  ==========  ==============  ==========
-                Keyword                  Action      Argument      Argument
-   =================================  ==========  ==============  ==========
-   I execute "${cmd}"                 Run         ${cmd}
-   I execute "${cmd}" with "${opts}"  Run         ${cmd} ${opts}
-   =================================  ==========  ==============  ==========
+   *** Keywords ***
+   I execute "${cmd}"
+       Run    ${cmd}
+   I execute "${cmd}" with "${opts}"
+       Run    ${cmd}    ${opts}
 
 A solution to this problem is using a custom regular expression that
 makes sure that the keyword matches only what it should in that
@@ -439,30 +419,25 @@ separated with a colon. For example, an argument that should match
 only numbers can be defined like `${arg:\d+}`. Using custom
 regular expressions is illustrated by the examples below.
 
-.. table:: Using custom regular expressions with embedded arguments
-   :class: example
+.. sourcecode:: robotframework
 
-   ============================  ===============================
-             Test Case                         Step
-   ============================  ===============================
-   Example                       I execute "ls"
-   \                             I execute "ls" with "-lh"
-   \                             I type 1 + 2
-   \                             I type 53 - 11
-   \                             Today is 2011-06-27
-   ============================  ===============================
+   *** Test Cases ***   
+   Example
+       I execute "ls"
+       I execute "ls" with "-lh"
+       I type 1 + 2
+       I type 53 - 11
+       Today is 2011-06-27
 
-.. table::
-   :class: example
-
-   ===========================================  ============  ==============  ===========  ==========
-                Keyword                            Action        Argument      Argument     Argument
-   ===========================================  ============  ==============  ===========  ==========
-   I execute "${cmd:[^"]+}"                     Run           ${cmd}
-   I execute "${cmd}" with "${opts}"            Run           ${cmd} ${opts}
-   I type ${a:\\d+} ${operator:[+-]} ${b:\\d+}  Calculate     ${a}            ${operator}  ${b}
-   Today is ${date:\\d{4\\}-\\d{2\\}-\\d{2\\}}  Log           ${date}
-   ===========================================  ============  ==============  ===========  ==========
+   *** Keywords ***
+   I execute "${cmd:[^"]+}"
+       Run    ${cmd}
+   I execute "${cmd}" with "${opts}"
+       Run    ${cmd}    ${opts}
+   I type ${a:\\d+} ${operator:[+-]} ${b:\\d+}
+       Calculate    ${a}    ${operator}    ${b}
+   Today is ${date:\\d{4\\}-\\d{2\\}-\\d{2\\}}
+       Log    ${date}
 
 In the above example keyword :name:`I execute "ls" with "-lh"` matches
 only :name:`I execute "${cmd}" with "${opts}"`. That is guaranteed
@@ -518,24 +493,15 @@ means that it is always possible to use variables with keywords having
 embedded arguments. For example, the following test case would pass
 using the keywords from the earlier example.
 
-.. table:: Using variables with custom regular expressions
-   :class: example
+.. sourcecode:: robotframework
 
-   =================  =================
-        Variable            Value
-   =================  =================
-   ${DATE}            2011-06-27
-   =================  =================
+   *** Variables ***   
+   ${DATE}    2011-06-27
 
-.. table::
-   :class: example
-
-   ============================  ===============================
-             Test Case                         Step
-   ============================  ===============================
-   Example                       I type ${1} + ${2}
-   \                             Today is ${DATE}
-   ============================  ===============================
+   *** Test Cases ***
+   Example
+       I type ${1} + ${2}
+       Today is ${DATE}
 
 A drawback of variables automatically matching custom regular
 expressions is that it is possible that the value the keyword gets
@@ -558,37 +524,32 @@ cases in `behavior-driven style`_. The example below illustrates this. Notice
 also that prefixes :name:`Given`, :name:`When` and :name:`Then` are `left out
 of the keyword definitions`__.
 
-.. table:: Embedded arguments used by BDD style tests
-   :class: example
+.. sourcecode:: robotframework
 
-   ============================  ===============================
-             Test Case                         Step
-   ============================  ===============================
-   Add two numbers               Given I have Calculator open
-   \                             When I add 2 and 40
-   \                             Then result should be 42
-   \
-   Add negative numbers          Given I have Calculator open
-   \                             When I add 1 and -2
-   \                             Then result should be -1
-   ============================  ===============================
+   *** Test Cases ***
+   Add two numbers
+       Given I have Calculator open
+       When I add 2 and 40
+       Then result should be 42
+   
+   Add negative numbers
+       Given I have Calculator open
+       When I add 1 and -2
+       Then result should be -1
 
-.. table::
-   :class: example
-
-   ======================================  ===============  ============  ============
-                  Keyword                       Action        Argument      Argument
-   ======================================  ===============  ============  ============
-   I have ${program} open                  Start Program    ${program}
-   \
-   I add ${number 1} and ${number 2}       Input Number     ${number 1}
-   \                                       Push Button      \+
-   \                                       Input Number     ${number 2}
-   \                                       Push Button      \=
-   \
-   Result should be ${expected}            ${result} =      Get Result
-   \                                       Should Be Equal  ${result}     ${expected}
-   ======================================  ===============  ============  ============
+   *** Keywords ***
+   I have ${program} open
+       Start Program    ${program}
+   
+   I add ${number 1} and ${number 2}
+       Input Number    ${number 1}
+       Push Button     +
+       Input Number    ${number 2}
+       Push Button     =
+   
+   Result should be ${expected}
+       ${result} =    Get Result
+       Should Be Equal    ${result}    ${expected}
 
 .. note:: Embedded arguments feature in Robot Framework is inspired by
           how *step definitions* are created in a popular BDD tool Cucumber__.
@@ -620,33 +581,27 @@ several scalar variables at once, to a list variable, or to scalar variables
 and a list variable. Several values can be returned simply by
 specifying those values in different cells after the :setting:`[Return]` setting.
 
-.. table:: User keywords returning values using :setting:`[Return]` setting
-   :class: example
+.. sourcecode:: robotframework
 
-   ================  ============  ===================  ===================  ===================
-       Test Case        Action         Argument              Argument            Argument
-   ================  ============  ===================  ===================  ===================
-   One Return Value  ${ret} =      Return One Value     argument
-   \                 Some Keyword  ${ret}
-   \
-   Multiple Values   ${a}          ${b}                 ${c} =               Return Three Values
-   \                 @{list} =     Return Three Values
-   \                 ${scalar}     @{rest} =            Return Three Values
-   ================  ============  ===================  ===================  ===================
+   *** Test Cases ***
+   One Return Value
+       ${ret} =    Return One Value    argument
+       Some Keyword    ${ret}
+   
+   Multiple Values
+       ${a}    ${b}    ${c} =    Return Three Values
+       @{list} =    Return Three Values
+       ${scalar}    @{rest} =    Return Three Values
 
-.. table::
-   :class: example
-
-   ===================  ============  ==============  ===========  ==========
-         Keyword           Action        Argument       Argument    Argument
-   ===================  ============  ==============  ===========  ==========
-   Return One Value     [Arguments]   ${arg}
-   \                    Do Something  ${arg}
-   \                    ${value} =    Get Some Value
-   \                    [Return]      ${value}
-   \
-   Return Three Values  [Return]      foo             bar          zap
-   ===================  ============  ==============  ===========  ==========
+   *** Keywords ***
+   Return One Value
+       [Arguments]    ${arg}
+       Do Something    ${arg}
+       ${value} =    Get Some Value
+       [Return]    ${value}
+   
+   Return Three Values
+       [Return]    foo    bar    zap
 
 Using special keywords to return
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -660,41 +615,35 @@ The first example below is functionally identical to the previous
 :setting:`[Return]` setting example. The second, and more advanced, example
 demonstrates returning conditionally inside a `for loop`_.
 
-.. table:: User keywords returning values using special keywords
-   :class: example
+.. sourcecode:: robotframework
 
-   ================  ===============  ================  ============  ========
-      Test Case          Action           Argument        Argument    Argument
-   ================  ===============  ================  ============  ========
-   One Return Value  ${ret} =         Return One Value  argument
-   \                 Some Keyword     ${ret}
-   \
-   Advanced          @{list} =        Create List       foo           baz
-   \                 ${index} =       Find Index        baz           @{list}
-   \                 Should Be Equal  ${index}          ${1}
-   \                 ${index} =       Find Index        non existing  @{list}
-   \                 Should Be Equal  ${index}          ${-1}
-   ================  ===============  ================  ============  ========
+   *** Test Cases ***
+   One Return Value
+       ${ret} =    Return One Value  argument
+       Some Keyword    ${ret}
+   
+   Advanced
+       @{list} =    Create List    foo    baz
+       ${index} =    Find Index    baz    @{list}
+       Should Be Equal    ${index}    ${1}
+       ${index} =    Find Index    non existing    @{list}
+       Should Be Equal    ${index}    ${-1}
 
-.. table::
-   :class: example
-
-   ================  ===================  ======================  =========================  ============
-        Keyword             Action                Argument                 Argument           Argument
-   ================  ===================  ======================  =========================  ============
-   Return One Value  [Arguments]          ${arg}
-   \                 Do Something         ${arg}
-   \                 ${value} =           Get Some Value
-   \                 Return From Keyword  ${value}
-   \                 Fail                 This is not executed
-   \
-   Find Index        [Arguments]          ${element}              @{items}
-   \                 ${index}=            Set Variable            ${0}
-   \                 :FOR                 ${item}                 IN                         @{items}
-   \                                      Return From Keyword If  '${item}' == '${element}'  ${index}
-   \                                      ${index}=               Set Variable               ${index + 1}
-   \                 Return From Keyword  ${-1}                   # Could also use [Return]
-   ================  ===================  ======================  =========================  ============
+   *** Keywords ***
+   Return One Value
+       [Arguments]    ${arg}
+       Do Something    ${arg}
+       ${value} =    Get Some Value
+       Return From Keyword    ${value}
+       Fail    This is not executed
+   
+   Find Index
+       [Arguments]    ${element}    @{items}
+       ${index} =    Set Variable    ${0}
+       :FOR    ${item}    IN    @{items}
+       \    Return From Keyword If    '${item}' == '${element}'    ${index}
+       \    ${index} =    Set Variable    ${index + 1}
+       \    Return From Keyword    ${-1}  # Could also use [Return]
 
 .. note:: Both :name:`Return From Keyword` and :name:`Return From Keyword If`
           are available since Robot Framework 2.8.
@@ -713,18 +662,16 @@ keyword teardown will fail the test case and subsequent steps in the
 test are not run. The name of the keyword to be executed as a teardown
 can also be a variable.
 
-.. table::
-   :class: example
+.. sourcecode:: robotframework
 
-   ==================  ===============  ===================  ==================
-     User Keyword           Action            Argument            Argument
-   ==================  ===============  ===================  ==================
-   With Teardown       Do Something
-   \                   [Teardown]       Log                  keyword teardown
-   \
-   Using variables     [Documentation]  Teardown given as    variable
-   \                   Do Something
-   \                   [Teardown]       ${TEARDOWN}
-   ==================  ===============  ===================  ==================
+   *** Keywords ***
+   With Teardown
+       Do Something
+       [Teardown]    Log    keyword teardown
+   
+   Using variables
+       [Documentation]    Teardown given as variable
+       Do Something
+       [Teardown]    ${TEARDOWN}
 
 __ `test setup and teardown`_

--- a/doc/userguide/src/CreatingTestData/ResourceAndVariableFiles.rst
+++ b/doc/userguide/src/CreatingTestData/ResourceAndVariableFiles.rst
@@ -36,16 +36,12 @@ system-independent (for example, :file:`${RESOURCES}/login_resources.html` or
 :file:`${RESOURCE_PATH}`). Additionally, slashes (`/`) in the path
 are automatically changed to backslashes (:codesc:`\\`) on Windows.
 
-.. table:: Importing resource files
-   :class: example
+.. sourcecode:: robotframework
 
-   =========  =======================  =======
-    Setting            Value            Value
-   =========  =======================  =======
-   Resource   myresources.html
-   Resource   ../data/resources.html
-   Resource   ${RESOURCES}/common.tsv
-   =========  =======================  =======
+   *** Settings ***
+   Resource    myresources.html
+   Resource    ../data/resources.html
+   Resource    ${RESOURCES}/common.tsv
 
 The user keywords and variables defined in a resource file are
 available in the file that takes that resource file into
@@ -92,45 +88,32 @@ __ `Test suite name and documentation`_
 Example resource file
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. table::
-   :class: example
+.. sourcecode:: robotframework
 
-   =============  ========================  =======  =======
-      Setting               Value            Value    Value
-   =============  ========================  =======  =======
-   Documentation  An example resource file
-   Library        SeleniumLibrary
-   Resource       ${RESOURCES}/common.html
-   =============  ========================  =======  =======
+   *** Settings ***
+   Documentation    An example resource file
+   Library     SeleniumLibrary
+   Resource    ${RESOURCES}/common.html
 
-.. table::
-   :class: example
+   *** Variables ***
+   ${HOST}           localhost:7272
+   ${LOGIN_URL}      http://${HOST}/
+   ${WELCOME_URL}    http://${HOST}/welcome.html
+   ${BROWSER}        Firefox
 
-   ==============  ============================  =======  =======
-      Variable                Value               Value    Value
-   ==============  ============================  =======  =======
-   ${HOST}         localhost:7272
-   ${LOGIN_URL}    \http://${HOST}/
-   ${WELCOME_URL}  \http://${HOST}/welcome.html
-   ${BROWSER}      Firefox
-   ==============  ============================  =======  =======
-
-.. table::
-   :class: example
-
-   ===============  ===============  ==============  ==============  ========
-       Keyword         Action           Argument        Argument     Argument
-   ===============  ===============  ==============  ==============  ========
-   Open Login Page  [Documentation]  Opens browser   to login page
-   \                Open Browser     ${LOGIN_URL}    ${BROWSER}
-   \                Title Should Be  Login Page
-   \
-   Input Name       [Arguments]      ${name}
-   \                Input Text       username_field  ${name}
-   \
-   Input Password   [Arguments]      ${password}
-   \                Input Text       password_field  ${password}
-   ===============  ===============  ==============  ==============  ========
+   *** Keywords ***
+   Open Login Page
+       [Documentation]    Opens browser to login page
+       Open Browser    ${LOGIN_URL}    ${BROWSER}
+       Title Should Be    Login Page
+   
+   Input Name
+       [Arguments]    ${name}
+       Input Text    username_field    ${name}
+   
+   Input Password
+       [Arguments]    ${password}
+       Input Text    password_field    ${password}
 
 Variable files
 --------------
@@ -180,17 +163,13 @@ can contain variables.
 __ `Taking resource files into use`_
 __ `Getting variables from a special function`_
 
-.. table:: Importing a variable file
-   :class: example
+.. sourcecode:: robotframework
 
-   =========  =======================  =======  =======
-    Setting             Value           Value    Value
-   =========  =======================  =======  =======
-   Variables  myvariables.py
-   Variables  ../data/variables.py
-   Variables   ${RESOURCES}/common.py
-   Variables  taking_arguments.py      arg1     ${ARG2}
-   =========  =======================  =======  =======
+   *** Settings ***
+   Variables    myvariables.py
+   Variables    ../data/variables.py
+   Variables    ${RESOURCES}/common.py
+   Variables    taking_arguments.py    arg1    ${ARG2}
 
 All variables from a variable file are available in the test data file
 that imports it. If several variable files are imported and they
@@ -289,21 +268,17 @@ ordered.
 The variables in both the examples above could be created also using the
 Variable table below.
 
-.. table::
-   :class: example
+.. sourcecode:: robotframework
 
-   ===================  ====================  ==========  ==========  =========
-         Variable              Value            Value       Value       Value
-   ===================  ====================  ==========  ==========  =========
-   ${VARIABLE}          An example string
-   ${ANOTHER_VARIABLE}  This is pretty easy!
-   ${INTEGER}           ${42}
-   @{STRINGS}           one                   two         kolme       four
-   @{NUMBERS}           ${1}                  ${INTEGER}  ${3.14}
-   &{MAPPING}           one=${1}              two=${2}    three=${3}
-   @{ANIMALS}           cat                   dog
-   &{FINNISH}           cat=kissa             dog=koira
-   ===================  ====================  ==========  ==========  =========
+   *** Variables ***
+   ${VARIABLE}            An example string
+   ${ANOTHER_VARIABLE}    This is pretty easy!
+   ${INTEGER}             ${42}
+   @{STRINGS}             one         two           kolme    four
+   @{NUMBERS}             ${1}        ${INTEGER}    ${3.14}
+   &{MAPPING}             one=${1}    two=${2}      three=${3}
+   @{ANIMALS}             cat         dog
+   &{FINNISH}             cat=kissa   dog=koira
 
 .. note:: Variables are not replaced in strings got from variable files.
           For example, `VAR = "an ${example}"` would create
@@ -598,17 +573,13 @@ YAML files must always end with :file:`.yaml` extension.
 If the above YAML file is imported, it will create exactly the same
 variables as the following variable table:
 
-.. table::
-   :class: example
+.. sourcecode:: robotframework
 
-   ============  =============  =============  =============  =============
-     Variable        Value          Value          Value          Value
-   ============  =============  =============  =============  =============
+   *** Variables ***
    ${STRING}     Hello, world!
    ${INTEGER}    ${42}
-   @{LIST}       one            two
-   &{DICT}       one=yksi       two=kaksi
-   ============  =============  =============  =============  =============
+   @{LIST}       one         two
+   &{DICT}       one=yksi    two=kaksi
 
 YAML files used as variable files must always be mappings in the top level.
 As the above example demonstrates, keys and values in the mapping become

--- a/doc/userguide/src/CreatingTestData/UsingTestLibraries.rst
+++ b/doc/userguide/src/CreatingTestData/UsingTestLibraries.rst
@@ -38,18 +38,14 @@ library name and arguments can be set using variables.
 
 __ `Using arguments`_
 
-.. table:: Importing test libraries
-   :class: example
+.. sourcecode:: robotframework
 
-   =========  ===================  =======  =======
-    Setting          Value          Value    Value
-   =========  ===================  =======  =======
-   Library    OperatingSystem      \        \
-   Library    com.company.TestLib  \        \
-   Library    MyLibrary            arg1     arg2
-   Library    ${LIBRARY}           \        \
-   =========  ===================  =======  =======
-
+   *** Settings ***
+   Library    OperatingSystem 
+   Library    com.company.TestLib
+   Library    MyLibrary    arg1    arg2
+   Library    ${LIBRARY}
+   
 It is possible to import test libraries in `test case files`_,
 `resource files`_ and `test suite initialization files`_. In all these
 cases, all the keywords in the imported library are available in that
@@ -68,16 +64,13 @@ used. This approach is useful in cases where the library is not
 available when the test execution starts and only some other keywords
 make it available.
 
-.. table:: Using Import Library keyword
-   :class: example
+.. sourcecode:: robotframework
 
-   ===========  =================  ==========  ==========  ==========
-    Test Case       Action          Argument    Argument    Argument
-   ===========  =================  ==========  ==========  ==========
-   Example      Do Something       \           \           \
-   \            Import Library     MyLibrary   arg1        arg2
-   \            KW From MyLibrary  \           \           \
-   ===========  =================  ==========  ==========  ==========
+   *** Test Cases ***
+   Example
+       Do Something 
+       Import Library    MyLibrary    arg1    arg2
+       KW From MyLibrary
 
 Specifying library to import
 ----------------------------
@@ -120,17 +113,14 @@ class file must always be available. If Python library is implemented
 as a directory, the path to it must have a trailing forward slash (`/`).
 Following examples demonstrate these different usages.
 
-.. table:: Importing test libraries using physical paths to them
-   :class: example
+.. sourcecode:: robotframework
 
-   =========  ===========================  ========  =========
-    Setting               Value             Value      Value
-   =========  ===========================  ========  =========
-   Library    PythonLib.py                 \         \
-   Library    /absolute/path/JavaLib.java  \         \
-   Library    relative/path/PythonDirLib/  possible  arguments
-   Library    ${RESOURCES}/Example.class   \         \
-   =========  ===========================  ========  =========
+   *** Settings ***
+   Library    PythonLib.py
+   Library    /absolute/path/JavaLib.java
+   Library    relative/path/PythonDirLib/    possible    arguments
+   Library    ${RESOURCES}/Example.class
+
 
 A limitation of this approach is that libraries implemented as Python classes `must
 be in a module with the same name as the class`__. Additionally, importing
@@ -168,41 +158,28 @@ having the new name in the next cell. The specified name is shown in
 logs and must be used in the test data when using keywords' full name
 (:name:`LibraryName.Keyword Name`).
 
-.. table:: Importing libraries with custom names
-   :class: example
+.. sourcecode:: robotframework
 
-   =========  ===================  =========  =========
-    Setting          Value           Value      Value
-   =========  ===================  =========  =========
-   Library    com.company.TestLib  WITH NAME  TestLib
-   Library    ${LIBRARY}           WITH NAME  MyName
-   =========  ===================  =========  =========
+   *** Settings ***
+   Library    com.company.TestLib    WITH NAME    TestLib
+   Library    ${LIBRARY}             WITH NAME    MyName
 
 Possible arguments to the library are placed into cells between the
 original library name and the `WITH NAME` text. The following example
 illustrates how the same library can be imported several times with
 different arguments:
 
-.. table:: Importing the same library several times with a different name
-   :class: example
+.. sourcecode:: robotframework
 
-   =========  ===========  =============  =======  =========  =========
-    Setting      Value          Value      Value     Value      Value
-   =========  ===========  =============  =======  =========  =========
-   Library    SomeLibrary  localhost      1234     WITH NAME  LocalLib
-   Library    SomeLibrary  server.domain  8080     WITH NAME  RemoteLib
-   =========  ===========  =============  =======  =========  =========
+   *** Settings ***
+   Library    SomeLibrary    localhost        1234    WITH NAME    LocalLib
+   Library    SomeLibrary    server.domain    8080    WITH NAME    RemoteLib
 
-.. table::
-   :class: example
-
-   ===========  ========================  ===========  ==========
-    Test Case             Action           Argument     Argument
-   ===========  ========================  ===========  ==========
-   My Test      LocalLib.Some Keyword     some arg     second arg
-   \            RemoteLib.Some Keyword    another arg  whatever
-   \            LocalLib.Another Keyword  \            \
-   ===========  ========================  ===========  ==========
+   *** Test Cases ***
+   My Test
+       LocalLib.Some Keyword     some arg       second arg
+       RemoteLib.Some Keyword    another arg    whatever
+       LocalLib.Another Keyword
 
 Setting a custom name to a test library works both when importing a
 library in the Setting table and when using the :name:`Import Library` keyword.

--- a/doc/userguide/src/CreatingTestData/Variables.rst
+++ b/doc/userguide/src/CreatingTestData/Variables.rst
@@ -96,17 +96,15 @@ that the variables `${GREET}` and `${NAME}` are available
 and assigned to strings `Hello` and `world`, respectively,
 both the example test cases are equivalent.
 
-.. table:: Scalar variables with string values
-   :class: example
+.. sourcecode:: robotframework
 
-   ============  ========  ====================  ==========
-    Test Case     Action        Argument          Argument
-   ============  ========  ====================  ==========
-   Constants     Log       Hello
-   \             Log       Hello, world!!
-   Variables     Log       ${GREET}
-   \             Log       ${GREET}, ${NAME}!!
-   ============  ========  ====================  ==========
+   *** Test Cases ***
+   Constants
+       Log    Hello
+       Log    Hello, world!!
+   Variables
+       Log    ${GREET}
+       Log    ${GREET}, ${NAME}!!
 
 When a scalar variable is used as the only value in a test data cell,
 the scalar variable is replaced with the value it has. The value may
@@ -138,17 +136,14 @@ object:
 
 With these two variables set, we then have the following test data:
 
-.. table:: Scalar variables with objects as values
-   :class: example
+.. sourcecode:: robotframework
 
-   ===========  ========  =================  ==========
-    Test Case    Action        Argument       Argument
-   ===========  ========  =================  ==========
-   Objects      KW 1      ${STR}
-   \            KW 2      ${OBJ}
-   \            KW 3      I said "${STR}"
-   \            KW 4      You said "${OBJ}"
-   ===========  ========  =================  ==========
+   *** Test Cases ***
+   Objects
+       KW 1    ${STR}
+       KW 2    ${OBJ}
+       KW 3    I said "${STR}"
+       KW 4    You said "${OBJ}"
 
 Finally, when this test data is executed, different keywords receive
 the arguments as explained below:
@@ -178,15 +173,13 @@ items are passed in as arguments separately. This is easiest to explain with
 an example. Assuming that a variable `@{USER}` has value `['robot','secret']`,
 the following two test cases are equivalent:
 
-.. table:: Using list variables
-   :class: example
+.. sourcecode:: robotframework
 
-   =============  ========  ===========  ==========
-     Test Case     Action    User Name    Password
-   =============  ========  ===========  ==========
-   Constants      Login     robot        secret
-   List Variable  Login     @{USER}
-   =============  ========  ===========  ==========
+   *** Test Cases ***
+   Constants
+       Login    robot    secret
+   List Variable
+       Login    @{USER}
 
 Robot Framework stores its own variables in one internal storage and allows
 using them as scalars, lists or dictionaries. Using a variable as a list
@@ -205,16 +198,13 @@ Using list variables with other data
 It is possible to use list variables with other arguments, including
 other list variables.
 
-.. table:: Using list variables with other data
-   :class: example
+.. sourcecode:: robotframework
 
-   =============  ==========  ==========  ==========  ===========
-     Test Case      Action     Argument    Argument    Argument
-   =============  ==========  ==========  ==========  ===========
-   Example        Keyword     @{LIST}     more        args
-   \              Keyword     ${SCALAR}   @{LIST}     constant
-   \              Keyword     @{LIST}     @{ANOTHER}  @{ONE MORE}
-   =============  ==========  ==========  ==========  ===========
+   *** Test Cases ***
+   Example
+       Keyword    @{LIST}      more          args
+       Keyword    ${SCALAR}    @{LIST}       constant
+       Keyword    @{LIST}      @{ANOTHER}    @{ONE MORE}
 
 If a list variable is used in a cell with other data (constant strings or other
 variables), the final value will contain a string representation of the
@@ -231,18 +221,17 @@ with too large an index causes an error. Indices are automatically converted
 to integers, and it is also possible to use variables as indices.
 List items accessed in this manner can be used similarly as scalar variables.
 
-.. table:: Accessing list variable items
-   :class: example
+.. sourcecode:: robotframework
 
-   ===============  ===============  ===================  ==========
-      Test Case         Action            Argument         Argument
-   ===============  ===============  ===================  ==========
-   Constants        Login            robot                secret
-   \                Title Should Be  Welcome robot!
-   List Variable    Login            @{USER}
-   \                Title Should Be  Welcome @{USER}[0]!
-   Variable Index   Log              @{LIST}[${INDEX}]
-   ===============  ===============  ===================  ==========
+   *** Test Cases ***
+   Constants
+       Login    robot    secret
+       Title Should Be    Welcome robot!
+   List Variable
+       Login    @{USER}
+       Title Should Be    Welcome @{USER}[0]!
+   Variable Index
+       Log    @{LIST}[${INDEX}]
 
 Using list variables with settings
 ''''''''''''''''''''''''''''''''''
@@ -255,20 +244,16 @@ as the name of the keyword, but can be used in arguments. With tag related
 settings they can be used freely. Using scalar variables is possible in
 those places where list variables are not supported.
 
-.. table:: Using list variables with settings
-   :class: example
+.. sourcecode:: robotframework
 
-   ==============  ================  ===============  ====================
-      Settings          Value            Value             Comment
-   ==============  ================  ===============  ====================
-   Library         ExampleLibrary    @{LIB ARGS}      # This works
-   Library         ${LIBRARY}        @{LIB ARGS}      # This works
-   Library         @{NAME AND ARGS}                   # This does not work
-   Suite Setup     Some Keyword      @{KW ARGS}       # This works
-   Suite Setup     ${KEYWORD}        @{KW ARGS}       # This works
-   Suite Setup     @{KEYWORD}                         # This does not work
-   Default Tags    @{TAGS}                            # This works
-   ==============  ================  ===============  ====================
+   *** Settings ***
+   Library         ExampleLibrary    @{LIB ARGS}    # This works
+   Library         ${LIBRARY}        @{LIB ARGS}    # This works
+   Library         @{NAME AND ARGS}                 # This does not work
+   Suite Setup     Some Keyword      @{KW ARGS}     # This works
+   Suite Setup     ${KEYWORD}        @{KW ARGS}     # This works
+   Suite Setup     @{KEYWORD}                       # This does not work
+   Default Tags    @{TAGS}                          # This works
 
 __ `All available settings in test data`_
 
@@ -286,15 +271,12 @@ this means that individual items of the dictionary are passed as
 value `{'name': 'robot', 'password': 'secret'}`, the following two test cases
 are equivalent.
 
-.. table:: Using dictionary variables
-   :class: example
+.. sourcecode:: robotframework
 
-   =============  ========  ===========  ===============
-     Test Case     Action    User Name      Password
-   =============  ========  ===========  ===============
-   Strings        Login     name=robot   password=secret
-   List Variable  Login     &{USER}
-   =============  ========  ===========  ===============
+   *** Test Cases ***
+   Strings
+       Login    name=robot    password=secret
+       List Variable    Login    &{USER}
 
 Dictionary variables are new in Robot Framework 2.9.
 
@@ -306,16 +288,13 @@ other dictionary variables. Because `named argument syntax`_ requires positional
 arguments to be before named argument, dictionaries can only be followed by
 named arguments or other dictionaries.
 
-.. table:: Using dictionary variables with other data
-   :class: example
+.. sourcecode:: robotframework
 
-   =============  ==========  ==========  ==========  ===========
-     Test Case      Action     Argument    Argument    Argument
-   =============  ==========  ==========  ==========  ===========
-   Example        Keyword     &{DICT}     named=arg
-   \              Keyword     positional  @{LIST}     &{DICT}
-   \              Keyword     &{DICT}     &{ANOTHER}  &{ONE MORE}
-   =============  ==========  ==========  ==========  ===========
+   *** Test Cases ***
+   Example
+       Keyword    &{DICT}       named=arg
+       Keyword    positional    @{LIST}       &{DICT}
+       Keyword    &{DICT}       &{ANOTHER}    &{ONE MORE}
 
 If a dictionary variable is used in a cell with other data (constant strings or
 other variables), the final value will contain a string representation of the
@@ -331,18 +310,17 @@ selected value. Keys are considered to be strings, but non-strings
 keys can be used as variables. Dictionary items accessed in this
 manner can be used similarly as scalar variables:
 
-.. table:: Accessing dictionary variable items
-   :class: example
+.. sourcecode:: robotframework
 
-   ===============  ===============  ======================  ===============
-      Test Case         Action              Argument             Argument
-   ===============  ===============  ======================  ===============
-   Constants        Login            name=robot              password=secret
-   \                Title Should Be  Welcome robot!
-   Dict Variable    Login            &{USER}
-   \                Title Should Be  Welcome &{USER}[name]!
-   Variable Key     Log Many         &{DICT}[${KEY}]         &{DICT}[${42}]
-   ===============  ===============  ======================  ===============
+   *** Test Cases ***
+   Constants
+       Login    name=robot    password=secret
+       Title Should Be    Welcome robot!
+   Dict Variable
+       Login    &{USER}
+       Title Should Be    Welcome &{USER}[name]!
+   Variable Key
+       Log Many    &{DICT}[${KEY}]    &{DICT}[${42}]
 
 Using dictionary variables with settings
 ''''''''''''''''''''''''''''''''''''''''
@@ -350,15 +328,11 @@ Using dictionary variables with settings
 Dictionary variables cannot generally be used with settings. The only exception
 are imports, setups and teardowns where dictionaries can be used as arguments.
 
-.. table:: Using list variables with settings
-   :class: example
+.. sourcecode:: robotframework
 
-   ==============  ================  =============  =============
-      Settings          Value            Value          Value
-   ==============  ================  =============  =============
-   Library         ExampleLibrary    &{LIB ARGS}
-   Suite Setup     Some Keyword      &{KW ARGS}     named=arg
-   ==============  ================  =============  =============
+   *** Settings ***
+   Library        ExampleLibrary    &{LIB ARGS}
+   Suite Setup    Some Keyword      &{KW ARGS}    named=arg
 
 .. _environment variable:
 
@@ -378,15 +352,12 @@ environment variables set in one test case can be used in other test
 cases executed after it. However, changes to environment variables are
 not effective after the test execution.
 
-.. table:: Using environment variables
-   :class: example
+.. sourcecode:: robotframework
 
-   =============  ========  =====================  ==========
-     Test Case     Action          Argument         Argument
-   =============  ========  =====================  ==========
-   Env Variables  Log       Current user: %{USER}
-   \              Run       %{JAVA_HOME}${/}javac
-   =============  ========  =====================  ==========
+   *** Test Cases ***
+   Env Variables
+       Log    Current user: %{USER}
+       Run    %{JAVA_HOME}${/}javac
 
 Java system properties
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -395,14 +366,11 @@ When running tests with Jython, it is possible to access `Java system properties
 using same syntax as `environment variables`_. If an environment variable and a
 system property with same name exist, the environment variable will be used.
 
-.. table:: Using Java system properties
-   :class: example
+.. sourcecode:: robotframework
 
-   =================  ========  ========================================  ==========
-     Test Case         Action          Argument                            Argument
-   =================  ========  ========================================  ==========
-   System Properties   Log      %{user.name} running tests on %{os.name}
-   =================  ========  ========================================  ==========
+   *** Test Cases ***
+   System Properties
+       Log    %{user.name} running tests on %{os.name}
 
 __ http://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html
 
@@ -430,45 +398,33 @@ scalar variable. This is done by giving the variable name (including
 the second one. If the second column is empty, an empty string is set
 as a value. Also an already defined variable can be used in the value.
 
-.. table:: Creating scalar variables
-   :class: example
+.. sourcecode:: robotframework
 
-   ============  ==================  =========
-     Variable           Value          Value
-   ============  ==================  =========
+   *** Variables ***
    ${NAME}       Robot Framework
    ${VERSION}    2.0
    ${ROBOT}      ${NAME} ${VERSION}
-   ============  ==================  =========
 
 It is also possible, but not obligatory,
 to use the equals sign `=` after the variable name to make assigning
 variables slightly more explicit.
 
-.. table:: Creating scalar variables using the equals sign
-   :class: example
+.. sourcecode:: robotframework
 
-   ============  ===============  =========
-     Variable         Value         Value
-   ============  ===============  =========
-   ${NAME} =     Robot Framework
-   ${VERSION} =  2.0
-   ============  ===============  =========
+   *** Variables ***
+   ${NAME} =       Robot Framework
+   ${VERSION} =    2.0
 
 If a scalar variable has a long value, it can be split to multiple columns and
 rows__. By default cells are catenated together using a space, but this
 can be changed by having `SEPARATOR=<sep>` in the first cell.
 
-.. table:: Creating long scalar variables
-   :class: example
+.. sourcecode:: robotframework
 
-   ============  ====================  =====================
-     Variable           Value                  Value
-   ============  ====================  =====================
-   ${EXAMPLE}    This value is joined  together with a space
-   ${MULTILINE}  SEPARATOR=\\n         First line
-   ...           Second line           Third line
-   ============  ====================  =====================
+   *** Variables ***
+   ${EXAMPLE}      This value is joined    together with a space
+   ${MULTILINE}    SEPARATOR=\\n    First line
+   ...             Second line      Third line
 
 Joining long values like above is a new feature in Robot Framework 2.9.
 Creating a scalar variable with multiple values was a syntax error in
@@ -488,19 +444,15 @@ can be `split into several rows`__.
 
 __ `Dividing test data to several rows`_
 
-.. table:: Creating list variables
-   :class: example
+.. sourcecode:: robotframework
 
-   ============  =========  =========  =========
-     Variable      Value      Value      Value
-   ============  =========  =========  =========
-   @{NAMES}      Matti      Teppo
-   @{NAMES2}     @{NAMES}   Seppo
+   *** Variables ***
+   @{NAMES}     Matti       Teppo
+   @{NAMES2}    @{NAMES}    Seppo
    @{NOTHING}
-   @{MANY}       one        two        three
-   ...           four       five       six
-   ...           seven
-   ============  =========  =========  =========
+   @{MANY}      one     two     three
+   ...          four    five    six
+   ...          seven
 
 Creating dictionary variables
 '''''''''''''''''''''''''''''
@@ -511,18 +463,14 @@ list variables. The difference is that items need to be created using
 items with same name, the last value has precedence. If a name contains
 an equal sign, it can be escaped__ with a backslash like `\=`.
 
-.. table:: Creating dictionary variables
-   :class: example
+.. sourcecode:: robotframework
 
-   ===============  ===============  ================  ===============
-       Variable          Value             Value            Value
-   ===============  ===============  ================  ===============
-   &{USER 1}        name=Matti       address=xxx       phone=123
-   &{USER 2}        name=Teppo       address=yyy       phone=456
-   &{MANY}          first=1          second=${2}       ${3}=third
-   &{EVEN MORE}     &{MANY}          first=override    empty=
-   ...              =empty           key\\=here=value
-   ===============  ===============  ================  ===============
+   *** Variables ***
+   &{USER 1}       name=Matti    address=xxx       phone=123
+   &{USER 2}       name=Teppo    address=yyy       phone=456
+   &{MANY}         first=1       second=${2}       ${3}=third
+   &{EVEN MORE}    &{MANY}       first=override    empty=
+   ...              =empty       key\\=here=value
 
 Dictionary variables created in variable table have two extra properties
 compared to normal Python dictionaries. First of all, values of these
@@ -639,16 +587,13 @@ Notice that although a value is assigned to a scalar variable, it can
 be used as a `list variable`_ if it has a list-like value and as a `dictionary
 variable`_ if it has a dictionary-like value.
 
-.. table:: Assigning list to scalar variable
-   :class: example
+.. sourcecode:: robotframework
 
-   ============  ================  ============  ==========  ==========  ==========
-     Test Case        Action         Argument     Argument    Argument    Argument
-   ============  ================  ============  ==========  ==========  ==========
-   Example       ${list} =         Create List   first       second      third
-   \             Length Should Be  ${list}       3
-   \             Log Many          @{list}
-   ============  ================  ============  ==========  ==========  ==========
+   *** Test Cases ***
+   Example
+       ${list} =    Create List    first    second    third
+       Length Should Be    ${list}    3
+       Log Many    @{list}
 
 Assigning list variables
 ''''''''''''''''''''''''
@@ -656,16 +601,13 @@ Assigning list variables
 If a keyword returns a list or any list-like object, it is possible to
 assign it to a `list variable`_.
 
-.. table:: Assigning list variable
-   :class: example
+.. sourcecode:: robotframework
 
-   ============  ================  ============  ==========  ==========  ==========
-     Test Case        Action         Argument     Argument    Argument    Argument
-   ============  ================  ============  ==========  ==========  ==========
-   Example       @{list} =         Create List   first       second      third
-   \             Length Should Be  ${list}       3
-   \             Log Many          @{list}
-   ============  ================  ============  ==========  ==========  ==========
+   *** Test Cases ***
+   Example       
+       @{list} =    Create List    first    second    third
+       Length Should Be    ${list}    3
+       Log Many    @{list}
 
 Because all Robot Framework variables are stored in same namespace, there is
 not much difference between assigning a value to a scalar variable or list
@@ -680,17 +622,14 @@ Assigning dictionary variables
 If a keyword returns a dictionary or any dictionary-like object, it is possible
 to assign it to a `dictionary variable`_.
 
-.. table:: Assigning dictionary variable
-   :class: example
+.. sourcecode:: robotframework
 
-   ============  ================  =================  ==========  ===========  ==========
-     Test Case        Action            Argument       Argument    Argument     Argument
-   ============  ================  =================  ==========  ===========  ==========
-   Example       &{dict} =         Create Dictionary  first=1     second=${2}  ${3}=third
-   \             Length Should Be  ${dict}            3
-   \             Do Something      &{dict}
-   \             Log               ${dict.first}
-   ============  ================  =================  ==========  ===========  ==========
+   *** Test Cases ***
+   Example
+       &{dict} =    Create Dictionary    first=1    second=${2}    ${3}=third
+       Length Should Be    ${dict}    3
+       Do Something    &{dict}
+       Log    ${dict.first}
 
 Because all Robot Framework variables are stored in same namespace, it would
 also be possible to assign a dictionary into a scalar variable and use it
@@ -710,17 +649,14 @@ If a keyword returns a list or a list-like object, it is possible to assign
 individual values into multiple scalar variables or into scalar variables and
 a list variable.
 
-.. table:: Assigning multiple values at once
-   :class: example
+.. sourcecode:: robotframework
 
-   ===============  ============  ==========  ==========  ==========
-      Test Case        Action      Argument    Argument    Argument
-   ===============  ============  ==========  ==========  ==========
-   Assign Multiple  ${a}          ${b}        ${c} =      Get Three
-   \                ${first}      @{rest} =   Get Three
-   \                @{before}     ${last} =   Get Three
-   \                ${begin}      @{middle}   ${end} =    Get Three
-   ===============  ============  ==========  ==========  ==========
+   *** Test Cases ***
+   Assign Multiple
+       ${a}    ${b}    ${c} =    Get Three
+       ${first}    @{rest} =    Get Three
+       @{before}    ${last} =    Get Three
+       ${begin}    @{middle}    ${end} =    Get Three
 
 Assuming that the keyword :name:`Get Three` returns a list `[1, 2, 3]`,
 the following variables are created:
@@ -822,15 +758,12 @@ operating-system-agnostic.
    |            | :codesc:`\\r\\n` in Windows. New in version 2.7.5.               |
    +------------+------------------------------------------------------------------+
 
-.. table:: Using operating-system-related built-in variables
-   :class: example
+.. sourcecode:: robotframework
 
-   =============  ========================  =======================  ==================================
-     Test Case             Action                   Argument                       Argument
-   =============  ========================  =======================  ==================================
-   Example        Create Binary File        ${CURDIR}${/}input.data  Some text here${\\n}on two lines
-   \              Set Environment Variable  CLASSPATH                ${TEMPDIR}${:}${CURDIR}${/}foo.jar
-   =============  ========================  =======================  ==================================
+   *** Test Cases ***
+   Example
+       Create Binary File    ${CURDIR}${/}input.data    Some text here${\\n}on two lines
+       Set Environment Variable    CLASSPATH    ${TEMPDIR}${:}${CURDIR}${/}foo.jar
 
 Number variables
 ~~~~~~~~~~~~~~~~
@@ -840,32 +773,28 @@ floating point numbers, as illustrated in the example below. This is
 useful when a keyword expects to get an actual number, and not a
 string that just looks like a number, as an argument.
 
-.. table:: Using number variables
-   :class: example
+.. sourcecode:: robotframework
 
-   ===========  ========  ===========  ==========  ===================================================
-    Test Case    Action    Argument     Argument                   Comment
-   ===========  ========  ===========  ==========  ===================================================
-   Example 1A   Connect   example.com  80          # Connect gets two strings as arguments
-   Example 1B   Connect   example.com  ${80}       # Connect gets a string and an integer
-   Example 2    Do X      ${3.14}      ${-1e-4}    # Do X gets floating point numbers 3.14 and -0.0001
-   ===========  ========  ===========  ==========  ===================================================
+   *** Test Cases ***
+   Example 1A
+       Connect    example.com    80     # Connect gets two strings as arguments
+   Example 1B
+       Connect    example.com    ${80}  # Connect gets a string and an integer
+   Example 2
+       Do X    ${3.14}    ${-1e-4}      # Do X gets floating point numbers 3.14 and -0.0001
 
 It is possible to create integers also from binary, octal, and
 hexadecimal values using `0b`, `0o` and `0x` prefixes, respectively.
 The syntax is case insensitive.
 
-.. table:: Using integer variables with base
-   :class: example
+.. sourcecode:: robotframework
 
-   ===========  ===============  ==========  ==========
-    Test Case        Action       Argument    Argument
-   ===========  ===============  ==========  ==========
-   Example      Should Be Equal  ${0b1011}   ${11}
-   \            Should Be Equal  ${0o10}     ${8}
-   \            Should Be Equal  ${0xff}     ${255}
-   \            Should Be Equal  ${0B1010}   ${0XA}
-   ===========  ===============  ==========  ==========
+   *** Test Cases ***
+   Example
+       Should Be Equal    ${0b1011}    ${11}
+       Should Be Equal    ${0o10}      ${8}
+       Should Be Equal    ${0xff}      ${255}
+       Should Be Equal    ${0B1010}    ${0XA}
 
 Boolean and None/null variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -873,18 +802,17 @@ Boolean and None/null variables
 Also Boolean values and Python `None` and Java `null` can
 be created using the variable syntax similarly as numbers.
 
-.. table:: Using Boolean and None/null variables
-   :class: example
+.. sourcecode:: robotframework
 
-   ===========  ===============  ==========  ==========  =============================================
-    Test Case        Action       Argument    Argument                      Comment
-   ===========  ===============  ==========  ==========  =============================================
-   Boolean      Set Status       ${true}                 # Set Status gets Boolean true as an argument
-   \            Create Y         something   ${false}    # Create Y gets a string and Boolean false
-   None         Do XYZ           ${None}                 # Do XYZ gets Python None as an argument
-   Null         ${ret} =         Get Value   arg         # Checking that Get Value returns Java null
-   \            Should Be Equal  ${ret}      ${null}
-   ===========  ===============  ==========  ==========  =============================================
+   *** Test Cases ***
+   Boolean 
+       Set Status    ${true}               # Set Status gets Boolean true as an argument
+       Create Y    something   ${false}    # Create Y gets a string and Boolean false
+   None
+       Do XYZ    ${None}                   # Do XYZ gets Python None as an argument
+   Null
+       ${ret} =    Get Value    arg        # Checking that Get Value returns Java null
+       Should Be Equal    ${ret}    ${null}
 
 These variables are case-insensitive, so for example `${True}` and
 `${true}` are equivalent. Additionally, `${None}` and
@@ -904,19 +832,21 @@ needed, it is possible to use the `extended variable syntax`_ like
 Equal` keyword gets identical arguments but those using variables are
 easier to understand than those using backslashes.
 
-.. table:: Using `${SPACE}` and `${EMPTY}` variables
-   :class: example
+.. sourcecode:: robotframework
 
-   =============   =================  ================  ================================
-     Test Case          Action            Argument                Argument
-   =============   =================  ================  ================================
-   One Space       Should Be Equal    ${SPACE}          \\ \\
-   Four Spaces     Should Be Equal    ${SPACE * 4}      \\ \\ \\ \\ \\
-   Ten Spaces      Should Be Equal    ${SPACE * 10}     \\ \\ \\ \\ \\ \\ \\ \\ \\ \\ \\
-   Quoted Space    Should Be Equal    "${SPACE}"        " "
-   Quoted Spaces   Should Be Equal    "${SPACE * 2}"    " \\ "
-   Empty           Should Be Equal    ${EMPTY}          \\
-   =============   =================  ================  ================================
+   *** Test Cases ***
+   One Space       
+       Should Be Equal    ${SPACE}          \\ \\
+   Four Spaces    
+       Should Be Equal    ${SPACE * 4}      \\ \\ \\ \\ \\
+   Ten Spaces      
+       Should Be Equal    ${SPACE * 10}     \\ \\ \\ \\ \\ \\ \\ \\ \\ \\ \\
+   Quoted Space    
+       Should Be Equal    "${SPACE}"        " "
+   Quoted Spaces   
+       Should Be Equal    "${SPACE * 2}"    " \\ "
+   Empty
+       Should Be Equal    ${EMPTY}          \\
 
 There is also an empty `list variable`_ `@{EMPTY}` and an empty `dictionary
 variable`_ `&{EMPTY}`. Because they have no content, they basically
@@ -925,18 +855,16 @@ with `test templates`_ when the `template keyword is used without
 arguments`__ or when overriding list or dictionary variables in different
 scopes. Modifying the value of `@{EMPTY}` or `&{EMPTY}` is not possible.
 
-.. table:: Using `@{EMPTY}` and `&{EMPTY}` variable
-   :class: example
+.. sourcecode:: robotframework
 
-   =============   ===================  ============  ============
-     Test Case           Action           Argument      Argument
-   =============   ===================  ============  ============
-   Template        [Template]           Some keyword
-   \               @{EMPTY}
-   \
-   Override        Set Global Variable  @{LIST}       @{EMPTY}
-                   Set Suite Variable   &{DICT}       &{EMPTY}
-   =============   ===================  ============  ============
+   *** Test Cases ***
+   Template        
+       [Template]    Some keyword
+       @{EMPTY}
+   
+   Override
+       Set Global Variable    @{LIST}    @{EMPTY}
+       Set Suite Variable     &{DICT}    &{EMPTY}
 
 .. note:: `@{EMPTY}` is new in Robot Framework 2.7.4 and `&{EMPTY}` in
           Robot Framework 2.9.
@@ -1214,16 +1142,13 @@ and test case:
    OBJECT = MyObject('Robot')
    DICTIONARY = {1: 'one', 2: 'two', 3: 'three'}
 
-.. table::
-   :class: example
+.. sourcecode:: robotframework
 
-   ===========  ========  =========================  ==========
-    Test Case    Action          Argument             Argument
-   ===========  ========  =========================  ==========
-   Example      KW 1      ${OBJECT.name}
-   \            KW 2      ${OBJECT.eat('Cucumber')}
-   \            KW 3      ${DICTIONARY[2]}
-   ===========  ========  =========================  ==========
+   *** Test Cases ***
+   Example
+       KW 1    ${OBJECT.name}
+       KW 2    ${OBJECT.eat('Cucumber')}
+       KW 3    ${DICTIONARY[2]}
 
 When this test data is executed, the keywords get the arguments as
 explained below:
@@ -1295,19 +1220,17 @@ reduce the need for setting temporary variables, but it is also easy
 to overuse it and create really cryptic test data. Following examples
 show few pretty good usages.
 
-.. table:: Using methods of strings and numbers
-   :class: example
+.. sourcecode:: robotframework
 
-   ===========  ============  ===================  ===============
-    Test Case      Action           Argument          Argument
-   ===========  ============  ===================  ===============
-   String       ${string} =   Set Variable         abc
-   \            Log           ${string.upper()}    # Logs 'ABC'
-   \            Log           ${string * 2}        # Logs 'abcabc'
-   Number       ${number} =   Set Variable         ${-2}
-   \            Log           ${number * 10}       # Logs -20
-   \            Log           ${number.__abs__()}  # Logs 2
-   ===========  ============  ===================  ===============
+   *** Test Cases ***
+   String
+       ${string} =    Set Variable    abc
+       Log    ${string.upper()}    # Logs 'ABC'
+       Log    ${string * 2}        # Logs 'abcabc'
+   Number       
+       ${number} =   Set Variable    ${-2}
+       Log    ${number * 10}       # Logs -20
+       Log    ${number.__abs__()}  # Logs 2
 
 Note that even though `abs(number)` is recommended over
 `number.__abs__()` in normal Python code, using
@@ -1332,15 +1255,12 @@ be set to it like in the example below.
 
 __ `Return values from keywords`_
 
-.. table:: Extended variable assignment
-   :class: example
+.. sourcecode:: robotframework
 
-   ===========  ====================  ==============  ===============
-    Test Case          Action            Argument         Argument
-   ===========  ====================  ==============  ===============
-   Example      ${OBJECT.name} =      Set Variable    New name
-   \            ${OBJECT.new_attr} =  Set Variable    New attribute
-   ===========  ====================  ==============  ===============
+   *** Test Cases ***
+   Example
+       ${OBJECT.name} =        Set Variable    New name
+       ${OBJECT.new_attr} =    Set Variable    New attribute
 
 The extended variable assignment syntax is evaluated using the
 following rules:
@@ -1405,22 +1325,13 @@ or `${JANE HOME}`, depending on if :name:`Get Name` returns
 `john` or `jane`. If it returns something else, resolving
 `${${name} HOME}` fails.
 
-.. table:: Using a variable inside another variable
-   :class: example
+.. sourcecode:: robotframework
 
-   ============  ==========  =======  =======
-     Variable       Value     Value    Value
-   ============  ==========  =======  =======
-   ${JOHN HOME}  /home/john
-   ${JANE HOME}  /home/jane
-   ============  ==========  =======  =======
+   *** Variables ***
+   ${JOHN HOME}    /home/john
+   ${JANE HOME}    /home/jane
 
-.. table::
-   :class: example
-
-   ===========  ============  ========================  ==========
-    Test Case      Action             Argument           Argument
-   ===========  ============  ========================  ==========
-   Example      ${name} =     Get Name
-   \            Do X          ${${name} HOME}
-   ===========  ============  ========================  ==========
+   *** Test Cases ***
+   Example
+       ${name} =    Get Name
+       Do X    ${${name} HOME}

--- a/doc/userguide/src/ExtendingRobotFramework/CreatingTestLibraries.rst
+++ b/doc/userguide/src/ExtendingRobotFramework/CreatingTestLibraries.rst
@@ -147,15 +147,11 @@ to the library, as well as the library name itself, can be specified
 using variables, so it is possible to alter them, for example, from the
 command line.
 
-.. table:: Importing a test library with arguments
-   :class: example
+.. sourcecode:: robotframework
 
-   =========  ===========  =========  =======
-    Setting      Value       Value     Value
-   =========  ===========  =========  =======
-   Library    MyLibrary    10.0.0.1   8080
-   Library    AnotherLib   ${VAR}
-   =========  ===========  =========  =======
+   *** Settings ***
+   Library    MyLibrary     10.0.0.1    8080
+   Library    AnotherLib    ${VAR}
 
 Example implementations, first one in Python and second in Java, for
 the libraries used in the above example:
@@ -502,24 +498,15 @@ The example below illustrates how the example libraries above can be
 used. If you want to try this yourself, make sure that the library is
 in the `module search path`_.
 
-.. table:: Using simple example library
-   :class: example
+.. sourcecode:: robotframework
 
-   =========  ===========  =======  =======
-    Setting      Value      Value    Value
-   =========  ===========  =======  =======
-   Library     MyLibrary
-   =========  ===========  =======  =======
+   *** Settings ***
+   Library    MyLibrary
 
-.. table::
-   :class: example
-
-   ===========  ===========  ============  ============
-    Test Case     Action       Argument      Argument
-   ===========  ===========  ============  ============
-   My Test      Do Nothing
-   \            Hello        world
-   ===========  ===========  ============  ============
+   *** Test Cases ***
+   My Test
+       Do Nothing
+       Hello    world
 
 Using a custom keyword name
 '''''''''''''''''''''''''''
@@ -538,14 +525,11 @@ this attribute when used as follows:
   def login(username, password):
       # ...
 
-.. table::
-   :class: example
+.. sourcecode:: robotframework
 
-   ===========  ====================  ============  ============
-    Test Case          Action           Argument      Argument
-   ===========  ====================  ============  ============
-   My Test      Login Via User Panel  ${username}   ${password}
-   ===========  ====================  ============  ============
+   *** Test Cases ***
+   My Test
+       Login Via User Panel    ${username}    ${password}
 
 Using this decorator without an argument will have no effect on the exposed
 keyword name, but will still create the `robot_name` attribute.  This can be useful
@@ -658,18 +642,15 @@ second example, one argument is always required, but the second and
 the third one have default values, so it is possible to use the keyword
 with one to three arguments.
 
-.. table:: Using keywords with variable number of arguments
-   :class: example
+.. sourcecode:: robotframework
 
-   ===========  ==================  =============  ============  =============
-    Test Case         Action          Argument       Argument       Argument
-   ===========  ==================  =============  ============  =============
-   Defaults     One Default
-   \            One Default         argument
-   \            Multiple Defaults   required arg
-   \            Multiple Defaults   required arg   optional
-   \            Multiple Defaults   required arg   optional 1    optional 2
-   ===========  ==================  =============  ============  =============
+   *** Test Cases ***
+   Defaults
+       One Default
+       One Default    argument
+       Multiple Defaults    required arg
+       Multiple Defaults    required arg    optional
+       Multiple Defaults    required arg    optional 1    optional 2
 
 Default values with Java
 ''''''''''''''''''''''''
@@ -732,23 +713,20 @@ be combined with other ways of specifying arguments:
   def also_defaults(req, def1="default 1", def2="default 2", *rest):
       print req, def1, def2, rest
 
-.. table:: Using keywords with a variable number of arguments
-   :class: example
+.. sourcecode:: robotframework
 
-   ===============  =============  =============  ============  ==============
-      Test Case         Action       Argument       Argument      Argument
-   ===============  =============  =============  ============  ==============
-   Varargs          Any Arguments
-   \                Any Arguments   argument
-   \                Any Arguments   arg 1          arg 2         arg 2
-   \                ...             arg 4          arg 5
-   \                One Required    required arg
-   \                One Required    required arg   another arg   yet another
-   \                Also Defaults   required
-   \                Also Defaults   required       these two     have defaults
-   \                Also Defaults   1              2             3
-   \                ...             4              5             6
-   ===============  =============  =============  ============  ==============
+   *** Test Cases ***
+   Varargs
+       Any Arguments
+       Any Arguments    argument
+       Any Arguments    arg 1    arg 2    arg 3
+       ...              arg 4    arg 5
+       One Required     required arg
+       One Required     required arg    another arg    yet another
+       Also Defaults    required
+       Also Defaults    required    these two    have defaults
+       Also Defaults    1    2    3
+       ...              4    5    6
 
 Variable number of arguments with Java
 ''''''''''''''''''''''''''''''''''''''
@@ -829,15 +807,12 @@ below shows the basic functionality:
         for name, value in stuff.items():
             print name, value
 
-.. table:: Using keywords with `**kwargs`
-   :class: example
+.. sourcecode:: robotframework
 
-   ====================  ================  ==============  ==============  ============================
-         Test Case            Action          Argument        Argument               Argument
-   ====================  ================  ==============  ==============  ============================
-   Keyword Arguments     Example Keyword   hello=world                     # Logs 'hello world'.
-   \                     Example Keyword   foo=1           bar=42          # Logs 'foo 1' and 'bar 42'.
-   ====================  ================  ==============  ==============  ============================
+   *** Test Cases ***
+   Keyword Arguments
+       Example Keyword    hello=world      # Logs 'hello world'.
+       Example Keyword    foo=1    bar=42  # Logs 'foo 1' and 'bar 42'.
 
 Basically, all arguments at the end of the keyword call that use the
 `named argument syntax`_ `name=value`, and that do not match any
@@ -857,20 +832,21 @@ work together:
       for name, value in sorted(kwargs.items()):
           print 'kwarg:', name, value
 
-.. table:: Using normal arguments, varargs, and kwargs together
-   :class: example
+.. sourcecode:: robotframework
 
-   =====================  ============  ===========  ===========  ==========  ===================================================
-         Test Case            Action      Argument     Argument     Argument                             Argument
-   =====================  ============  ===========  ===========  ==========  ===================================================
-   Positional             Various Args  hello        world                    # Logs 'arg: hello' and 'vararg: world'.
-   Named                  Various Args  arg=value                             # Logs 'arg: value'.
-   Kwargs                 Various Args  a=1          b=2          c=3         # Logs 'kwarg: a 1', 'kwarg: b 2' and 'kwarg: c 3'.
-   \                      Various Args  c=3          a=1          b=2         # Same as above. Order does not matter.
-   Positional and kwargs  Various Args  1            2            kw=3        # Logs 'arg: 1', 'vararg: 2' and 'kwarg: kw 3'.
-   Named and kwargs       Various Args  arg=value    hello=world              # Logs 'arg: value' and 'kwarg: hello world'.
-   \                      Various Args  hello=world  arg=value                # Same as above. Order does not matter.
-   =====================  ============  ===========  ===========  ==========  ===================================================
+   *** Test Cases ***
+   Positional
+       Various Args    hello    world             # Logs 'arg: hello' and 'vararg: world'.
+   Named
+       Various Args    arg=value                  # Logs 'arg: value'.
+   Kwargs
+       Various Args    a=1    b=2    c=3          # Logs 'kwarg: a 1', 'kwarg: b 2' and 'kwarg: c 3'.
+       Various Args    c=3    a=1    b=2          # Same as above. Order does not matter.
+   Positional and kwargs
+       Various Args    1    2    kw=3              # Logs 'arg: 1', 'vararg: 2' and 'kwarg: kw 3'.
+   Named and kwargs
+       Various Args    arg=value      hello=world  # Logs 'arg: value' and 'kwarg: hello world'.
+       Various Args    hello=world    arg=value    # Same as above. Order does not matter.
 
 For a real world example of using a signature exactly like in the above
 example, see :name:`Run Process` and :name:`Start Keyword` keywords in the
@@ -974,21 +950,19 @@ of course still possible to use variables containing correct types with
 these keywords. Using variables is the only option if keywords have
 conflicting signatures.
 
-.. table:: Using automatic type coercion
-   :class: example
+.. sourcecode:: robotframework
 
-   ===========  =================  =============  ==========  =====================
-    Test Case         Action          Argument     Argument        Argument
-   ===========  =================  =============  ==========  =====================
-   Coercion     Double Argument    3.14
-   \            Double Argument    2e16                       # scientific notation
-   \            Compatible Types   Hello, world!  1234
-   \            Compatible Types   Hi again!      -10         true
-   \
-   No Coercion  Double Argument    ${3.14}
-   \            Conflicting Types  1              ${2}        # must use variables
-   \            Conflicting Types  ${1}           2
-   ===========  =================  =============  ==========  =====================
+   *** Test Cases ***
+   Coercion
+       Double Argument     3.14
+       Double Argument     2e16  # scientific notation
+       Compatible Types    Hello, world!    1234
+       Compatible Types    Hi again!    -10    true
+   
+   No Coercion  
+       Double Argument    ${3.14}
+       Conflicting Types    1       ${2}  # must use variables
+       Conflicting Types    ${1}    2
 
 Starting from Robot Framework 2.8, argument type coercion works also with
 `Java library constructors`__.
@@ -1027,14 +1001,11 @@ __ `Using a custom keyword name`_
     def add_copies_to_cart(quantity, item):
         # ...
 
-.. table:: Using embedded arguments with library keyword
-   :class: example
+.. sourcecode:: robotframework
 
-   ===========  ==============================  =============
-    Test Case         Action                    Argument
-   ===========  ==============================  =============
-   My Test      Add 7 Copies Of Coffee To Cart
-   ===========  ==============================  =============
+   *** Test Cases ***
+   My Test
+       Add 7 Copies Of Coffee To Cart
 
 Communicating with Robot Framework
 ----------------------------------
@@ -1515,15 +1486,14 @@ __ `Scalar variables`_
   def return_object(name):
       return MyObject(name)
 
-.. table:: Return one value from keywords
-   :class: example
+.. sourcecode:: robotframework
 
-   ================  ===============  ==============
-   ${string} =       Return String
-   Should Be Equal   ${string}        Hello, world!
-   ${object} =       Return Object    Robot
-   Should Be Equal   ${object.name}   Robot
-   ================  ===============  ==============
+   *** Test Cases ***
+   Returning one value
+       ${string} =    Return String
+       Should Be Equal    ${string}    Hello, world!
+       ${object} =    Return Object    Robot
+       Should Be Equal    ${object.name}    Robot
 
 Keywords can also return values so that they can be assigned into
 several `scalar variables`_ at once, into `a list variable`__, or
@@ -1542,20 +1512,19 @@ __ `List variables`_
       return ['a', 'list', 'of', 'strings']
 
 
-.. table:: Returning multiple values
-   :class: example
+.. sourcecode:: robotframework
 
-   ================  ==================  ==================  =======================
-   ${var1}           ${var2} =           Return Two Values
-   Should Be Equal   ${var1}             first value
-   Should Be Equal   ${var2}             second value
-   @{list} =         Return Two Values
-   Should Be Equal   @{list}[0]          first value
-   Should Be Equal   @{list}[1]          second value
-   ${s1}             ${s2}               @{li} =             Return Multiple Values
-   Should Be Equal   ${s1} ${s2}         a list
-   Should Be Equal   @{li}[0] @{li}[1]   of strings
-   ================  ==================  ==================  =======================
+   *** Test Cases ***
+   Returning multiple values
+       ${var1}    ${var2} =    Return Two Values
+       Should Be Equal    ${var1}    first value
+       Should Be Equal    ${var2}    second value
+       @{list} =    Return Two Values
+       Should Be Equal    @{list}[0]    first value
+       Should Be Equal    @{list}[1]    second value
+       ${s1}    ${s2}    @{li} =    Return Multiple Values
+       Should Be Equal    ${s1} ${s2}    a list
+       Should Be Equal    @{li}[0] @{li}[1]    of strings
 
 Communication when using threads
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2048,23 +2017,23 @@ Using the named argument syntax with dynamic libraries is illustrated
 by the following examples. All the examples use a keyword :name:`Dynamic`
 that has been specified to have argument specification
 `[arg1, arg2=xxx, arg3=yyy]`.
-The last column shows the arguments that the keyword is actually called with.
+The comment shows the arguments that the keyword is actually called with.
 
-.. table:: Using named argument syntax with a dynamic keyword
-   :class: example
+.. sourcecode:: robotframework
 
-   ===============   ========  ========  ========  ========  =============
-      Test Case       Action   Argument  Argument  Argument   Called With
-   ===============   ========  ========  ========  ========  =============
-   Only positional   Dynamic   a                             # [a]
-   \                 Dynamic   a         b                   # [a, b]
-   \                 Dynamic   a         b         c         # [a, b, c]
-   Named             Dynamic   a         arg2=b              # [a, b]
-   \                 Dynamic   a         b         arg3=c    # [a, b, c]
-   \                 Dynamic   a         arg2=b    arg3=c    # [a, b, c]
-   \                 Dynamic   arg1=a    arg2=b    arg3=c    # [a, b, c]
-   Fill skipped      Dynamic   a         arg3=c              # [a, xxx, c]
-   ===============   ========  ========  ========  ========  =============
+   *** Test Cases ***
+   Only positional    
+       Dynamic    a                             # [a]
+       Dynamic    a         b                   # [a, b]
+       Dynamic    a         b         c         # [a, b, c]
+   Named
+       Dynamic    a         arg2=b              # [a, b]
+       Dynamic    a         b         arg3=c    # [a, b, c]
+       Dynamic    a         arg2=b    arg3=c    # [a, b, c]
+       Dynamic    arg1=a    arg2=b    arg3=c    # [a, b, c]
+   Fill skipped
+       Dynamic    a         arg3=c              # [a, xxx, c]
+   
 
 __ `Getting keyword arguments`_
 
@@ -2085,24 +2054,25 @@ Using the free keyword argument syntax with dynamic libraries is illustrated
 by the following examples. All the examples use a keyword :name:`Dynamic`
 that has been specified to have argument specification
 `[arg1=xxx, arg2=yyy, **kwargs]`.
-The last column shows the arguments that the keyword is actually called with.
+The comment shows the arguments that the keyword is actually called with.
 
-.. table:: Using free keyword arguments with a dynamic keyword
-   :class: example
+.. sourcecode:: robotframework
 
-   =====================  ========  ========  ========  ========  ========================
-         Test Case         Action   Argument  Argument  Argument         Called With
-   =====================  ========  ========  ========  ========  ========================
-   No arguments           Dynamic                                 # [], {}
-   Only positional        Dynamic   a                             # [a], {}
-   \                      Dynamic   a         b                   # [a, b], {}
-   Only kwargs            Dynamic   a=1                           # [], {a: 1}
-   \                      Dynamic   a=1       b=2       c=3       # [], {a: 1, b: 2, c: 3}
-   Positional and kwargs  Dynamic   a         b=2                 # [a], {b: 2}
-   \                      Dynamic   a         b=2       c=3       # [a], {b: 2, c: 3}
-   Named and kwargs       Dynamic   arg1=a    b=2                 # [a], {b: 2}
-   \                      Dynamic   arg2=a    b=2       c=3       # [xxx, a], {b: 2, c: 3}
-   =====================  ========  ========  ========  ========  ========================
+   *** Test Cases ***
+   No arguments
+       Dynamic                            # [], {}
+   Only positional
+       Dynamic    a                       # [a], {}
+       Dynamic    a         b             # [a, b], {}
+   Only kwargs
+       Dynamic    a=1                     # [], {a: 1}
+       Dynamic    a=1       b=2    c=3    # [], {a: 1, b: 2, c: 3}
+   Positional and kwargs
+       Dynamic    a         b=2           # [a], {b: 2}
+       Dynamic    a         b=2    c=3    # [a], {b: 2, c: 3}
+   Named and kwargs
+       Dynamic    arg1=a    b=2           # [a], {b: 2}
+       Dynamic    arg2=a    b=2    c=3    # [xxx, a], {b: 2, c: 3}
 
 __ `Running dynamic keywords`_
 __ `Getting keyword arguments`_
@@ -2422,25 +2392,16 @@ the new library in addition to it when needed. That is demonstrated in
 the example below where the code from the previous examples is
 expected to be available in a new library :name:`SeLibExtensions`.
 
-.. table:: Using library and another library that extends it
-   :class: example
+.. sourcecode:: robotframework
 
-   ===========  ===============  =======  =======
-    Settings         Value        Value    Value
-   ===========  ===============  =======  =======
-   Library      SeleniumLibrary
-   Library      SeLibExtensions
-   ===========  ===============  =======  =======
+   *** Settings ***
+   Library    SeleniumLibrary
+   Library    SeLibExtensions
 
-.. table::
-   :class: example
-
-   ===============  =======================  ==============  =================
-      Test Case             Action              Argument          Argument
-   ===============  =======================  ==============  =================
-   Example          Open Browser             http://example  # SeleniumLibrary
-   \                Title Should Start With  Example         # SeLibExtensions
-   ===============  =======================  ==============  =================
+   *** Test Cases ***
+   Example
+       Open Browser    http://example      # SeleniumLibrary
+       Title Should Start With    Example  # SeLibExtensions
 
 Libraries using dynamic or hybrid API
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/userguide/src/ExtendingRobotFramework/RemoteLibrary.rst
+++ b/doc/userguide/src/ExtendingRobotFramework/RemoteLibrary.rst
@@ -61,16 +61,12 @@ different to how other libraries are used. If you need to use the Remote
 library multiple times in a test suite, or just want to give it a more
 descriptive name, you can import it using the `WITH NAME syntax`_.
 
-.. table:: Importing Remote library
-   :class: example
+.. sourcecode:: robotframework
 
-   =========  ===========  =========================  =========  =========  =========
-    Setting      Value                Value             Value      Value      Value
-   =========  ===========  =========================  =========  =========  =========
-   Library    Remote       \http://127.0.0.1:8270     WITH NAME  Example1
-   Library    Remote       \http://example.com:8080/  WITH NAME  Example2
-   Library    Remote       \http://10.0.0.2/example   1 minute   WITH NAME  Example3
-   =========  ===========  =========================  =========  =========  =========
+   *** Settings ***
+   Library    Remote    http://127.0.0.1:8270       WITH NAME    Example1
+   Library    Remote    http://example.com:8080/    WITH NAME    Example2
+   Library    Remote    http://10.0.0.2/example    1 minute    WITH NAME    Example3
 
 The URL used by the first example above is also the default address
 that the Remote library uses if no address is given. Similarly port

--- a/doc/userguide/src/SupportingTools/Libdoc.rst
+++ b/doc/userguide/src/SupportingTools/Libdoc.rst
@@ -322,39 +322,22 @@ documentation similarly as with test libraries.
 Also the resource file itself can have :setting:`Documentation` in the
 Setting table for documenting the whole resource file.
 
-Possible variables in resource files are not documented.
+Possible variables in resource files can not be documented.
 
-.. table:: An example resource file
-   :class: example
+.. sourcecode:: robotframework
 
-   +---------------+-----------------------------------------+-----------------------------------+
-   |    Setting    |                  Value                  |               Value               |
-   +===============+=========================================+===================================+
-   | Documentation | Resource file for demo purposes.        |                                   |
-   +---------------+-----------------------------------------+-----------------------------------+
-   | ...           | This resource is only used in an example| and it doesn't do anything useful.|
-   +---------------+-----------------------------------------+-----------------------------------+
+   *** Settings ***
+   Documentation    Resource file for demo purposes.
+   ...              This resource is only used in an example and it doesn't do anything useful
 
-.. table::
-   :class: example
-
-   +--------------+------------------+------------------------+-------------------------------+
-   |    Keyword   |      Action      |         Argument       |            Argument           |
-   +==============+==================+========================+===============================+
-   | My Keyword   | [Documentation]  | Does nothing           |                               |
-   +--------------+------------------+------------------------+-------------------------------+
-   |              | No Operation     |                        |                               |
-   +--------------+------------------+------------------------+-------------------------------+
-   |              |                  |                        |                               |
-   +--------------+------------------+------------------------+-------------------------------+
-   | Your Keyword | [Arguments]      | ${arg}                 |                               |
-   +--------------+------------------+------------------------+-------------------------------+
-   |              | [Documentation]  | Takes one argument and | | Example:\\n                 |
-   |              |                  | \*does nothing\* with  | | \| Your Keyword \| xxx \|\\n|
-   |              |                  | it.\\n                 | | \| Your Keyword \| yyy \|\\n|
-   +--------------+------------------+------------------------+-------------------------------+
-   |              | No Operation     |                        |                               |
-   +--------------+------------------+------------------------+-------------------------------+
+   *** Keywords ***
+   My Keyword
+       [Documentation]   Does nothing
+       No Operation
+   Your Keyword
+       [Arguments]  ${arg}
+       [Documentation]   Takes one argument and *does nothing* with it.\n Examples:\n Your Keyword   xxx\n Your Keyword   yyy  
+       No Operation
 
 __ `Automatic newlines in test data`_
 


### PR DESCRIPTION
First phase of #1972
In this commit I just update the HMTL format to a Plain Text format.
I also updated the accompanying text when it was really needed.

There is still some work to do on
- reviewing the terminology (tables, rows, cells) but I will do this in another separate PL. The current version should be readable enough I hope.
- updating Pygments so that it handles the new dict variables