### PR TITLE
reST format: changed docutils report level to severe

### DIFF
--- a/atest/testdata/parsing/data_formats/rest/sample.rst
+++ b/atest/testdata/parsing/data_formats/rest/sample.rst
@@ -221,3 +221,20 @@ Library    OperatingSystem
 +---------------------+-----------------+---------------+------------------+--+
 |                     |                 |               |                  |  |
 +---------------------+-----------------+---------------+------------------+--+
+
+
+
+The following are non-standard docutils directives, and we should ignore
+errors when parsing this.
+
+Testing also a :term:`test` as it should generate an error.
+
+.. highlight:: robotframework
+
+.. todo::
+   This is not really a todo so you have to do nothing.
+
+.. automodule:: some_module
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/src/robot/parsing/restreader.py
+++ b/src/robot/parsing/restreader.py
@@ -27,7 +27,10 @@ def RestReader():
         def read(self, rstfile, rawdata):
             doctree = publish_doctree(
                 rstfile.read(), source_path=rstfile.name,
-                settings_overrides={'input_encoding': 'UTF-8'})
+                settings_overrides={
+                    'input_encoding': 'UTF-8',
+                    'report_level': 4  # only severe messages
+                })
             store = RobotDataStorage(doctree)
             if store.has_data():
                 return self._read_text(store.get_data(), rawdata)


### PR DESCRIPTION
This is relative to issue #2093. The argument is that errors outside robot code blocks should be ignored when running robot. Still need to find a way to test this.