### PR TITLE
Ommiting copying and moving when source and destination are the same …

### DIFF
--- a/atest/robot/standard_libraries/operating_system/move_copy_files.robot
+++ b/atest/robot/standard_libraries/operating_system/move_copy_files.robot
@@ -74,3 +74,19 @@ Copying From Name With Glob
 
 Moving From Name With Glob
     Check Test Case    ${TESTNAME}
+
+Copying To The Same Path
+    ${tc} =    Check Test Case    ${TESTNAME}
+    Check Log Message    ${tc.kws[0].msgs[0]}    Source '*' and destination '*' point to the same file.    pattern=True    html=True
+
+Moving To The Same Path
+    ${tc} =    Check Test Case    ${TESTNAME}
+    Check Log Message    ${tc.kws[0].msgs[0]}    Source '*' and destination '*' point to the same file.    pattern=True    html=True
+
+Copying To The Same Directory
+    ${tc} =    Check Test Case    ${TESTNAME}
+    Check Log Message    ${tc.kws[0].msgs[0]}    Source '*' and destination '*' point to the same file.    pattern=True    html=True
+
+Moving To The Same Directory
+    ${tc} =    Check Test Case    ${TESTNAME}
+    Check Log Message    ${tc.kws[0].msgs[0]}    Source '*' and destination '*' point to the same file.    pattern=True    html=True

--- a/atest/testdata/standard_libraries/operating_system/move_copy_files.robot
+++ b/atest/testdata/standard_libraries/operating_system/move_copy_files.robot
@@ -184,6 +184,18 @@ Moving From Name With Glob
     Move Files    ${SOURCE GLOB}/${GLOB FILE}   ${DEST}
     Directory Should Have Items    ${DEST}    ${GLOB FILE}
 
+Copying To The Same Path
+    Copy File    ${SOURCE}/movecopy-one.txt    ${SOURCE}/movecopy-one.txt
+
+Moving To The Same Path
+    Move File    ${SOURCE}/movecopy-one.txt    ${SOURCE}/movecopy-one.txt
+
+Copying To The Same Directory
+    Copy File    ${SOURCE}/movecopy-one.txt    ${SOURCE}
+
+Moving To The Same Directory
+    Move File    ${SOURCE}/movecopy-one.txt    ${SOURCE}
+
 *** Keywords ***
 Create Test Files For Multi-file Operations
     Create Directory    ${SOURCE}

--- a/src/robot/libraries/OperatingSystem.py
+++ b/src/robot/libraries/OperatingSystem.py
@@ -847,8 +847,20 @@ class OperatingSystem(object):
 
         See also `Copy Files`, `Move File`, and `Move Files`.
         """
-        source, destination = self._copy_file(source, destination)
-        self._link("Copied file from '%s' to '%s'", source, destination)
+        if not self._are_source_and_destination_same_file(destination, source):
+            source, destination = self._copy_file(source, destination)
+            self._link("Copied file from '%s' to '%s'", source, destination)
+
+    def _are_source_and_destination_same_file(self, destination, source):
+        source = os.path.realpath(self.normalize_path(source))
+        destination = os.path.realpath(self.normalize_path(destination))
+        if source == destination:
+            self._link("Source '%s' and destination '%s' point to the same file.", source, destination)
+            return True
+        if os.path.dirname(source) == destination and os.path.isdir(destination):
+            self._link("Source '%s' and destination '%s' point to the same file.", source, destination)
+            return True
+        return False
 
     def move_file(self, source, destination):
         """Moves the source file into the destination.
@@ -861,9 +873,10 @@ class OperatingSystem(object):
 
         See also `Move Files`, `Copy File`, and `Copy Files`.
         """
-        source, destination, _ = self._prepare_for_move_or_copy(source, destination)
-        shutil.move(source, destination)
-        self._link("Moved file from '%s' to '%s'", source, destination)
+        if not self._are_source_and_destination_same_file(destination, source):
+            source, destination, _ = self._prepare_for_move_or_copy(source, destination)
+            shutil.move(source, destination)
+            self._link("Moved file from '%s' to '%s'", source, destination)
 
     def copy_files(self, *sources_and_destination):
         """Copies specified files to the target directory.


### PR DESCRIPTION
Solution for issue #2153 
Now before copying/moving we're checking if the source and directory are the same file.