### PR TITLE
increase internal max started KW limit. 

### DIFF
--- a/src/robot/running/context.py
+++ b/src/robot/running/context.py
@@ -51,7 +51,7 @@ EXECUTION_CONTEXTS = ExecutionContexts()
 
 
 class _ExecutionContext(object):
-    _started_keywords_threshold = 42  # Jython on Windows don't work with higher
+    _started_keywords_threshold = 98    # Jython (> v2.7.0) & Python causes "maximum recursion depth exceeded" crashes with ~120 started KWs.
 
     def __init__(self, namespace, output, dry_run=False):
         self.namespace = namespace


### PR DESCRIPTION
Increase the limit to 98.
Fixes  #2175 

FYI:
Win8.1 + Python 2.7.10 +  RF 2.8.7: python acceptance tests fail when `_started_keywords_threshold = 99` (with python's `maximum recursion depth exceeded` exception) , jython tests still pass.
Might be worth trying whether this limit is the same on other platforms.

<pre>
> python atest/run.py jython -t "*ecur*" atest/robot
Running command:
C:\Python27\python.exe C:\git\fork-rf\src\robot\run.py --doc Robot Framework acceptance tests --metadata interpreter:Jyt
hon 2.7 on Windows --variablefile C:\git\fork-rf\atest\interpreter.py;jython;Jython;2.7 --pythonpath C:\git\fork-rf\ates
t\resources --outputdir C:\git\fork-rf\atest\results\jython --splitlog --console dotted --SuiteStatLevel 3 --TagStatExcl
ude no-* --exclude no-jython --exclude require-lxml --exclude no-windows --exclude no-windows-jython -t *ecur* atest/rob
ot

Running suite 'Robot' with 16 tests.
==============================================================================
................
==============================================================================
Run suite 'Robot' with 16 tests in 1 minute 26 seconds 43 milliseconds.

PASSED
16 critical tests, 16 passed, 0 failed
16 tests total, 16 passed, 0 failed

Output:  C:\git\fork-rf\atest\results\jython\output.xml
Log:     C:\git\fork-rf\atest\results\jython\log.html
Report:  C:\git\fork-rf\atest\results\jython\report.html


> python atest/run.py python -t "*ecur*" atest/robot
Running command:
C:\Python27\python.exe C:\git\fork-rf\src\robot\run.py --doc Robot Framework acceptance tests --metadata interpreter:Pyt
hon 2.7 on Windows --variablefile C:\git\fork-rf\atest\interpreter.py;python;Python;2.7 --pythonpath C:\git\fork-rf\ates
t\resources --outputdir C:\git\fork-rf\atest\results\python --splitlog --console dotted --SuiteStatLevel 3 --TagStatExcl
ude no-* --exclude require-jython --exclude no-windows -t *ecur* atest/robot

Running suite 'Robot' with 16 tests.
==============================================================================
................
==============================================================================
Run suite 'Robot' with 16 tests in 7 seconds 614 milliseconds.

PASSED
16 critical tests, 16 passed, 0 failed
16 tests total, 16 passed, 0 failed

Output:  C:\git\fork-rf\atest\results\python\output.xml
Log:     C:\git\fork-rf\atest\results\python\log.html
Report:  C:\git\fork-rf\atest\results\python\report.html
</pre>