### PR TITLE
[RFC] Telnet: Add support for Binary Transmission

### DIFF
--- a/atest/robot/standard_libraries/telnet/read_and_write.robot
+++ b/atest/robot/standard_libraries/telnet/read_and_write.robot
@@ -65,6 +65,9 @@ Read Until Regexp Fails
 Read Until Regexp Requires At Least One Pattern
     Check Test Case    ${TEST NAME}
 
+Read Binary Data
+    Check Test Case    ${TEST NAME}
+
 Read Until Prompt
     ${tc} =    Check Test Case    ${TEST NAME}
     Check Log Message    ${tc.kws[1].msgs[0]}    ${HOME}\n${FULL PROMPT}

--- a/atest/testdata/standard_libraries/telnet/read_and_write.robot
+++ b/atest/testdata/standard_libraries/telnet/read_and_write.robot
@@ -108,6 +108,25 @@ Read Until Regexp Requires At Least One Pattern
     [Documentation]    FAIL At least one pattern required
     Read Until Regexp
 
+Read Binary Data
+    # default is off (no binary transmission mode)
+    Write    echo -e He\\\\x00llo
+    ${out} =    Read Until Prompt
+    Should Be Equal    ${out}    Hello\r\n${FULL PROMPT}
+
+    # In binary transmission mode both \r and \n is interpreted as line termination, thus
+    # we must only use one of them.
+    Set Newline    LF
+    Enable Binary Transmission Mode
+    Write    echo -e He\\\\x00llo
+    ${out} =    Read Until Prompt
+    Should Be Equal    ${out}    He\x00llo\r\n${FULL PROMPT}
+
+    Disable Binary Transmission Mode
+    Write    echo -e He\\\\x00llo
+    ${out} =    Read Until Prompt
+    Should Be Equal    ${out}    Hello\r\n${FULL PROMPT}
+
 Read Until Prompt
     [Documentation]    FAIL Prompt '$$' not found in ${TIMEOUT}.
     Write    pwd


### PR DESCRIPTION
This is specified in RFC 856. In a nutshell, it disables any special
interpretation for all characters but FFh (IAC). Useful, if you have a
serial-line-to-telnet service and want to transmit binary data on the
serial line.

Signed-off-by: Michael Walle michael.walle@kontron.com
