### PR TITLE
Adds the byte string flag to a test condition.

### DIFF
--- a/atest/resources/rebot_resource.robot
+++ b/atest/resources/rebot_resource.robot
@@ -16,7 +16,7 @@ Create Output With Robot
     Set Suite Variable    $ORIG_START    ${SUITE.starttime}
     Set Suite Variable    $ORIG_END    ${SUITE.endtime}
     Set Suite Variable    $ORIG_ELAPSED    ${SUITE.elapsedtime}
-    Run Keyword If    "${outputname}"    Move File    ${OUTFILE}    ${outputname}
+    Run Keyword If    r"${outputname}"    Move File    ${OUTFILE}    ${outputname}
 
 Check times
     [Arguments]    ${item}    ${start}    ${end}    ${elapsed}


### PR DESCRIPTION
This fixes tests in Windows  when username preceded by \ would result in escape sequence, for example starting with 'x'.

This is a very low priority PR because it only affects RF acceptance tests. However it could serve as an example for a fix in a particular situation. After this fix, there are only three failed tests (one of then due to lowercase/uppercase comparison in a Windows path).