### PR TITLE
Supporting time for Repeat Keyword in BuiltIn Lib

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -69,3 +69,4 @@ Jean-Charles Deville           Make variable errors not exit `Runner keywords` (
 Laurent Bristiel               Convert examples in User Guide to plain text format (2.9, #1972)
 Tim Orling                     IronPython support for `Dialogs` library (2.9.2, #1235)
 Jozef Behran                   Fix ${TEST_MESSAGE} to reflect current test message (3.0, #2188)
+Joong-Hee Lee                  Extend 'Repeat Keyword' to support timeout (3.0, #2245)

--- a/atest/robot/standard_libraries/builtin/repeat_keyword.robot
+++ b/atest/robot/standard_libraries/builtin/repeat_keyword.robot
@@ -25,10 +25,17 @@ Zero And Negative Times
     ${tc} =    Check Test Case    ${TEST NAME}
     Check Repeated Messages    ${tc.kws[0]}    0
     Check Repeated Messages    ${tc.kws[2]}    0
+    Check Repeated Messages    ${tc.kws[3]}    0
 
 Invalid Times
     Check Test Case    Invalid Times 1
     Check Test Case    Invalid Times 2
+
+Repeat Keyword With Time String
+    ${tc} =    Check Test Case    ${TEST NAME}
+    Check Repeated Messages With Time    ${tc.kws[0]}    This is done for 00:00:00.003
+    Check Repeated Messages With Time    ${tc.kws[1]}    This is done for 3 milliseconds
+    Check Repeated Messages With Time    ${tc.kws[2]}    This is done for 3ms
 
 Repeat Keyword Arguments As Variables
     ${tc} =    Check Test Case    ${TEST_NAME}
@@ -72,6 +79,15 @@ Check Repeated Messages
     \    Check Log Message    ${kw.kws[${i}].msgs[0]}    ${msg}
     Run Keyword If    ${count} == 0    Check Log Message    ${kw.msgs[0]}    Keyword 'This is not executed' repeated zero times.
     Run Keyword If    ${count} != 0    Should Be Equal As Integers    ${kw.msg_count}    ${count}
+
+Check Repeated Messages With Time
+    [Arguments]    ${kw}    ${msg}=${None}
+    Should Be True    ${kw.kw_count} > 1
+    : FOR    ${i}    IN RANGE    ${kw.kw_count}
+    \    Check Log Message    ${kw.msgs[${i}]}
+    \    ...    Repeating keyword, round ${i+1}, *remaining.    pattern=yes
+    \    Check Log Message    ${kw.kws[${i}].msgs[0]}    ${msg}
+    Should Be Equal As Integers    ${kw.msg_count}    ${kw.kw_count}
 
 Check Repeated Keyword Name
     [Arguments]    ${kw}    ${count}    ${name}=${None}

--- a/atest/testdata/standard_libraries/builtin/repeat_keyword.robot
+++ b/atest/testdata/standard_libraries/builtin/repeat_keyword.robot
@@ -22,6 +22,7 @@ Zero And Negative Times
     Repeat Keyword    0 times    This is not executed
     ${name} =    Set Variable    This is not executed
     Repeat Keyword    ${-1}    ${name}    ${nonex}
+    Repeat Keyword    0 secs    This is not executed
 
 Invalid Times 1
     [Documentation]    FAIL STARTS: '1.3' cannot be converted to an integer: ValueError:
@@ -30,6 +31,11 @@ Invalid Times 1
 Invalid Times 2
     [Documentation]    FAIL STARTS: 'notaninteger' cannot be converted to an integer: ValueError:
     Repeat Keyword    Not an integer    No Operation
+
+Repeat Keyword With Time String
+    Repeat Keyword    00:00:00.003    Log    This is done for 00:00:00.003
+    Repeat Keyword    3 milliseconds    Log    This is done for 3 milliseconds
+    Repeat Keyword    3ms    Log    This is done for 3ms
 
 Repeat Keyword Arguments As Variables
     ${kw}    ${arg} =    Set Variable    Should Be Equal    Hello, world!


### PR DESCRIPTION
"Repeat Keyword" repeats the keyword specified times basically.
This commit is to support time string (in robot's time format) as the
the first argument of the "Repeat Keyword".
When a time string passed to the first argument, "Repeat Keyword"
repeats the keyword for the specified time regardless of how many times
it repeats.
A number like 42 is interpreted as a count instead of 42 seconds for
backward compatibility. Also floating point numbers like 1.5 would
raise exception just like before for same reason.