### PR TITLE
Fix a bug in the JS model builder tests

### DIFF
--- a/utest/reporting/test_jsmodelbuilders.py
+++ b/utest/reporting/test_jsmodelbuilders.py
@@ -1,7 +1,10 @@
+import base64
 import unittest
+import zlib
 from os.path import abspath, basename, dirname, join
 
 from robot.utils.asserts import assert_equal, assert_true
+from robot.utils.platform import PY2
 from robot.result import Message, Keyword, TestCase, TestSuite
 from robot.result.executionerrors import ExecutionErrors
 from robot.model import Statistics
@@ -17,9 +20,17 @@ except NameError:
 CURDIR = dirname(abspath(__file__))
 
 
+def decode_string(string):
+    string = string if PY2 else string.encode('ASCII')
+    return zlib.decompress(base64.b64decode(string)).decode('UTF-8')
+
+
 def remap(model, strings):
     if isinstance(model, StringIndex):
-        return strings[model][1:]
+        if strings[model].startswith('*'):
+            # Strip the asterisk from a raw string.
+            return strings[model][1:]
+        return decode_string(strings[model])
     elif isinstance(model, (int, long, type(None))):
         return model
     elif isinstance(model, tuple):


### PR DESCRIPTION
The test intends to make sure that the TestSuite class produces the expected
behaviour. However, the test does not account for potentially compressed
strings that are produced inside the TestSuite class.

This patch compresses those strings to match what TestSuite would do.

Example to showcase the failure:
```bash
#!/bin/bash

readonly TEMP_DIR="$(mktemp -d)"
CLONE_DIR="$TEMP_DIR"
for i in {1..30}; do
    CLONE_DIR+="/longdirname"
done
readonly CLONE_DIR

mkdir -p "$CLONE_DIR"

git clone https://github.com/robotframework/robotframework.git "$CLONE_DIR"/

pushd "$CLONE_DIR"
./utest/run.py
popd

rm -rf "$TEMP_DIR"
```