### PR TITLE
Avoid a recursive call to List files

### DIFF
--- a/doc/userguide/src/CreatingTestData/CreatingTestCases.rst
+++ b/doc/userguide/src/CreatingTestData/CreatingTestCases.rst
@@ -339,7 +339,6 @@ library keywords, user keywords, and when importing the Telnet_ test library.
    *** Keywords ***
    List files
        [Arguments]    ${path}=.    ${options}=
-       List files    options=-lh
        Execute command    ls ${options} ${path}
 
 Free keyword arguments


### PR DESCRIPTION
Tried running the example code locally and got an error "Maximum limit of started keywords exceeded."
It is because List files calls itself