### PR TITLE
Telnet.py: Add missing shutdown()

### DIFF
--- a/src/robot/libraries/Telnet.py
+++ b/src/robot/libraries/Telnet.py
@@ -14,6 +14,7 @@
 
 from contextlib import contextmanager
 import inspect
+import socket
 import re
 import struct
 import telnetlib
@@ -718,6 +719,7 @@ class TelnetConnection(telnetlib.Telnet):
 
         See `Logging` section for more information about log levels.
         """
+        self.sock.shutdown(socket.SHUT_RDWR)
         self.close()
         output = self._decode(self.read_all())
         self._log(output, loglevel)

--- a/src/robot/libraries/Telnet.py
+++ b/src/robot/libraries/Telnet.py
@@ -14,8 +14,8 @@
 
 from contextlib import contextmanager
 import inspect
-import socket
 import re
+import socket
 import struct
 import telnetlib
 import time


### PR DESCRIPTION
Telnet connections might be left open. Detected with Ubuntu 14.04 and is most likely valid for other distributions as well.

Cannot provide test case for this at the moment.