### PR TITLE
Adding working Docker build for the robot framework

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM gliderlabs/alpine:3.3
+
+MAINTAINER "Daniel Whatmuff" <danielwhatmuff@gmail.com>
+
+LABEL name="Docker image for the Robot Framework http://robotframework.org/"
+LABEL usage="docker run --rm -v $(pwd)/path/to/tests/:/path/to/tests/ -ti robot-docker robot --variable HOST:example.com --outputdir results path/to/tests/"
+
+#Install Python Pip and the Robot framework
+RUN apk-install bash py-pip && \
+    pip install --upgrade pip && \
+    pip install robotframework robotframework-selenium2library && \
+    python --help
+
+CMD ["robot"]

--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,17 @@ from GitHub_. After that you can install the framework with::
 For more detailed installation instructions, including installing
 Python, Jython and IronPython, see `<INSTALL.rst>`__.
 
+Run Robot inside Docker
+------------
+
+To build a Robot Docker image::
+
+    docker build -t robot-docker .
+
+To run tests and output the results to your host, mount a directory::
+
+    docker run --rm -v /path/to/tests/:/path/to/tests/ -ti robot-docker robot --variable HOST:example.com --outputdir results /path/to/tests/
+
 Example
 -------
 


### PR DESCRIPTION
This Docker build is based on Alpine Linux and is just 64MB. Found it useful when running tests from Jenkins, also providing an image for new Test Engineers means consistent execution across Windows/Mac etc.

REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
robot-docker        latest              42837806b30a        45 minutes ago      64.7 MB