### PR TITLE
Logging Variables Based on scope

### DIFF
--- a/src/robot/variables/filesetter.py
+++ b/src/robot/variables/filesetter.py
@@ -30,11 +30,12 @@ class VariableFileSetter(object):
 
     def __init__(self, store):
         self._store = store
+        self.vars = []
 
     def set(self, path_or_variables, args=None, overwrite=False):
         variables = self._import_if_needed(path_or_variables, args)
         self._set(variables, overwrite)
-        return variables
+        return self.vars
 
     def _import_if_needed(self, path_or_variables, args=None):
         if not is_string(path_or_variables):
@@ -55,6 +56,8 @@ class VariableFileSetter(object):
     def _set(self, variables, overwrite=False):
         for name, value in variables:
             self._store.add(name, value, overwrite)
+            self.vars.append(name)
+
 
 
 class YamlImporter(object):

--- a/src/robot/variables/tablesetter.py
+++ b/src/robot/variables/tablesetter.py
@@ -26,10 +26,14 @@ class VariableTableSetter(object):
 
     def __init__(self, store):
         self._store = store
+        self.vars = []
 
     def set(self, variables, overwrite=False):
         for name, value in VariableTableReader().read(variables):
-            self._store.add(name, value, overwrite, decorated=False)
+            self.vars.append(name)
+            stripped_name = name[2:-1]
+            self._store.add(stripped_name, value, overwrite, decorated=False)
+        return self.vars
 
 
 class VariableTableReader(object):
@@ -45,7 +49,7 @@ class VariableTableReader(object):
                 var.report_invalid_syntax(err)
 
     def _get_name_and_value(self, name, value, error_reporter):
-        return name[2:-1], VariableTableValue(value, name, error_reporter)
+        return name[0]+'{'+name[2:-1]+'}', VariableTableValue(value, name, error_reporter)
 
 
 def VariableTableValue(value, name, error_reporter=None):

--- a/src/robot/variables/variables.py
+++ b/src/robot/variables/variables.py
@@ -64,7 +64,7 @@ class Variables(object):
 
     def set_from_variable_table(self, variables, overwrite=False):
         setter = VariableTableSetter(self.store)
-        setter.set(variables, overwrite)
+        return setter.set(variables, overwrite)
 
     def clear(self):
         self.store.clear()


### PR DESCRIPTION
This pull request adds extra functionality to Log Variables keyword in BuiltIn library. 
Now Log Variables can log based on scope of a variable as discussed in #2389 .
Example usage has been added in the function documentation.

Changes:
I have added a new member variable called **scope_of_variable** in class **VariableScopes** in scopes.py.
This variable is a **dictionary** with **keys "GLOBAL,TEST_SUITE,TEST_CASE,LOCAL"** and with **values as lists.**
Each time a new variable is set, the variable name is added to the value-list with the scope of the variable being the key.
This is then accessed in Get Variables keyword in the BuiltIn library and the appropriate variables are returned to Log Variables in turn.