### PR TITLE
De-flake test_get_current_timetuple_excluding_millis

### DIFF
--- a/utest/utils/test_robottime.py
+++ b/utest/utils/test_robottime.py
@@ -22,10 +22,10 @@ class TestTime(unittest.TestCase):
 
     def test_get_current_timetuple_excluding_millis(self):
         while True:
-            expected = time.localtime()
+            expected = time.localtime(time.time())
             actual = _get_timetuple()
             # make sure got same times and _get_timetuple() did not round millis
-            if expected == time.localtime() and actual[-1] > 0:
+            if expected == time.localtime(time.time()) and actual[-1] > 0:
                 break
         assert_equal(actual[:-1], expected[:6])
 


### PR DESCRIPTION
Looking at the source for Python 3.4, it appears that time.localtime()
is implemented such that it calls time(2) while time.time() calls
clock_gettime(2).

The phenomenon is such that performing the following reads:
1. time.localtime()
2. time.time()  - inside of _get_timetuple()
3. time.localtime()
   the timestamps 1. and 3. return a time.struct_time with the tm_sec
   field set to X. Occasionally, timestamp 2. returns a value of X+1.
   This only appears to happen on a second boundary. The fraction
   component of time.time() is in the sub-millisecond range.

Forcing all three timestamps to be sourced in the same way seems to
fix the problem.

On those occasional failures, I see the following printed:
AssertionError: (2016, 3, 13, 10, 40, 21) != (2016, 3, 13, 10, 40, 20)
