### PR TITLE
fix For-in-range loop Documentation in AdvancedFeatures.rst

### DIFF
--- a/doc/userguide/src/CreatingTestData/AdvancedFeatures.rst
+++ b/doc/userguide/src/CreatingTestData/AdvancedFeatures.rst
@@ -395,7 +395,7 @@ lower limit, upper limit and step.
        \    Log    ${index}
 
    Float parameters
-       [Documentation]  Loops over values 3.14, 4.34, and 5.34
+       [Documentation]  Loops over values 3.14, 4.34, and 5.54
        :FOR    ${index}    IN RANGE    3.14    6.09    1.2
        \    Log    ${index}
 


### PR DESCRIPTION
The Documentation of the case, Float parameters should be "Loops over values 3.14, 4.34, and 5.54".