### PR TITLE
#2437 Options' default value of RobotSettings and RebotSettings should not be changed when running

### DIFF
--- a/src/robot/conf/settings.py
+++ b/src/robot/conf/settings.py
@@ -77,6 +77,10 @@ class _BaseSettings(object):
 
     def _process_cli_opts(self, opts):
         for name, (cli_name, default) in self._cli_opts.items():
+            if isinstance(default, list):
+                # redirect to a new list, prevent from modifying class default in instance level
+                default = default[:]
+
             value = opts[cli_name] if cli_name in opts else default
             if default == [] and not is_list_like(value):
                 value = [value]

--- a/utest/conf/test_settings.py
+++ b/utest/conf/test_settings.py
@@ -19,6 +19,24 @@ class TestRobotAndRebotSettings(unittest.TestCase):
         RebotSettings()
         assert_equal(RobotSettings()._opts, orig_opts)
 
+    def test_robot_and_rebot_settings_not_modify_class_level_default_values(self):
+        rebot_settings = RebotSettings()
+        assert_equal(rebot_settings['TestNames'], [])
+
+        robot_settings = RobotSettings()
+        robot_settings['TestNames'] += ['test_file1', 'test_file2']
+
+        assert_equal(rebot_settings['TestNames'], [])
+
+    def test_robot_settings_are_independent(self):
+        s0 = RobotSettings()
+        assert_equal(s0['TestNames'], [])
+
+        s1 = RobotSettings()
+        s1['TestNames'] += ['test_file1', 'test_file2']
+
+        assert_equal(s0['TestNames'], [])
+
     def test_extra_options(self):
         assert_equal(RobotSettings(name='My Name')['Name'], 'My Name')
         assert_equal(RobotSettings({'name': 'Override'}, name='Set')['Name'],'Set')


### PR DESCRIPTION
fix for https://github.com/robotframework/robotframework/issues/2437