### PR TITLE
Should (not) be equal as strings

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -71,3 +71,4 @@ Tim Orling                     IronPython support for `Dialogs` library (2.9.2, 
 Jozef Behran                   Fix ${TEST_MESSAGE} to reflect current test message (3.0, #2188)
 Joong-Hee Lee                  Extend 'Repeat Keyword' to support timeout (3.0, #2245)
 Anton Nikitin                  Should (Not) Contain Any (3.0.1, #2120)
+Chris Callan                   Added feature to compare case insensitively (3.0.1, #2461)

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -71,4 +71,4 @@ Tim Orling                     IronPython support for `Dialogs` library (2.9.2, 
 Jozef Behran                   Fix ${TEST_MESSAGE} to reflect current test message (3.0, #2188)
 Joong-Hee Lee                  Extend 'Repeat Keyword' to support timeout (3.0, #2245)
 Anton Nikitin                  Should (Not) Contain Any (3.0.1, #2120)
-Chris Callan                   Added feature to compare case insensitively (3.0.1, #2461)
+Chris Callan                   Added feature to compare case insensitively (3.0.1, #2461,2467)

--- a/atest/robot/standard_libraries/builtin/verify.robot
+++ b/atest/robot/standard_libraries/builtin/verify.robot
@@ -119,9 +119,15 @@ Should Not Be Equal As Strings
     ${tc}=    Check test case    ${TESTNAME}
     Verify argument type message    ${tc.kws[0].msgs[0]}    unicode    float
 
+Should Not Be Equal As Strings With Case Insensitivity
+    Check Test Case     ${TESTNAME}
+
 Should Be Equal As Strings
     ${tc}=    Check test case    ${TESTNAME}
     Verify argument type message    ${tc.kws[0].msgs[0]}    int    unicode
+
+Should Be Equal As Strings With Case Insensitivity
+    Check Test Case     ${TESTNAME}
 
 Should Be Equal As Strings Multiline
     [Tags]    no-python26    # diff contains extra spaces on python 2.6

--- a/atest/robot/standard_libraries/builtin/verify.robot
+++ b/atest/robot/standard_libraries/builtin/verify.robot
@@ -33,6 +33,9 @@ Should Not Be Equal
     Verify argument type message    ${tc.kws[1].msgs[0]}    unicode    int
     Verify argument type message    ${tc.kws[2].msgs[0]}    unicode    unicode
 
+Should Not Be Equal With Case Insensitivity
+    Check Test Case     ${TESTNAME}
+
 Should Not Be Equal with bytes containing non-ascii characters
     ${tc}=    Check test case    ${TESTNAME}
     Verify argument type message    ${tc.kws[0].msgs[0]}    bytes    bytes
@@ -45,6 +48,9 @@ Should Be Equal
     Verify argument type message    ${tc.kws[1].msgs[0]}    int    int
     Verify argument type message    ${tc.kws[2].msgs[0]}    bytes    bytes
     Verify argument type message    ${tc.kws[3].msgs[0]}    unicode    unicode
+
+Should Be Equal With Case Insensitivity
+    Check Test Case     ${TESTNAME}
 
 Should Be Equal fails with values
     Check test case    ${TESTNAME}

--- a/atest/testdata/cli/dryrun/args.robot
+++ b/atest/testdata/cli/dryrun/args.robot
@@ -10,7 +10,7 @@ Valid positional args
     Normal and varargs and kwargs   1    2    3    4
 
 Too few arguments
-    [Documentation]  FAIL Keyword 'BuiltIn.Should Be Equal' expected 2 to 4 arguments, got 1.
+    [Documentation]  FAIL Keyword 'BuiltIn.Should Be Equal' expected 2 to 5 arguments, got 1.
     Should Be Equal    1
 
 Too few arguments for UK

--- a/atest/testdata/cli/dryrun/dryrun.robot
+++ b/atest/testdata/cli/dryrun/dryrun.robot
@@ -80,7 +80,7 @@ Invalid syntax in UK
 
 Multiple Failures
     [Documentation]  FAIL Several failures occurred:\n\n
-    ...  1) Keyword 'BuiltIn.Should Be Equal' expected 2 to 4 arguments, got 1.\n\n
+    ...  1) Keyword 'BuiltIn.Should Be Equal' expected 2 to 5 arguments, got 1.\n\n
     ...  2) Invalid argument specification: Invalid argument syntax '${arg'.\n\n
     ...  3) Keyword 'BuiltIn.Log' expected 1 to 5 arguments, got 6.\n\n
     ...  4) No keyword with name 'Yet another non-existing keyword' found.\n\n

--- a/atest/testdata/running/test_template.robot
+++ b/atest/testdata/running/test_template.robot
@@ -238,8 +238,8 @@ Templated test with for loop continues after keyword timeout
     \    ${sleep}s    ${timeout}s
 
 Templated test ends after syntax errors
-    [Documentation]    FAIL   Keyword 'BuiltIn.Should Be Equal' expected 2 to 4 arguments, got 5.
-    Syntax    error    makes    test    end
+    [Documentation]    FAIL   Keyword 'BuiltIn.Should Be Equal' expected 2 to 5 arguments, got 6.
+    Syntax    error    makes    test    end     again
     Not compared    anymore
 
 Templated test continues after variable error

--- a/atest/testdata/standard_libraries/builtin/verify.robot
+++ b/atest/testdata/standard_libraries/builtin/verify.robot
@@ -220,12 +220,25 @@ Should Not Be Equal As Strings
     False    ${True}
     bar    bar    These strings most certainly should not be equal    False
 
+Should Not Be Equal As String With Case Insensitivity
+    [Documentation]  FAIL foo == foo
+    [Template]      Should Not Be Equal As Strings
+    test value      TEST VALUE1     ignore_case=True
+    HYVÄÄ YÖTÄ      hyvää yötä1     ignore_case=True
+    Foo             foo             ignore_case=True
+
 Should Be Equal As Strings
     [Documentation]    FAIL foo != bar
     [Template]    Should Be Equal As Strings
     ${1}    1
     ${None}    None
     foo    bar
+
+Should Be Equal As Strings With Case Insensitivity
+    [Template]      Should Be Equal As Strings
+    test value      TEST VALUE1     ignore_case=True
+    HYVÄÄ YÖTÄ      hyvää yötä1     ignore_case=True
+    Foo             foo             ignore_case=True
 
 Should Be Equal As Strings Multiline
     [Documentation]    FAIL Multiline strings are different:

--- a/atest/testdata/standard_libraries/builtin/verify.robot
+++ b/atest/testdata/standard_libraries/builtin/verify.robot
@@ -236,8 +236,8 @@ Should Be Equal As Strings
 
 Should Be Equal As Strings With Case Insensitivity
     [Template]      Should Be Equal As Strings
-    test value      TEST VALUE1     ignore_case=True
-    HYVÄÄ YÖTÄ      hyvää yötä1     ignore_case=True
+    test value      TEST VALUE      ignore_case=True
+    HYVÄÄ YÖTÄ      hyvää yötä      ignore_case=True
     Foo             foo             ignore_case=True
 
 Should Be Equal As Strings Multiline

--- a/atest/testdata/standard_libraries/builtin/verify.robot
+++ b/atest/testdata/standard_libraries/builtin/verify.robot
@@ -68,6 +68,11 @@ Should Not Be Equal
     ${STR1}    ${INT1}
     ${STR1}    1
 
+Should Not Be Equal With Case Insensitivity
+    [Template]  Should Not Be Equal
+    test value      TEST VALUE1      ignore_case=True
+    HYVÄÄ YÖTÄ      hyvää yötä1     ignore_case=True
+
 Should Not Be Equal with bytes containing non-ascii characters
     [Documentation]    FAIL ${BYTES WITH NON ASCII} == ${BYTES WITH NON ASCII}
     Should Not Be Equal    ${BYTES WITH NON ASCII}    ${BYTES WITHOUT NON ASCII}
@@ -81,6 +86,11 @@ Should Be Equal
     ${INT1}    ${1}
     ${BYTES WITHOUT NON ASCII}    ${BYTES WITHOUT NON ASCII}
     A    B    Error message    values=yes
+
+Should Be Equal With Case Insensitivity
+    [Template]  Should Be Equal
+    test value      TEST VALUE      ignore_case=True
+    HYVÄÄ YÖTÄ      hyvää yötä      ignore_case=True
 
 Should Be Equal fails with values
     [Documentation]    FAIL Several failures occurred:\n\n 1) 3: 1 != 2\n\n 2) c: a != b\n\n 3) z: x != y

--- a/atest/testdata/standard_libraries/builtin/verify.robot
+++ b/atest/testdata/standard_libraries/builtin/verify.robot
@@ -220,7 +220,7 @@ Should Not Be Equal As Strings
     False    ${True}
     bar    bar    These strings most certainly should not be equal    False
 
-Should Not Be Equal As String With Case Insensitivity
+Should Not Be Equal As Strings With Case Insensitivity
     [Documentation]  FAIL foo == foo
     [Template]      Should Not Be Equal As Strings
     test value      TEST VALUE1     ignore_case=True

--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -767,27 +767,43 @@ class _Verify(_BuiltInBase):
         second = self._convert_to_number(second, precision)
         self._should_be_equal(first, second, msg, values)
 
-    def should_not_be_equal_as_strings(self, first, second, msg=None, values=True):
+    def should_not_be_equal_as_strings(self, first, second, msg=None, values=True, ignore_case=False):
         """Fails if objects are equal after converting them to strings.
+
+        If ignore_case is True, it indicates that ``first`` and ``second`` should be
+        compared case-insensitively.  This option only applies if ``first`` and ``second``
+        are string types.  See `Boolean  arguments` section for more details.
+        This option is new in Robot Framework 3.0.1.
 
         See `Should Be Equal` for an explanation on how to override the default
         error message with ``msg`` and ``values``.
         """
         self._log_types_at_info_if_different(first, second)
         first, second = [self._convert_to_string(i) for i in (first, second)]
+        if is_truthy(ignore_case):
+            first = first.lower()
+            second = second.lower()
         self._should_not_be_equal(first, second, msg, values)
 
-    def should_be_equal_as_strings(self, first, second, msg=None, values=True):
+    def should_be_equal_as_strings(self, first, second, msg=None, values=True, ignore_case=False):
         """Fails if objects are unequal after converting them to strings.
 
         See `Should Be Equal` for an explanation on how to override the default
         error message with ``msg`` and ``values``.
+
+        If ignore_case is True, it indicates that ``first`` and ``second`` should be
+        compared case-insensitively.  This option only applies if ``first`` and ``second``
+        are string types.  See `Boolean  arguments` section for more details.
+        This option is new in Robot Framework 3.0.1.
 
         If both arguments are multiline strings, the comparison is done using
         `multiline string comparisons`.
         """
         self._log_types_at_info_if_different(first, second)
         first, second = [self._convert_to_string(i) for i in (first, second)]
+        if is_truthy(ignore_case):
+            first = first.lower()
+            second = second.lower()
         self._should_be_equal(first, second, msg, values)
 
     def should_not_start_with(self, str1, str2, msg=None, values=True):

--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -32,7 +32,7 @@ from robot.utils import (DotDict, escape, format_assign_message,
                          Matcher, normalize, NormalizedDict, parse_time, prepr,
                          RERAISED_EXCEPTIONS, plural_or_not as s, roundup,
                          secs_to_timestr, seq2str, split_from_equals, StringIO,
-                         timestr_to_secs, type_name, unic)
+                         timestr_to_secs, type_name, unic, is_list_like)
 from robot.utils.asserts import assert_equal, assert_not_equal
 from robot.variables import (is_list_var, is_var, DictVariableTableValue,
                              VariableTableValue, VariableSplitter,
@@ -597,7 +597,7 @@ class _Verify(_BuiltInBase):
         if not self._is_true(condition):
             raise AssertionError(msg or "'%s' should be true." % condition)
 
-    def should_be_equal(self, first, second, msg=None, values=True):
+    def should_be_equal(self, first, second, msg=None, values=True, ignore_case=False):
         """Fails if the given objects are unequal.
 
         Optional ``msg`` and ``values`` arguments specify how to construct
@@ -613,10 +613,21 @@ class _Verify(_BuiltInBase):
         for example, string ``false`` or ``no values``. See `Boolean arguments`
         section for more details.
 
+        If ignore_case is True, it indicates that ``first`` and ``second`` should be
+        compared case-insensitively.  See `Boolean  arguments` section for more details.
+        (This option is new in Robot Framework 3.0.1)
+
         If both arguments are multiline strings, the comparison is done using
         `multiline string comparisons`.
         """
         self._log_types_at_info_if_different(first, second)
+        if is_truthy(ignore_case):
+            if is_string(first) and is_string(second):
+                first = first.lower()
+                second = second.lower()
+            elif is_list_like(first) and is_list_like(second):
+                first = [x.lower() if type(x) is str else x for x in first]
+                second = [x.lower() if type(x) is str else x for x in second]
         self._should_be_equal(first, second, msg, values)
 
     def _should_be_equal(self, first, second, msg, values):
@@ -646,13 +657,24 @@ class _Verify(_BuiltInBase):
     def _include_values(self, values):
         return is_truthy(values) and str(values).upper() != 'NO VALUES'
 
-    def should_not_be_equal(self, first, second, msg=None, values=True):
+    def should_not_be_equal(self, first, second, msg=None, values=True, ignore_case=False):
         """Fails if the given objects are equal.
 
         See `Should Be Equal` for an explanation on how to override the default
         error message with ``msg`` and ``values``.
+
+        If ignore_case is True, it indicates that ``first`` and ``second`` should be
+        compared case-insensitively.  See `Boolean  arguments` section for more details.
+        (This option is new in Robot Framework 3.0.1)
         """
         self._log_types_at_info_if_different(first, second)
+        if is_truthy(ignore_case):
+            if is_string(first) and is_string(second):
+                first = first.lower()
+                second = second.lower()
+            elif is_list_like(first) and is_list_like(second):
+                first = [x.lower() if type(x) is str else x for x in first]
+                second = [x.lower() if type(x) is str else x for x in second]
         self._should_not_be_equal(first, second, msg, values)
 
     def _should_not_be_equal(self, first, second, msg, values):


### PR DESCRIPTION
This should be the implementation of the "Should (Not) Be Equal As Strings" keyword pair.
I tried my best to get the "Should (Not) Be Equal" changes to not be included, but I don't think I was successful.  
