### PR TITLE
Should (not) contain - keyword pair

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -71,3 +71,4 @@ Tim Orling                     IronPython support for `Dialogs` library (2.9.2, 
 Jozef Behran                   Fix ${TEST_MESSAGE} to reflect current test message (3.0, #2188)
 Joong-Hee Lee                  Extend 'Repeat Keyword' to support timeout (3.0, #2245)
 Anton Nikitin                  Should (Not) Contain Any (3.0.1, #2120)
+Chris Callan                   Should (Not) Contain (3.0.1, #2480)

--- a/atest/robot/standard_libraries/builtin/verify.robot
+++ b/atest/robot/standard_libraries/builtin/verify.robot
@@ -142,11 +142,17 @@ Should End With without values
 Should Not Contain
     Check test case    ${TESTNAME}
 
+Should Not Contain With Case Insensitivity
+    Check Test Case    ${TESTNAME}
+
 Should Not Contain With Non-String Values
     Check test case    ${TESTNAME}
 
 Should Contain
     Check test case    ${TESTNAME}
+
+Should Contain With Case Insensitivity
+    Check Test Case    ${TESTNAME}
 
 Should Contain With False Values Argument
     Check test case    ${TESTNAME}

--- a/atest/testdata/standard_libraries/builtin/verify.robot
+++ b/atest/testdata/standard_libraries/builtin/verify.robot
@@ -269,6 +269,12 @@ Should Not Contain
     Hello again    yet
     Hello yet again    yet
 
+Should Not Contain With Case Sensitivity
+    [Documentation]    FAIL 'Hello yet again' contains 'yet'
+    [Template]    Should Not Contain
+    Hello again    yet          ignore_case=True
+    Hello yet again    YET      ignore_case=True
+
 Should Not Contain With Non-String Values
     [Documentation]    FAIL '(1, 2)' contains '1'
     ${list}    ${tuple}    ${dict} =    Evaluate    ['a'], (1,2), {'a':1, 'b':2}
@@ -283,6 +289,13 @@ Should Contain
     abcdefg    cd
     abcdefg    abcdefg    Massage
     abcdefg    ABCDEFG    Message
+
+Should Contain With Case Sensitivity
+    [Documentation]    FAIL Message: 'abcdefg' does not contain 'ABCDEFG'
+    [Template]    Should Contain
+    abcdefg    CD                   ignore_case=True
+    abcdefg    ABCDEFG    Massage   ignore_case=True
+    abcdefg    ABCDefg    Message   ignore_case=True
 
 Should Contain With False Values Argument
     [Documentation]    FAIL Message

--- a/atest/testdata/standard_libraries/builtin/verify.robot
+++ b/atest/testdata/standard_libraries/builtin/verify.robot
@@ -291,10 +291,9 @@ Should Contain
     abcdefg    ABCDEFG    Message
 
 Should Contain With Case Insensitivity
-    [Documentation]    FAIL Message: 'abcdefg' does not contain 'ABCDEFG'
     [Template]    Should Contain
     abcdefg    CD                   ignore_case=True
-    abcdefg    ABCDEFG    Massage   ignore_case=True
+    abcdefg    ABCDEFG    Message   ignore_case=True
     abcdefg    ABCDefg    Message   ignore_case=True
 
 Should Contain With False Values Argument

--- a/atest/testdata/standard_libraries/builtin/verify.robot
+++ b/atest/testdata/standard_libraries/builtin/verify.robot
@@ -269,7 +269,7 @@ Should Not Contain
     Hello again    yet
     Hello yet again    yet
 
-Should Not Contain With Case Sensitivity
+Should Not Contain With Case Insensitivity
     [Documentation]    FAIL 'Hello yet again' contains 'yet'
     [Template]    Should Not Contain
     Hello again    yet          ignore_case=True
@@ -290,7 +290,7 @@ Should Contain
     abcdefg    abcdefg    Massage
     abcdefg    ABCDEFG    Message
 
-Should Contain With Case Sensitivity
+Should Contain With Case Insensitivity
     [Documentation]    FAIL Message: 'abcdefg' does not contain 'ABCDEFG'
     [Template]    Should Contain
     abcdefg    CD                   ignore_case=True

--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -32,7 +32,7 @@ from robot.utils import (DotDict, escape, format_assign_message,
                          Matcher, normalize, NormalizedDict, parse_time, prepr,
                          RERAISED_EXCEPTIONS, plural_or_not as s, roundup,
                          secs_to_timestr, seq2str, split_from_equals, StringIO,
-                         timestr_to_secs, type_name, unic)
+                         timestr_to_secs, type_name, unic, is_list_like)
 from robot.utils.asserts import assert_equal, assert_not_equal
 from robot.variables import (is_list_var, is_var, DictVariableTableValue,
                              VariableTableValue, VariableSplitter,
@@ -808,33 +808,51 @@ class _Verify(_BuiltInBase):
             raise AssertionError(self._get_string_msg(str1, str2, msg, values,
                                                       'does not end with'))
 
-    def should_not_contain(self, container, item, msg=None, values=True):
+    def should_not_contain(self, container, item, msg=None, values=True, ignore_case=False):
         """Fails if ``container`` contains ``item`` one or more times.
 
         Works with strings, lists, and anything that supports Python's ``in``
         operator. See `Should Be Equal` for an explanation on how to override
         the default error message with ``msg`` and ``values``.
 
+        If ignore_case is True, it indicates that ``item`` and ``container`` should be
+        compared case-insensitively.  See `Boolean  arguments` section for more details.
+        (This option is new in Robot Framework 3.0.1)
+
         Examples:
         | Should Not Contain | ${output}    | FAILED |
         | Should Not Contain | ${some list} | value  |
         """
-        if item in container:
+        prv_container = container
+        if is_truthy(ignore_case) and is_string(item):
+            item = item.lower()
+            if is_list_like(container):
+                prv_container = set([x.lower() if is_string(x) else x for x in container])
+        if item in prv_container:
             raise AssertionError(self._get_string_msg(container, item, msg,
                                                       values, 'contains'))
 
-    def should_contain(self, container, item, msg=None, values=True):
+    def should_contain(self, container, item, msg=None, values=True, ignore_case=False):
         """Fails if ``container`` does not contain ``item`` one or more times.
 
         Works with strings, lists, and anything that supports Python's ``in``
         operator. See `Should Be Equal` for an explanation on how to override
         the default error message with ``msg`` and ``values``.
 
+        If ignore_case is True, it indicates that ``item`` and ``container`` should be
+        compared case-insensitively.  See `Boolean  arguments` section for more details.
+        (This option is new in Robot Framework 3.0.1)
+
         Examples:
         | Should Contain | ${output}    | PASS  |
         | Should Contain | ${some list} | value |
         """
-        if item not in container:
+        prv_container = container
+        if is_truthy(ignore_case) and is_string(item):
+            item = item.lower()
+            if is_list_like(container):
+                prv_container = set([x.lower() if is_string(x) else x for x in container])
+        if item not in prv_container:
             raise AssertionError(self._get_string_msg(container, item, msg,
                                                       values, 'does not contain'))
 


### PR DESCRIPTION
This is the second set of keyword pairs for the case-insensitivity changes.  Covers the "Should Contain" and "Should Not Contain" keywords and their associated Acceptance Test cases.