### PR TITLE
Model object should support copy and deepcopy

### DIFF
--- a/utest/model/test_keyword.py
+++ b/utest/model/test_keyword.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 from robot.utils.asserts import (assert_equal, assert_none, assert_true,
                                  assert_raises, assert_raises_with_msg)
@@ -32,6 +33,22 @@ class TestKeyword(unittest.TestCase):
 
     def test_slots(self):
         assert_raises(AttributeError, setattr, Keyword(), 'attr', 'value')
+
+    def test_copy_keyword(self):
+        kw = Keyword()
+        kw_new = copy.copy(kw)
+        self.assertEqual(kw.name, kw_new.name)
+
+        kw_new.name = kw.name + '1'
+        self.assertNotEqual(kw.name, kw_new.name)
+
+        self.assertEqual(id(kw.tags), id(kw_new.tags))
+
+    def test_deepcopy_keyword(self):
+        kw = Keyword()
+        kw_new = copy.deepcopy(kw)
+        self.assertEqual(kw.name, kw_new.name)
+        self.assertNotEqual(id(kw.tags), id(kw_new.tags))
 
 
 class TestChildren(unittest.TestCase):

--- a/utest/model/test_testcase.py
+++ b/utest/model/test_testcase.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 from robot.utils.asserts import (assert_equal, assert_raises,
                                  assert_raises_with_msg, assert_true)
@@ -44,6 +45,22 @@ class TestTestCase(unittest.TestCase):
 
     def test_slots(self):
         assert_raises(AttributeError, setattr, self.test, 'attr', 'value')
+
+    def test_copy_testcase(self):
+        new_case = copy.copy(self.test)
+        self.assertEqual(new_case.name, self.test.name)
+
+        new_case.name = self.test.name + '_1'
+        self.assertNotEqual(new_case.name, self.test.name)
+
+        self.assertEqual(id(new_case.tags), id(self.test.tags))
+        new_case.tags = "123"
+        self.assertNotEqual(id(new_case.tags), id(self.test.tags))
+
+    def test_deep_copy_testcase(self):
+        new_case = copy.deepcopy(self.test)
+        self.assertEqual(new_case.name, self.test.name)
+        self.assertNotEqual(id(new_case.tags), id(self.test.tags))
 
 
 class TestStringRepresentation(unittest.TestCase):

--- a/utest/running/test_run_model.py
+++ b/utest/running/test_run_model.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 
 from robot import model
@@ -21,6 +22,44 @@ class TestModelTypes(unittest.TestCase):
         kw = TestCase().keywords.create()
         assert_equal(type(kw), Keyword)
         assert_not_equal(type(kw), model.Keyword)
+
+
+class TestRunningCase(unittest.TestCase):
+    def test_copy_testcase(self):
+        case = TestCase()
+        new_case = copy.copy(case)
+        self.assertEqual(new_case.name, case.name)
+
+        new_case.name = case.name + '_1'
+        self.assertNotEqual(new_case.name, case.name)
+
+        self.assertEqual(id(new_case.tags), id(case.tags))
+        new_case.tags = "123"
+        self.assertNotEqual(id(new_case.tags), id(case.tags))
+
+    def test_deep_copy_testcase(self):
+        case = TestCase()
+        new_case = copy.deepcopy(case)
+        self.assertEqual(new_case.name, case.name)
+        self.assertNotEqual(id(new_case.tags), id(case.tags))
+
+
+class TestRunningKeyword(unittest.TestCase):
+    def test_copy_keyword(self):
+        kw = Keyword()
+        kw_new = copy.copy(kw)
+        self.assertEqual(kw.name, kw_new.name)
+
+        kw_new.name = kw.name + '1'
+        self.assertNotEqual(kw.name, kw_new.name)
+
+        self.assertEqual(id(kw.tags), id(kw_new.tags))
+
+    def test_deepcopy_keyword(self):
+        kw = Keyword()
+        kw_new = copy.deepcopy(kw)
+        self.assertEqual(kw.name, kw_new.name)
+        self.assertNotEqual(id(kw.tags), id(kw_new.tags))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Enable the `copy` and `deepcopy` feature of model objects.
This PR is the fix for that I mentioned in #2483 .