### PR TITLE
Add --rerunfailedsuites option

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -73,3 +73,4 @@ Joong-Hee Lee                  Extend 'Repeat Keyword' to support timeout (3.0, 
 Anton Nikitin                  Should (Not) Contain Any (3.0.1, #2120)
 Yang Qian                      Support to copy/deepcopy model objects (3.0.1, #2484)
 Chris Callan                   Case-insensitivity support to various comparison keywords (3.0.1, #2461)
+Benjamin Einaudi               Add --rerunfailedsuites option (3.0.1, #2487)

--- a/atest/robot/cli/runner/rerunfailed.robot
+++ b/atest/robot/cli/runner/rerunfailed.robot
@@ -12,6 +12,7 @@ ${RUN FAILED FROM}    ${RERUN DIR}/rerun-output.xml
 *** Test Cases ***
 Passing is not re-executed
     Test Should Not Have Been Executed    Passing
+    Test Should Not Have Been Executed    Not Failing
 
 Failing is re-executed
     Test Should Have Been Executed    Failing
@@ -38,7 +39,7 @@ Suite initialization
     Run Tests    ${EMPTY}    ${SUITE DIR}
     Copy File    ${OUTFILE}    ${RUN FAILED FROM}
     Copy File    ${ORIG DIR}/runfailed2.robot    ${SUITE DIR}/runfailed.txt
-    Run Tests    --rerunfailed ${RUN FAILED FROM} --test Selected --exclude tag    ${SUITE DIR}
+    Run Tests    --rerunfailed ${RUN FAILED FROM} --test Selected --exclude excluded_tag    ${SUITE DIR}
 
 Test Should Have Been Executed
     [Arguments]    ${name}

--- a/atest/robot/cli/runner/rerunfailedsuites.robot
+++ b/atest/robot/cli/runner/rerunfailedsuites.robot
@@ -1,0 +1,44 @@
+*** Settings ***
+Suite Setup       Suite initialization
+Suite Teardown    Remove Directory    ${RERUN SUITE DIR}    recursive
+Resource          atest_resource.robot
+
+*** Variables ***
+${ORIG DIR}           ${DATADIR}/cli/runfailed
+${RERUN SUITE DIR}    %{TEMPDIR}/rerunsuites-dir
+${SUITE DIR}          ${RERUN SUITE DIR}/suite
+${RUN FAILED FROM}    ${RERUN SUITE DIR}/rerun-suites-output.xml
+
+*** Test Cases ***
+Passing suite is not re-executed
+    Test Should Not Have Been Executed    Passing
+
+Failing suite is re-executed
+    Test Should Have Been Executed   Failing
+    Test Should Have Been Executed   Not Failing
+
+Suite teardown failures are noticed
+    Test Should Have Been Executed   Test passed but suite teardown fails
+
+Excluded failing is not executed
+    Test Should Not Have Been Executed    Failing with tag
+
+Non-existing failing from output file is not executed
+    Test Should Not Have Been Executed    Only in one suite
+
+*** Keywords ***
+Suite initialization
+    Copy Directory    ${ORIG DIR}/suite    ${SUITE DIR}
+    Copy File    ${ORIG DIR}/runfailed1.robot     ${SUITE DIR}/runfailed.txt
+    Run Tests    ${SUITE DIR}
+    Copy File    ${OUTFILE}    ${RUN FAILED FROM}
+    Copy File    ${ORIG DIR}/runfailed2.robot     ${SUITE DIR}/runfailed.txt
+    Run Tests    --rerunfailedsuites ${RUN FAILED FROM} --noncritical non_critical --exclude excluded_tag ${SUITE DIR}
+
+Test Should Have Been Executed
+    [Arguments]    ${name}
+    Check Test Case    ${name}
+
+Test Should Not Have Been Executed
+    [Arguments]    ${name}
+    Run Keyword And Expect Error    No test '${name}' found*    Check Test Case    ${name}

--- a/atest/robot/cli/runner/rerunfailedsuites_corners.robot
+++ b/atest/robot/cli/runner/rerunfailedsuites_corners.robot
@@ -7,33 +7,33 @@ ${RUN FAILED FROM}    %{TEMPDIR}${/}run-failed-output.xml
 
 *** Test Cases ***
 Runs everything when output is set to NONE
-    Run Tests  --ReRunFailed NoNe  cli/runfailed/onlypassing
+    Run Tests  --ReRunFailedSuites NoNe  cli/runfailed/onlypassing
     File Should Exist  ${OUTFILE}
     Check Test Case    Passing
 
 Stops on error when output contains only passing test cases
     Generate output  cli/runfailed/onlypassing
-    Run Tests Without Processing Output  -R ${RUN FAILED FROM}  cli/runfailed/onlypassing
+    Run Tests Without Processing Output  -S ${RUN FAILED FROM}  cli/runfailed/onlypassing
     Stderr Should Be Equal To
-    ...  [ ERROR ] Collecting failed tests from '${RUN FAILED FROM}' failed: All tests passed.${USAGE TIP}\n
+    ...  [ ERROR ] Collecting failed suites from '${RUN FAILED FROM}' failed: All suites passed.${USAGE TIP}\n
 
 Stops on error when output contains only non-existing failing test cases
     Generate output  cli/runfailed/runfailed1.robot
-    Run Tests Without Processing Output  --RERUNFAILED ${RUN FAILED FROM}  cli/runfailed/onlypassing
+    Run Tests Without Processing Output  --RERUNFAILEDSUITES ${RUN FAILED FROM}  cli/runfailed/onlypassing
     Stderr Should Be Equal To
-    ...  [ ERROR ] Suite 'Onlypassing' contains no tests named 'Runfailed1.Failing' or 'Runfailed1.Only in one suite'.${USAGE TIP}\n
+    ...  [ ERROR ]  Suite 'Onlypassing'  contains no tests in suite  'Runfailed1'.${USAGE TIP}\n
 
 Stops on error when output does not exist
-    Run Tests Without Processing Output  --rerunfailed nonex.xml  cli/runfailed/onlypassing
+    Run Tests Without Processing Output  --rerunfailedsuites nonex.xml  cli/runfailed/onlypassing
     Stderr Should Match
-    ...  [ ERROR ] Collecting failed tests from 'nonex.xml' failed:
+    ...  [ ERROR ] Collecting failed suites from 'nonex.xml' failed:
     ...  Reading XML source 'nonex.xml' failed:*${USAGE TIP}\n
 
 Stops on error when output is invalid
     Create File  ${RUN FAILED FROM}  <xml><but not='correct'/></xml>
-    Run Tests Without Processing Output  --rerunfailed ${RUN FAILED FROM}  cli/runfailed/onlypassing
+    Run Tests Without Processing Output  --rerunfailedsuites ${RUN FAILED FROM}  cli/runfailed/onlypassing
     Stderr Should Be Equal To
-    ...  [ ERROR ] Collecting failed tests from '${RUN FAILED FROM}' failed:
+    ...  [ ERROR ] Collecting failed suites from '${RUN FAILED FROM}' failed:
     ...  Reading XML source '${RUN FAILED FROM}' failed:
     ...  Incompatible XML element 'xml'.${USAGE TIP}\n
 

--- a/atest/testdata/cli/runfailed/runfailed1.robot
+++ b/atest/testdata/cli/runfailed/runfailed1.robot
@@ -1,13 +1,6 @@
 *** Test Cases ***
-Passing
-    No Operation
-
 Failing
     [Documentation]    FAIL Message
-    Fail    Message
-
-Failing With Tag
-    [Tags]    tag
     Fail    Message
 
 Selected

--- a/atest/testdata/cli/runfailed/runfailed2.robot
+++ b/atest/testdata/cli/runfailed/runfailed2.robot
@@ -1,13 +1,6 @@
 *** Test Cases ***
-Passing
-    No Operation
-
 Failing
     [Documentation]    FAIL Message
-    Fail    Message
-
-Failing With Tag
-    [Tags]    tag
     Fail    Message
 
 Selected

--- a/atest/testdata/cli/runfailed/suite/subsuite/suite_failed.robot
+++ b/atest/testdata/cli/runfailed/suite/subsuite/suite_failed.robot
@@ -1,5 +1,5 @@
 *** Test Cases ***
-Failing
+Not Failing
     No Operation  # Not really failing..
 
 Really Failing

--- a/atest/testdata/cli/runfailed/suite/subsuite/suite_failed_with_excluded_tag.robot
+++ b/atest/testdata/cli/runfailed/suite/subsuite/suite_failed_with_excluded_tag.robot
@@ -1,0 +1,8 @@
+*** Settings ***
+Suite Teardown    No Operation
+
+*** Test Cases ***
+Failing with tag
+    [Tags]  excluded_tag
+    Fail    failed test
+

--- a/atest/testdata/cli/runfailed/suite/subsuite/suite_succeed.robot
+++ b/atest/testdata/cli/runfailed/suite/subsuite/suite_succeed.robot
@@ -1,0 +1,4 @@
+*** Test Cases ***
+Passing
+    No Operation
+

--- a/doc/userguide/src/Appendices/CommandLineOptions.rst
+++ b/doc/userguide/src/Appendices/CommandLineOptions.rst
@@ -22,6 +22,8 @@ Command line options for test execution
   -R, --rerunfailed <file>  `Selects failed tests`_ from an earlier `output file`_ to be re-executed.
   --runfailed <file>      Deprecated since Robot Framework 2.8.4.
                           Use :option:`--rerunfailed` instead.
+  -S, --rerunfailedsuites <file>  `Selects failed test suite`_ from an earlier `output file`_ to be re-executed.
+
   -i, --include <tag>     `Selects the test cases`_ by tag.
   -e, --exclude <tag>     `Selects the test cases`_ by tag.
   -c, --critical <tag>    Tests that have the given tag are `considered critical`_.
@@ -148,6 +150,7 @@ Command line options for post-processing outputs
 .. _Sets the tag(s): `Setting tags`_
 .. _Selects the test cases by name: `By test suite and test case names`_
 .. _Selects the test suites: `Selects the test cases by name`_
+.. _Selects failed tests suites: `Re-executing failed test suites`_
 .. _Selects failed tests: `Re-executing failed test cases`_
 .. _Selects the test cases: `By tag names`_
 .. _considered critical: `Setting criticality`_

--- a/doc/userguide/src/ExecutingTestCases/ConfiguringExecution.rst
+++ b/doc/userguide/src/ExecutingTestCases/ConfiguringExecution.rst
@@ -140,6 +140,20 @@ is same as not specifying this option at all.
 
 __ `Merging outputs`_
 
+Re-executing failed test suites
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Command line option :option:`rerunfailedsuites (-S)` can be used to select all failed
+suites from an earlier `output file`_ for re-execution. Like  :option:`--rerunfailed (-R)`, this option is useful when
+full test execution takes a lot of time. Note that all tests from a failed test suite will be re-executed, even
+passing ones. This option is useful when the tests of a test suite depends on each other.
+
+Behind the scenes this option selects the failed suite as they would have been
+selected individually with the :option:`--suite` option. It is possible to further
+fine-tune the list of selected tests by using :option:`--test`, :option:`--suite`,
+:option:`--include` and :option:`--exclude` options.
+
+.. note:: :option:`--rerunfailedsuites` option was added in Robot Framework 3.0.1.
+
 When no tests match selection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/userguide/src/ExecutingTestCases/PostProcessing.rst
+++ b/doc/userguide/src/ExecutingTestCases/PostProcessing.rst
@@ -127,7 +127,7 @@ There is often a need to re-execute a subset of tests, for example, after
 fixing a bug in the system under test or in the tests themselves. This can be
 accomplished by `selecting test cases`_ by names (:option:`--test` and
 :option:`--suite` options), tags (:option:`--include` and :option:`--exclude`),
-or by previous status (:option:`--rerunfailed`).
+or by previous status (:option:`--rerunfailed` or :option: `--rerunfailedsuites`).
 
 Combining re-execution results with the original results using the default
 `combining outputs`_ approach does not work too well. The main problem is

--- a/src/robot/conf/gatherfailed.py
+++ b/src/robot/conf/gatherfailed.py
@@ -32,6 +32,22 @@ class GatherFailedTests(SuiteVisitor):
         pass
 
 
+class GatherFailedSuites(SuiteVisitor):
+
+    def __init__(self):
+        self.suites = []
+
+    def start_suite(self, suite):
+        if any(not test.passed for test in suite.tests):
+            self.suites.append(suite.longname)
+
+    def visit_test(self, test):
+        pass
+
+    def visit_keyword(self, kw):
+        pass
+
+
 def gather_failed_tests(output):
     if output.upper() == 'NONE':
         return []
@@ -44,3 +60,17 @@ def gather_failed_tests(output):
         raise DataError("Collecting failed tests from '%s' failed: %s"
                         % (output, get_error_message()))
     return gatherer.tests
+
+
+def gather_failed_suites(output):
+    if output.upper() == 'NONE':
+        return []
+    gatherer = GatherFailedSuites()
+    try:
+        ExecutionResult(output, include_keywords=False).suite.visit(gatherer)
+        if not gatherer.suites:
+            raise DataError('All suites passed.')
+    except:
+        raise DataError("Collecting failed suites from '%s' failed: %s"
+                        % (output, get_error_message()))
+    return gatherer.suites

--- a/src/robot/conf/settings.py
+++ b/src/robot/conf/settings.py
@@ -26,7 +26,7 @@ from robot.utils import (abspath, escape, format_time, get_link_path,
                          html_escape, is_list_like, py2to3,
                          split_args_from_name_or_path)
 
-from .gatherfailed import gather_failed_tests
+from .gatherfailed import gather_failed_tests, gather_failed_suites
 
 
 @py2to3
@@ -36,6 +36,7 @@ class _BaseSettings(object):
                  'Metadata'         : ('metadata', []),
                  'TestNames'        : ('test', []),
                  'ReRunFailed'      : ('rerunfailed', 'NONE'),
+                 'ReRunFailedSuites': ('rerunfailedsuites', 'NONE'),
                  'SuiteNames'       : ('suite', []),
                  'SetTag'           : ('settag', []),
                  'Include'          : ('include', []),
@@ -83,6 +84,7 @@ class _BaseSettings(object):
                 value = list(value) if is_list_like(value) else [value]
             self[name] = self._process_value(name, value)
         self['TestNames'] += self['ReRunFailed']
+        self['SuiteNames'] += self['ReRunFailedSuites']
 
     def __setitem__(self, name, value):
         if name not in self._cli_opts:
@@ -92,6 +94,8 @@ class _BaseSettings(object):
     def _process_value(self, name, value):
         if name == 'ReRunFailed':
             return gather_failed_tests(value)
+        if name == 'ReRunFailedSuites':
+            return gather_failed_suites(value)
         if name == 'LogLevel':
             return self._process_log_level(value)
         if value == self._get_default_value(name):

--- a/src/robot/run.py
+++ b/src/robot/run.py
@@ -125,6 +125,8 @@ Options
  -R --rerunfailed output  Select failed tests from an earlier output file to be
                           re-executed. Equivalent to selecting same tests
                           individually using --test option.
+ -S --rerunfailedsuites output  Select failed suite from an earlier output file
+                          to be re-executed (New in RF 3.0.1).
  -c --critical tag *      Tests having given tag are considered critical. If no
                           critical tags are set, all tags are critical. Tags
                           can be given as a pattern like with --include.


### PR DESCRIPTION
Based on [this issue](https://github.com/robotframework/robotframework/issues/2117) (I do need this functionnality too), I started implementing it.

:warning: this do not support the `--critical/noncritical`as I **need some advice**:
- shall I filter from first output (where for example `--noncritical`was set) : then I need to update the model to get the information when output is processed
- shall I only filter from second execution parameters

Can you also give me some comment about my work, what I need to change/correct if any.

Thanks! 