### PR TITLE
Should (not) be equal as strings

### DIFF
--- a/atest/robot/standard_libraries/builtin/verify.robot
+++ b/atest/robot/standard_libraries/builtin/verify.robot
@@ -113,9 +113,15 @@ Should Not Be Equal As Strings
     ${tc}=    Check test case    ${TESTNAME}
     Verify argument type message    ${tc.kws[0].msgs[0]}    unicode    float
 
+Should Not Be Equal As Strings With Case Insensitivity
+    ${tc}=    Check test case    ${TESTNAME}
+
 Should Be Equal As Strings
     ${tc}=    Check test case    ${TESTNAME}
     Verify argument type message    ${tc.kws[0].msgs[0]}    int    unicode
+
+Should Be Equal As Strings With Case Insensitivity
+    ${tc}=    Check test case    ${TESTNAME}
 
 Should Be Equal As Strings Multiline
     [Tags]    no-python26    # diff contains extra spaces on python 2.6

--- a/atest/testdata/standard_libraries/builtin/verify.robot
+++ b/atest/testdata/standard_libraries/builtin/verify.robot
@@ -210,7 +210,7 @@ Should Not Be Equal As Strings
     False    ${True}
     bar    bar    These strings most certainly should not be equal    False
 
-Should Not Be Equal As Strings With Case Inensitivity
+Should Not Be Equal As Strings With Case Insensitivity
     [Documentation]     FAIL These strings were equal
     [Template]      Should Not Be Equal As Strings
     1    ${1.1}         ignore_case=True

--- a/atest/testdata/standard_libraries/builtin/verify.robot
+++ b/atest/testdata/standard_libraries/builtin/verify.robot
@@ -210,12 +210,28 @@ Should Not Be Equal As Strings
     False    ${True}
     bar    bar    These strings most certainly should not be equal    False
 
+Should Not Be Equal As Strings With Case Inensitivity
+    [Documentation]     FAIL These strings were equal
+    [Template]      Should Not Be Equal As Strings
+    1    ${1.1}         ignore_case=True
+    False    ${True}    ignore_case=True
+    HYVÄÄ YÖTÄ      hyvää yötä1      ignore_case=True
+    bar    BAR          These strings were equal      False     ignore_case=True
+
 Should Be Equal As Strings
     [Documentation]    FAIL foo != bar
     [Template]    Should Be Equal As Strings
     ${1}    1
     ${None}    None
     foo    bar
+
+Should Be Equal As Strings With Case Insensitivity
+    [Documentation]
+    [Template]      Should Be Equal As Strings
+    ${1}    1           ignore_case=True
+    ${None}    NONE     ignore_case=True
+    test value      TEST VALUE      ignore_case=True
+    HYVÄÄ YÖTÄ      hyvää yötä      ignore_case=True
 
 Should Be Equal As Strings Multiline
     [Documentation]    FAIL Multiline strings are different:

--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -745,27 +745,41 @@ class _Verify(_BuiltInBase):
         second = self._convert_to_number(second, precision)
         self._should_be_equal(first, second, msg, values)
 
-    def should_not_be_equal_as_strings(self, first, second, msg=None, values=True):
+    def should_not_be_equal_as_strings(self, first, second, msg=None, values=True,
+                                       ignore_case=False):
         """Fails if objects are equal after converting them to strings.
+
+        If ignore_case is True, it indicates that ``first`` and ``second`` should be
+        compared case-insensitively.  See `Boolean  arguments` section for more details.
+        (This option is new in Robot Framework 3.0.1)
 
         See `Should Be Equal` for an explanation on how to override the default
         error message with ``msg`` and ``values``.
         """
         self._log_types_at_info_if_different(first, second)
         first, second = [self._convert_to_string(i) for i in (first, second)]
+        if is_truthy(ignore_case):
+            first, second = [x.lower() for x in (first, second)]
         self._should_not_be_equal(first, second, msg, values)
 
-    def should_be_equal_as_strings(self, first, second, msg=None, values=True):
+    def should_be_equal_as_strings(self, first, second, msg=None, values=True,
+                                   ignore_case=False):
         """Fails if objects are unequal after converting them to strings.
 
         See `Should Be Equal` for an explanation on how to override the default
         error message with ``msg`` and ``values``.
+
+        If ignore_case is True, it indicates that ``first`` and ``second`` should be
+        compared case-insensitively.  See `Boolean  arguments` section for more details.
+        (This option is new in Robot Framework 3.0.1)
 
         If both arguments are multiline strings, the comparison is done using
         `multiline string comparisons`.
         """
         self._log_types_at_info_if_different(first, second)
         first, second = [self._convert_to_string(i) for i in (first, second)]
+        if is_truthy(ignore_case):
+            first, second = [x.lower() for x in (first, second)]
         self._should_be_equal(first, second, msg, values)
 
     def should_not_start_with(self, str1, str2, msg=None, values=True):


### PR DESCRIPTION
Pull Request to extend the case-sensitivity functionality to the "Should (Not) Be Equal As Strings" keyword pair