### PR TITLE
Updates the run method documention by listing not supported arguments.

### DIFF
--- a/src/robot/run.py
+++ b/src/robot/run.py
@@ -488,6 +488,18 @@ def run(*datasources, **options):
 
     A return code is returned similarly as when running on the command line.
 
+    The following command line arguments are not available from the `run`
+    method::
+
+        --pythonpath
+        --argumentfile
+        --help
+        --version
+        --escape
+
+    Thw workaround for `--pythonpath` argument is to add the requires paths by
+    using the `sys.path` method.
+
     Example::
 
         from robot import run


### PR DESCRIPTION
The --pythonpath, --argumentfile, --help, --version and --escape
arguments are not supported from the run method. Updated method
documentation to declare the exceptions.