### PR TITLE
 "Should (Not) Start With" keywords with case insensitivity option

### DIFF
--- a/atest/robot/standard_libraries/builtin/verify.robot
+++ b/atest/robot/standard_libraries/builtin/verify.robot
@@ -124,7 +124,13 @@ Should Be Equal As Strings Multiline
 Should Not Start With
     Check test case    ${TESTNAME}
 
+Should Not Start With Case Insensitivity
+    Check test case    ${TESTNAME}
+
 Should Start With
+    Check test case    ${TESTNAME}
+
+Should Start With Case Insensitivity
     Check test case    ${TESTNAME}
 
 Should Start With without values

--- a/atest/testdata/standard_libraries/builtin/verify.robot
+++ b/atest/testdata/standard_libraries/builtin/verify.robot
@@ -235,12 +235,28 @@ Should Not Start With
     Hello, world!    HELLO
     Hello, world!    Hello
 
+Should Not Start With Case Insensitivity
+    [Documentation]    FAIL 'hello, world!' starts with (case-insensitive) 'hello'
+    [Template]    Should Not Start With
+    [Tags]  Mine
+    Hello, world!   Hi          ignore_case=True
+    Hello, world!   ELLO        ignore_case=True
+    HYVÄÄ YÖTÄ      zyvää       ignore_case=True
+    Hello, world!   hello       ignore_case=True
+
 Should Start With
     [Documentation]    FAIL My message: '${LONG}' does not start with 'Does not start'
     [Template]    Should Start With
     Hello, world!    Hello
     Hello, world!    Hello, world!
     ${LONG}    Does not start    My message    values=true
+
+Should Start With Case Insensitivity
+    [Template]    Should Start With
+    [Tags]  Mine
+    Hello, world!   hello               ignore_case=True
+    Hello, world!   HELLO, WORLD!       ignore_case=True
+    HYVÄÄ YÖTÄ      hyvää               ignore_case=True
 
 Should Start With without values
     [Documentation]    FAIL My message

--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -768,25 +768,45 @@ class _Verify(_BuiltInBase):
         first, second = [self._convert_to_string(i) for i in (first, second)]
         self._should_be_equal(first, second, msg, values)
 
-    def should_not_start_with(self, str1, str2, msg=None, values=True):
+    def should_not_start_with(self, str1, str2, msg=None, values=True,
+                              ignore_case=False):
         """Fails if the string ``str1`` starts with the string ``str2``.
 
+        If ignore_case is True, it indicates that ``str1`` and ``str2``
+        should be compared case-insensitively.  See `Boolean  arguments` section
+        for more details.  (This option is new in Robot Framework 3.0.1)
+
         See `Should Be Equal` for an explanation on how to override the default
         error message with ``msg`` and ``values``.
         """
+        str_assertion = 'starts with'
+        if is_truthy(ignore_case):
+            str1 = str1.lower()
+            str2 = str2.lower()
+            str_assertion += " (case-insensitive)"
         if str1.startswith(str2):
             raise AssertionError(self._get_string_msg(str1, str2, msg, values,
-                                                      'starts with'))
+                                                      str_assertion))
 
-    def should_start_with(self, str1, str2, msg=None, values=True):
+    def should_start_with(self, str1, str2, msg=None, values=True,
+                          ignore_case=False):
         """Fails if the string ``str1`` does not start with the string ``str2``.
+
+        If ignore_case is True, it indicates that ``str1`` and ``str2``
+        should be compared case-insensitively.  See `Boolean  arguments` section
+        for more details.  (This option is new in Robot Framework 3.0.1)
 
         See `Should Be Equal` for an explanation on how to override the default
         error message with ``msg`` and ``values``.
         """
+        str_assertion = 'does not start with'
+        if is_truthy(ignore_case):
+            str1 = str1.lower()
+            str2 = str2.lower()
+            str_assertion += " (case-insensitive)"
         if not str1.startswith(str2):
             raise AssertionError(self._get_string_msg(str1, str2, msg, values,
-                                                      'does not start with'))
+                                                      str_assertion))
 
     def should_not_end_with(self, str1, str2, msg=None, values=True):
         """Fails if the string ``str1`` ends with the string ``str2``.


### PR DESCRIPTION
Sorry for the delay in getting this one done, trouble finding any free time lately.
I've implemented the ignore_case option for these two keywords, included updated acceptance tests, and took a swing at adding "(case-insensitive)" to the failure message string. 