### PR TITLE
issue 2517: Resize listbox for long values

### DIFF
--- a/atest/robot/standard_libraries/dialogs/dialogs.robot
+++ b/atest/robot/standard_libraries/dialogs/dialogs.robot
@@ -40,6 +40,9 @@ Get Value From User Exited
 Get Selection From User
     Check Test Case    ${TESTNAME}
 
+Get Selection From User Long
+    Check Test Case    ${TESTNAME}
+
 Get Selection From User Cancelled
     Check Test Case    ${TESTNAME}
 

--- a/atest/testdata/standard_libraries/dialogs/dialogs.robot
+++ b/atest/testdata/standard_libraries/dialogs/dialogs.robot
@@ -53,6 +53,11 @@ Get Selection From User
     ...    zip    zap    foo    value    bar
     Should Be Equal    ${value}    value
 
+Get Selection From User Long
+    ${value} =    Get Selection From User    Select 'value' and press OK.
+    ...    zip    zap    foo    value    bar    This is a really long string and the window should change the size properly to content
+    Should Be Equal    ${value}    value
+
 Get Selection From User Cancelled
     [Documentation]  FAIL No value provided by user.
     Get Selection From User    Press Cancel.    zip    zap    foo

--- a/src/robot/libraries/dialogs_py.py
+++ b/src/robot/libraries/dialogs_py.py
@@ -158,6 +158,7 @@ class SelectionDialog(_TkDialog):
         self._listbox = Listbox(parent)
         for item in values:
             self._listbox.insert(END, item)
+        self._listbox.config(width=0)
         return self._listbox
 
     def _validate_value(self):


### PR DESCRIPTION
Added one line to dialogs_py.py to resize the listbox. Added tests and run was ok for me, but I didn't check other versions. (Only on Ubuntu with python).

As this is my first contribution to a github project I'll be thankful for any help to improve my work.