### PR TITLE
Validating variables used as parameters during dryrun

### DIFF
--- a/src/robot/running/librarykeywordrunner.py
+++ b/src/robot/running/librarykeywordrunner.py
@@ -113,7 +113,7 @@ class LibraryKeywordRunner(object):
         if self._handler.longname in self._executed_in_dry_run:
             self._run(context, args)
         else:
-            self._handler.resolve_arguments(args)
+            self._handler.resolve_arguments(args, context.variables)
 
 
 class EmbeddedArgumentsRunner(LibraryKeywordRunner):

--- a/src/robot/running/userkeywordrunner.py
+++ b/src/robot/running/userkeywordrunner.py
@@ -199,7 +199,7 @@ class UserKeywordRunner(object):
             self._dry_run(context, kw.args, result)
 
     def _dry_run(self, context, args, result):
-        self._resolve_arguments(args)
+        self._resolve_arguments(args, context.variables)
         with context.user_keyword:
             timeout = self._get_timeout()
             if timeout:


### PR DESCRIPTION
During dryrun, it is possible to verify that a variable
used as argument is not missing from the variables section (*** Variables ***).
But it will not work obviously for keywords like Set Variable.

Fixes #2322