### PR TITLE
add try/catch block to prevent SecurityErrors when accessing localSto…

### DIFF
--- a/src/robot/htmldata/common/storage.js
+++ b/src/robot/htmldata/common/storage.js
@@ -8,21 +8,19 @@ storage = function () {
 
     function get(name, defaultValue) {
         try {
-            if (!localStorage)
-                return defaultValue;
             var value = localStorage[prefix + name];
-            if (typeof value === 'undefined')
-                return defaultValue;
-            return value;
         } catch (exception) {
             return defaultValue;
         }
+        if (typeof value === 'undefined')
+            return defaultValue;
+        return value;
+
     }
 
     function set(name, value) {
         try {
-            if (localStorage)
-                localStorage[prefix + name] = value;
+            localStorage[prefix + name] = value;
         } catch (exception) {}
     }
 

--- a/src/robot/htmldata/common/storage.js
+++ b/src/robot/htmldata/common/storage.js
@@ -7,17 +7,23 @@ storage = function () {
     }
 
     function get(name, defaultValue) {
-        if (!localStorage)
+        try {
+            if (!localStorage)
+                return defaultValue;
+            var value = localStorage[prefix + name];
+            if (typeof value === 'undefined')
+                return defaultValue;
+            return value;
+        } catch (exception) {
             return defaultValue;
-        var value = localStorage[prefix + name];
-        if (typeof value === 'undefined')
-            return defaultValue;
-        return value;
+        }
     }
 
     function set(name, value) {
-        if (localStorage)
-            localStorage[prefix + name] = value;
+        try {
+            if (localStorage)
+                localStorage[prefix + name] = value;
+        } catch (exception) {}
     }
 
     return {init: init, get: get, set: set};


### PR DESCRIPTION
…rage

Fixes  #2606 catching exceptions that may occur when accessing browser's localStorage object, see [explanation](https://mathiasbynens.be/notes/localstorage-pattern#comment-9)