### PR TITLE
Fix for Run Keyword And Return in teardown #2594

### DIFF
--- a/atest/robot/standard_libraries/builtin/run_keyword_and_return.robot
+++ b/atest/robot/standard_libraries/builtin/run_keyword_and_return.robot
@@ -21,6 +21,9 @@ Nested usage
 Keyword fails
     Check Test Case    ${TESTNAME}
 
+Keyword fails in teardown
+    Check Test Case    ${TESTNAME}
+
 Inside Run Keyword variants
     ${tc} =    Check Test Case    ${TESTNAME}
     Check log message    ${tc.kws[2].kws[0].kws[0].msgs[0]}    First keyword

--- a/atest/testdata/standard_libraries/builtin/run_keyword_and_return.robot
+++ b/atest/testdata/standard_libraries/builtin/run_keyword_and_return.robot
@@ -23,6 +23,11 @@ Keyword fails
     [Documentation]    FAIL    Expected error
     Keyword fails
 
+Keyword fails in teardown
+    [Documentation]    FAIL    Teardown failed:\nExpected error
+    No Operation
+    [Teardown]    Keyword fails
+
 Inside Run Keyword variants
     [Documentation]    FAIL    Continuable\n\nAlso teardown failed:\nContinuable
     ${ret} =    Inside Run Keyword If

--- a/src/robot/errors.py
+++ b/src/robot/errors.py
@@ -111,6 +111,7 @@ class ExecutionFailed(RobotError):
         self.exit = exit
         self._continue_on_failure = continue_on_failure
         self.return_value = return_value
+        self._return_requested = False
 
     @property
     def timeout(self):
@@ -130,6 +131,9 @@ class ExecutionFailed(RobotError):
         for child in getattr(self, '_errors', []):
             child.continue_on_failure = continue_on_failure
 
+    def set_return_requested(self):
+        self._return_requested = True
+
     def can_continue(self, teardown=False, templated=False, dry_run=False):
         if dry_run:
             return True
@@ -138,6 +142,8 @@ class ExecutionFailed(RobotError):
         if templated:
             return True
         if self.keyword_timeout:
+            return False
+        if self._return_requested:
             return False
         if teardown:
             return True

--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -2365,7 +2365,11 @@ class _Control(_BuiltInBase):
 
         New in Robot Framework 2.8.2.
         """
-        ret = self.run_keyword(name, *args)
+        try:
+            ret = self.run_keyword(name, *args)
+        except ExecutionFailed as err:
+            err.set_return_requested()
+            raise
         self.return_from_keyword(escape(ret))
 
     @run_keyword_variant(resolve=2)


### PR DESCRIPTION
In teardown context, keywords "Run Keyword And Return" and
"Run Keyword And Return If" did not return from the enclosing
user keyword if the given keyword execution failed.