### PR TITLE
Fix line continuation of comments bug

### DIFF
--- a/src/robot/writer/rowsplitter.py
+++ b/src/robot/writer/rowsplitter.py
@@ -75,7 +75,10 @@ class RowSplitter(object):
             current, row = self._split(row)
             yield self._escape_last_cell_if_empty(current)
             if row:
-                row = self._continue_row(row, indent)
+                if self._comment_mark in current:
+                    row = self._continue_row(row, indent, True)
+                else:
+                    row = self._continue_row(row, indent)
 
     def _split(self, data):
         index = min(self._get_possible_split_indices(data))
@@ -101,8 +104,10 @@ class RowSplitter(object):
             row = row[:-1] + [self._empty_cell_escape]
         return row
 
-    def _continue_row(self, row, indent):
+    def _continue_row(self, row, indent, is_comment = False):
         row = [self._line_continuation] + row
+        if is_comment:
+            row = [self._comment_mark] + row
         if indent + 1 < self._cols:
             row = [''] * indent + row
         return row

--- a/src/robot/writer/rowsplitter.py
+++ b/src/robot/writer/rowsplitter.py
@@ -75,10 +75,8 @@ class RowSplitter(object):
             current, row = self._split(row)
             yield self._escape_last_cell_if_empty(current)
             if row:
-                if self._comment_mark in current:
-                    row = self._continue_row(row, indent, True)
-                else:
-                    row = self._continue_row(row, indent)
+                print(row)
+                row = self._continue_row(row, indent)
 
     def _split(self, data):
         index = min(self._get_possible_split_indices(data))
@@ -104,10 +102,11 @@ class RowSplitter(object):
             row = row[:-1] + [self._empty_cell_escape]
         return row
 
-    def _continue_row(self, row, indent, is_comment = False):
-        row = [self._line_continuation] + row
-        if is_comment:
-            row = [self._comment_mark] + row
+    def _continue_row(self, row, indent):
+        if row and row[0][0] == self._comment_mark:
+            row = [self._comment_mark, self._line_continuation] + [row[0][1:]] + row[1:]
+        else:
+            row = [self._line_continuation] + row
         if indent + 1 < self._cols:
             row = [''] * indent + row
         return row

--- a/src/robot/writer/rowsplitter.py
+++ b/src/robot/writer/rowsplitter.py
@@ -75,7 +75,6 @@ class RowSplitter(object):
             current, row = self._split(row)
             yield self._escape_last_cell_if_empty(current)
             if row:
-                print(row)
                 row = self._continue_row(row, indent)
 
     def _split(self, data):


### PR DESCRIPTION
Say you have a really long comment:
`# very very very long comment`
Before this fix, writer would split lines of comments in the following way:
```
# very very very
... # long comment
```
This adds unneeded line continuations and breaks tests. After the fix it looks like this:
```
# very very very
# ... long comment
```