### PR TITLE
Fix keyword remover usage error

### DIFF
--- a/atest/robot/cli/rebot/invalid_usage.robot
+++ b/atest/robot/cli/rebot/invalid_usage.robot
@@ -43,7 +43,7 @@ Invalid --TagStatLink
     ...    --tagstatlink a:b:c --TagStatLink less_than_3x_:
 
 Invalid --RemoveKeywords
-    Invalid value for option '--removekeywords'. Expected 'ALL', 'PASSED', 'NAME:<pattern>', 'FOR', or 'WUKS' but got 'Invalid'.
+    Invalid value for option '--removekeywords'. Expected 'ALL', 'PASSED', 'NAME:<pattern>', 'TAG:<pattern>', 'FOR', or 'WUKS' but got 'Invalid'.
     ...    --removekeywords wuks --removek name:xxx --RemoveKeywords Invalid
 
 *** Keywords ***

--- a/atest/robot/cli/runner/invalid_usage.robot
+++ b/atest/robot/cli/runner/invalid_usage.robot
@@ -31,4 +31,4 @@ Invalid --TagStatLink
 
 Invalid --RemoveKeywords
     --removekeywords wuks --removek name:xxx --RemoveKeywords Invalid tests.txt
-    ...    Invalid value for option '--removekeywords'. Expected 'ALL', 'PASSED', 'NAME:<pattern>', 'FOR', or 'WUKS' but got 'Invalid'.
+    ...    Invalid value for option '--removekeywords'. Expected 'ALL', 'PASSED', 'NAME:<pattern>', 'TAG:<pattern>', 'FOR', or 'WUKS' but got 'Invalid'.

--- a/src/robot/result/keywordremover.py
+++ b/src/robot/result/keywordremover.py
@@ -30,8 +30,8 @@ def KeywordRemover(how):
                 'FOR': ForLoopItemsRemover,
                 'WUKS': WaitUntilKeywordSucceedsRemover}[upper]()
     except KeyError:
-        raise DataError("Expected 'ALL', 'PASSED', 'NAME:<pattern>', 'FOR', "
-                        "or 'WUKS' but got '%s'." % how)
+        raise DataError("Expected 'ALL', 'PASSED', 'NAME:<pattern>', 'TAG:<pattern>', "
+                        "'FOR', or 'WUKS' but got '%s'." % how)
 
 
 class _KeywordRemover(SuiteVisitor):


### PR DESCRIPTION
The `--removekeywords` option supports tags, but this isn't reflected in the error message if used incorrectly:

> [ERROR ] Invalid value for option '--removekeywords'. Expected 'ALL', 'PASSED', 'NAME:<pattern>', 'FOR', or 'WUKS' but got 'TAGS:not_ready'.

This PR simply adds `'TAG:<pattern>'` to the error message.