### PR TITLE
Fix when using typing check, keyword is not found

### DIFF
--- a/src/robot/running/arguments/argumentparser.py
+++ b/src/robot/running/arguments/argumentparser.py
@@ -40,13 +40,14 @@ class _ArgumentParser(object):
 class PythonArgumentParser(_ArgumentParser):
 
     def _get_arg_spec(self, handler):
-        args_tuple = inspect.getfullargspec(handler)
+        if sys.version_info[0] == 2:
+            args, varargs, kwargs, defaults = inspect.getargspec(handler)
+        elif sys.version_info[0] == 3:
+            args, varargs, varkw, defaults, _, _, _ = inspect.getfullargspec(handler)
         if inspect.ismethod(handler) or handler.__name__ == '__init__':
-            args = args_tuple.args[1:]  # drop 'self'
-        else:
-            args = args_tuple.args
-        defaults = list(args_tuple.defaults) if args_tuple.defaults else []
-        return args, defaults, args_tuple.varargs, args_tuple.varkw
+            args = args[1:]  # drop 'self'
+        defaults = list(defaults) if defaults else []
+        return args, defaults, varargs, varkw
 
 
 class JavaArgumentParser(_ArgumentParser):

--- a/src/robot/running/arguments/argumentparser.py
+++ b/src/robot/running/arguments/argumentparser.py
@@ -42,7 +42,8 @@ class PythonArgumentParser(_ArgumentParser):
     def _get_arg_spec(self, handler):
         if sys.version_info[0] == 2:
             args, varargs, kwargs, defaults = inspect.getargspec(handler)
-        elif sys.version_info[0] == 3:
+            varkw = kwargs
+        else:
             args, varargs, varkw, defaults, _, _, _ = inspect.getfullargspec(handler)
         if inspect.ismethod(handler) or handler.__name__ == '__init__':
             args = args[1:]  # drop 'self'

--- a/src/robot/running/arguments/argumentparser.py
+++ b/src/robot/running/arguments/argumentparser.py
@@ -21,8 +21,8 @@ if sys.platform.startswith('java'):
 
 from robot.errors import DataError
 from robot.variables import is_dict_var, is_list_var, is_scalar_var
-
 from .argumentspec import ArgumentSpec
+from robot.utils import PY2
 
 
 class _ArgumentParser(object):
@@ -40,15 +40,14 @@ class _ArgumentParser(object):
 class PythonArgumentParser(_ArgumentParser):
 
     def _get_arg_spec(self, handler):
-        if sys.version_info[0] == 2:
+        if PY2:
             args, varargs, kwargs, defaults = inspect.getargspec(handler)
-            varkw = kwargs
         else:
-            args, varargs, varkw, defaults, _, _, _ = inspect.getfullargspec(handler)
+            args, varargs, kwargs, defaults, _, _, _ = inspect.getfullargspec(handler)
         if inspect.ismethod(handler) or handler.__name__ == '__init__':
             args = args[1:]  # drop 'self'
         defaults = list(defaults) if defaults else []
-        return args, defaults, varargs, varkw
+        return args, defaults, varargs, kwargs
 
 
 class JavaArgumentParser(_ArgumentParser):

--- a/src/robot/running/arguments/argumentparser.py
+++ b/src/robot/running/arguments/argumentparser.py
@@ -40,11 +40,13 @@ class _ArgumentParser(object):
 class PythonArgumentParser(_ArgumentParser):
 
     def _get_arg_spec(self, handler):
-        args, varargs, kwargs, defaults = inspect.getargspec(handler)
+        args_tuple = inspect.getfullargspec(handler)
         if inspect.ismethod(handler) or handler.__name__ == '__init__':
-            args = args[1:]  # drop 'self'
-        defaults = list(defaults) if defaults else []
-        return args, defaults, varargs, kwargs
+            args = args_tuple.args[1:]  # drop 'self'
+        else:
+            args = args_tuple.args
+        defaults = list(args_tuple.defaults) if args_tuple.defaults else []
+        return args, defaults, args_tuple.varargs, args_tuple.varkw
 
 
 class JavaArgumentParser(_ArgumentParser):


### PR DESCRIPTION
For Python 3, when I use typing check, Robot Framework always shows me "no keyword with name" error. I found it should be the deprecated method "inspect.getargspec" used in argumentparser.py.

So I put some new code with "inspect.getfullargspec", everything works fine for me now.

This change should be compatible between Python 2 and 3.
Typing hint refer: https://docs.python.org/3.6/library/typing.html
Inspect refer: https://docs.python.org/3.6/library/inspect.html#inspect.getfullargspec