### PR TITLE
default_tags and force_tags attributes in TestSuite object

### DIFF
--- a/src/robot/model/testsuite.py
+++ b/src/robot/model/testsuite.py
@@ -45,6 +45,24 @@ class TestSuite(ModelObject):
         self.tests = None
         self.keywords = None
         self._my_visitors = []
+        self.default_tags = None
+        self.force_tags = None
+
+    @property
+    def default_tags(self):
+        return self.default_tags
+
+    @setter
+    def default_tags(self, default_tags):
+        return default_tags
+		
+    @property
+    def force_tags(self):
+        return self.force_tags
+
+    @setter
+    def force_tags(self, force_tags):
+        return force_tags
 
     @property
     def _visitors(self):

--- a/src/robot/running/builder.py
+++ b/src/robot/running/builder.py
@@ -93,6 +93,8 @@ class TestSuiteBuilder(object):
                           source=data.source,
                           doc=unic(data.setting_table.doc),
                           metadata=self._get_metadata(data.setting_table))
+        suite.default_tags = data.setting_table.default_tags
+        suite.force_tags = data.setting_table.force_tags
         self._build_setup(suite, data.setting_table.suite_setup)
         self._build_teardown(suite, data.setting_table.suite_teardown)
         for test_data in data.testcase_table.tests:


### PR DESCRIPTION
I want to filter and analyze a suite, and I use TestSuiteBuilder.
After I build it, I have to print the suites with tag informations, but the TestSuite object has no such attributes.
The new attributes filled when TestSuiteBuilder build called.