### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: python
+python:
+  - "2.7"
+  - "3.5"
+  - "3.6"
+  - "pypy"
+  - "pypy3"
+env:
+  - PYTHON_EXE=python
+matrix:
+  include:
+  - python: "2.7"
+    sudo: required
+    env: PYTHON_EXE=jython
+    addons:
+      apt:
+        packages:
+          - jython
+install:
+  - pip install .
+  - pip install invoke -r atest/requirements.txt
+script:
+  - $PYTHON_EXE utest/run.py
+  - if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ];
+    then atest/run.py "$PYTHON_EXE" --exclude no-ciORrequire-screenshot atest/robot;
+    else echo "We only run atest from the py2.7 part of the build matrix."; fi


### PR DESCRIPTION
# Summary
Add travis unit testing for python versions and acceptance testing for py2.7. [Successful](https://travis-ci.org/Brian-Williams/robotframework/builds/274342159) build on fork.

### pypi and jython addition problems
Also additional unit tests could be added like shown in [this branch](https://github.com/Brian-Williams/robotframework/blob/add-more-ci/.travis.yml), however there are currently pypy and jython unit test [errors](https://travis-ci.org/Brian-Williams/robotframework/builds/274468773) the pypy appears to be an actual failure with OrderedDicts, however I don't know much about jython.

We need a before_install script to correctly install jython.

### Configuration suggestion
Because a github pages branch exists. 'Build only if .travis.yml is present' should be turned on.