### PR TITLE
Drop support for Python 2.6

### DIFF
--- a/atest/interpreter.py
+++ b/atest/interpreter.py
@@ -45,11 +45,6 @@ class Interpreter(object):
 
     @property
     def excludes(self):
-        if self.is_python and self.version == '2.6':
-            yield 'no-python26'
-            yield 'require-et13'
-        else:
-            yield 'require-python26'
         if self.is_jython:
             yield 'no-jython'
             yield 'require-lxml'
@@ -75,8 +70,6 @@ class Interpreter(object):
             yield 'no-windows'
             if self.is_jython:
                 yield 'no-windows-jython'
-            if self.is_python and self.version == '2.6':
-                yield 'no-windows-python26'
         if not self.is_windows:
             yield 'require-windows'
         if self.is_osx:

--- a/atest/robot/standard_libraries/builtin/should_be_equal.robot
+++ b/atest/robot/standard_libraries/builtin/should_be_equal.robot
@@ -20,7 +20,6 @@ Should Be Equal fails without values
     Check test case    ${TESTNAME}
 
 Should Be Equal with multiline text uses diff
-    [Tags]    no-python26    # diff contains extra spaces on python 2.6
     Check test case    ${TESTNAME}
 
 Should Be Equal with multiline diff text requires both multiline

--- a/atest/robot/standard_libraries/builtin/should_be_equal_as_xxx.robot
+++ b/atest/robot/standard_libraries/builtin/should_be_equal_as_xxx.robot
@@ -39,7 +39,6 @@ Should Be Equal As Strings case-insensitive
     Check test case    ${TESTNAME}
 
 Should Be Equal As Strings multiline
-    [Tags]    no-python26    # diff contains extra spaces on python 2.6
     Check test case    ${TESTNAME}
 
 Should Not Be Equal As Strings

--- a/atest/robot/standard_libraries/process/terminate_process.robot
+++ b/atest/robot/standard_libraries/process/terminate_process.robot
@@ -14,7 +14,7 @@ Kill process
     Check Log Message    ${tc.kws[1].msgs[1]}    Process completed.
 
 Terminate process running on shell
-    [Tags]    no-windows-python26   no-jython
+    [Tags]    no-jython
     Check Test Case    ${TESTNAME}
 
 Kill process running on shell
@@ -22,7 +22,7 @@ Kill process running on shell
     Check Test Case    ${TESTNAME}
 
 Also child processes are terminated
-    [Tags]    no-windows-python26   no-jython
+    [Tags]    no-jython
     Check Test Case    ${TESTNAME}
 
 Also child processes are killed
@@ -30,7 +30,7 @@ Also child processes are killed
     Check Test Case    ${TESTNAME}
 
 Kill process when terminate fails
-    [Tags]    no-windows-python26    no-windows-jython
+    [Tags]    no-windows-jython
     ${tc} =    Check Test Case    ${TESTNAME}
     Check Log Message    ${tc.kws[5].msgs[0]}    Gracefully terminating process.
     Check Log Message    ${tc.kws[5].msgs[1]}    Graceful termination failed.

--- a/atest/robot/standard_libraries/xml/xpath.robot
+++ b/atest/robot/standard_libraries/xml/xpath.robot
@@ -53,17 +53,7 @@ Non-ASCII tag names
     Check Test Case    ${TESTNAME}
 
 More complex non-ASCII xpath
-    [Tags]    no-python26
     Check Test Case    ${TESTNAME}
-
-Warning when using more complex non-ASCII xpath with interpreter < 2.7
-    [Tags]    require-python26
-    ${tc}=    Get Test Case    More complex non-ASCII xpath
-    ${msg}=    Catenate
-    ...    XPATHs containing non-ASCII characters and other than tag names
-    ...    do not always work with Python versions prior to 2.7.
-    ...    Verify results manually and consider upgrading to 2.7.
-    Check Log Message    ${tc.kws[0].kws[0].msgs[0]}    ${msg}    WARN
 
 Evaluate xpath does not work
     Check Test Case    ${TESTNAME}

--- a/atest/run.py
+++ b/atest/run.py
@@ -12,7 +12,7 @@ See its help (e.g. `robot --help`) for more information.
 The specified interpreter is used by acceptance tests under `atest/robot` to
 run test cases under `atest/testdata`. It can be the name of the interpreter
 like (e.g. `python` or `jython`, a path to the selected interpreter like
-`/usr/bin/python26`, or a path to the standalone jar distribution (e.g.
+`/usr/bin/python36`, or a path to the standalone jar distribution (e.g.
 `dist/robotframework-2.9dev234.jar`). If the interpreter itself needs
 arguments, the interpreter and arguments need to be quoted like `"py -3"`.
 

--- a/atest/testdata/standard_libraries/builtin/variables_to_verify.py
+++ b/atest/testdata/standard_libraries/builtin/variables_to_verify.py
@@ -1,7 +1,5 @@
 import os
-
 from collections import OrderedDict
-
 
 if os.name == 'java':
     from java.lang import String

--- a/atest/testdata/standard_libraries/builtin/variables_to_verify.py
+++ b/atest/testdata/standard_libraries/builtin/variables_to_verify.py
@@ -1,6 +1,6 @@
 import os
 
-from robot.utils import OrderedDict
+from collections import OrderedDict
 
 
 if os.name == 'java':

--- a/atest/testdata/standard_libraries/collections/dictionary.robot
+++ b/atest/testdata/standard_libraries/collections/dictionary.robot
@@ -118,7 +118,7 @@ Dictionaries Should Be Equal
     Dictionaries Should Be Equal    ${BIG}    ${BIG}
 
 Dictionaries Of Different Type Should Be Equal
-    ${big2}=    Evaluate    collections.OrderedDict($BIG)    modules=robot
+    ${big2}=    Evaluate    collections.OrderedDict($BIG)    modules=collections
     Dictionaries Should Be Equal    ${BIG}    ${big2}
 
 Dictionaries Should Equal With First Dictionary Missing Keys

--- a/atest/testdata/standard_libraries/collections/dictionary.robot
+++ b/atest/testdata/standard_libraries/collections/dictionary.robot
@@ -118,7 +118,7 @@ Dictionaries Should Be Equal
     Dictionaries Should Be Equal    ${BIG}    ${BIG}
 
 Dictionaries Of Different Type Should Be Equal
-    ${big2}=    Evaluate    robot.utils.OrderedDict($BIG)    modules=robot
+    ${big2}=    Evaluate    collections.OrderedDict($BIG)    modules=robot
     Dictionaries Should Be Equal    ${BIG}    ${big2}
 
 Dictionaries Should Equal With First Dictionary Missing Keys
@@ -212,7 +212,7 @@ Log Dictionary With Different Log Levels
 Log Dictionary With Different Dictionaries
     Log Dictionary    ${D0}
     Log Dictionary    ${D1}
-    ${dict} =    Evaluate    robot.utils.OrderedDict(((True, 'xxx'), ('foo', []), ((1, 2, 3), 3.14)))   modules=robot
+    ${dict} =    Evaluate    collections.OrderedDict(((True, 'xxx'), ('foo', []), ((1, 2, 3), 3.14)))   modules=robot
     Log Dictionary    ${dict}
 
 Pop From Dictionary Without Default

--- a/atest/testdata/standard_libraries/collections/dictionary.robot
+++ b/atest/testdata/standard_libraries/collections/dictionary.robot
@@ -212,7 +212,7 @@ Log Dictionary With Different Log Levels
 Log Dictionary With Different Dictionaries
     Log Dictionary    ${D0}
     Log Dictionary    ${D1}
-    ${dict} =    Evaluate    collections.OrderedDict(((True, 'xxx'), ('foo', []), ((1, 2, 3), 3.14)))   modules=robot
+    ${dict} =    Evaluate    collections.OrderedDict(((True, 'xxx'), ('foo', []), ((1, 2, 3), 3.14)))   modules=collections
     Log Dictionary    ${dict}
 
 Pop From Dictionary Without Default

--- a/atest/testdata/variables/list_and_dict_variable_file.py
+++ b/atest/testdata/variables/list_and_dict_variable_file.py
@@ -1,4 +1,4 @@
-from robot.utils import OrderedDict
+from collections import OrderedDict
 
 
 def get_variables(*args):

--- a/atest/testdata/variables/return_values.robot
+++ b/atest/testdata/variables/return_values.robot
@@ -92,7 +92,7 @@ List Variable From Dictionary
     Should Be Equal    @{list}    name
     Should Be True    ${list} == ['name']
     @{list} =    Create Dictionary    a=1    b=2    c=3
-    Should Be True    set(${list}) == set(['a', 'b', 'c'])
+    Should Be True    set(${list}) == {'a', 'b', 'c'}
 
 Unrepresentable objects to list variables
     @{unrepr} =    Return Unrepresentable Objects    identifier=list

--- a/src/robot/libraries/Remote.py
+++ b/src/robot/libraries/Remote.py
@@ -262,22 +262,6 @@ class TimeoutTransport(xmlrpclib.Transport):
         return self._connection[1]
 
 
-if sys.version_info[:2] == (2, 6):
-
-    class TimeoutTransport(TimeoutTransport):
-
-        def make_connection(self, host):
-            host, extra_headers, x509 = self.get_host_info(host)
-            return TimeoutHTTP(host, timeout=self.timeout)
-
-    class TimeoutHTTP(httplib.HTTP):
-
-        def __init__(self, host='', port=None, strict=None, timeout=None):
-            if port == 0:
-                port = None
-            self._setup(self._connection_class(host, port, strict, timeout=timeout))
-
-
 if IRONPYTHON:
 
     class TimeoutTransport(xmlrpclib.Transport):

--- a/src/robot/reporting/jsexecutionresult.py
+++ b/src/robot/reporting/jsexecutionresult.py
@@ -16,8 +16,8 @@
 import sys
 import time
 
-from robot.utils import OrderedDict, IRONPYTHON
-
+from collections import OrderedDict
+from robot.utils import IRONPYTHON
 from .stringcache import StringIndex
 
 

--- a/src/robot/reporting/jsexecutionresult.py
+++ b/src/robot/reporting/jsexecutionresult.py
@@ -15,11 +15,11 @@
 
 import sys
 import time
-
 from collections import OrderedDict
-from robot.utils import IRONPYTHON
-from .stringcache import StringIndex
 
+from robot.utils import IRONPYTHON
+
+from .stringcache import StringIndex
 
 # http://ironpython.codeplex.com/workitem/31549
 if IRONPYTHON and sys.version_info < (2, 7, 2):

--- a/src/robot/reporting/stringcache.py
+++ b/src/robot/reporting/stringcache.py
@@ -13,7 +13,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from robot.utils import OrderedDict, compress_text
+from robot.utils import compress_text
+from collections import OrderedDict
 
 
 class StringIndex(int):

--- a/src/robot/reporting/stringcache.py
+++ b/src/robot/reporting/stringcache.py
@@ -13,8 +13,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from robot.utils import compress_text
 from collections import OrderedDict
+
+from robot.utils import compress_text
 
 
 class StringIndex(int):

--- a/src/robot/running/namespace.py
+++ b/src/robot/running/namespace.py
@@ -13,24 +13,22 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import os
 import copy
+import os
+from collections import OrderedDict
 from itertools import chain
 
 from robot.errors import DataError, KeywordError
 from robot.libraries import STDLIBS
 from robot.output import LOGGER, Message
-from robot.parsing.settings import Library, Variables, Resource
-from robot.utils import (eq, find_file, is_string, printable_name,
-                         seq2str2, RecommendationFinder)
+from robot.parsing.settings import Library, Resource, Variables
+from robot.utils import (RecommendationFinder, eq, find_file, is_string,
+                         printable_name, seq2str2)
 
+from .importer import ImportCache, Importer
+from .runkwregister import RUN_KW_REGISTER
 from .usererrorhandler import UserErrorHandler
 from .userkeyword import UserLibrary
-from .importer import Importer, ImportCache
-from .runkwregister import RUN_KW_REGISTER
-
-from collections import OrderedDict
-
 
 IMPORTER = Importer()
 

--- a/src/robot/running/namespace.py
+++ b/src/robot/running/namespace.py
@@ -21,13 +21,15 @@ from robot.errors import DataError, KeywordError
 from robot.libraries import STDLIBS
 from robot.output import LOGGER, Message
 from robot.parsing.settings import Library, Variables, Resource
-from robot.utils import (eq, find_file, is_string, OrderedDict, printable_name,
+from robot.utils import (eq, find_file, is_string, printable_name,
                          seq2str2, RecommendationFinder)
 
 from .usererrorhandler import UserErrorHandler
 from .userkeyword import UserLibrary
 from .importer import Importer, ImportCache
 from .runkwregister import RUN_KW_REGISTER
+
+from collections import OrderedDict
 
 
 IMPORTER = Importer()

--- a/src/robot/utils/__init__.py
+++ b/src/robot/utils/__init__.py
@@ -38,7 +38,7 @@ from .application import Application
 from .compat import isatty, py2to3, StringIO, with_metaclass
 from .compress import compress_text
 from .connectioncache import ConnectionCache
-from .dotdict import DotDict, OrderedDict
+from .dotdict import DotDict
 from .encoding import (console_decode, console_encode,
                        system_decode, system_encode, CONSOLE_ENCODING,
                        SYSTEM_ENCODING)
@@ -74,3 +74,4 @@ from .text import (cut_long_message, format_assign_message,
                    split_args_from_name_or_path)
 from .unic import prepr, unic
 from .utf8reader import Utf8Reader
+from collections import OrderedDict

--- a/src/robot/utils/__init__.py
+++ b/src/robot/utils/__init__.py
@@ -74,4 +74,3 @@ from .text import (cut_long_message, format_assign_message,
                    split_args_from_name_or_path)
 from .unic import prepr, unic
 from .utf8reader import Utf8Reader
-from collections import OrderedDict

--- a/src/robot/utils/robotpath.py
+++ b/src/robot/utils/robotpath.py
@@ -83,7 +83,7 @@ def abspath(path, case_normalize=False):
     3. Turn ``c:`` into ``c:\\`` on Windows instead of ``c:\\current\\path``.
     """
     path = normpath(path, case_normalize)
-    return normpath(_abspath(path), case_normalize)
+    return normpath(os.path.abspath(path), case_normalize)
 
 
 def get_link_path(target, base):

--- a/src/robot/utils/robotpath.py
+++ b/src/robot/utils/robotpath.py
@@ -83,7 +83,7 @@ def abspath(path, case_normalize=False):
     3. Turn ``c:`` into ``c:\\`` on Windows instead of ``c:\\current\\path``.
     """
     path = normpath(path, case_normalize)
-    return normpath(os.path.abspath(path), case_normalize)
+    return normpath(_abspath(path), case_normalize)
 
 
 def get_link_path(target, base):

--- a/utest/utils/test_compat.py
+++ b/utest/utils/test_compat.py
@@ -22,12 +22,8 @@ class TestIsATty(unittest.TestCase):
     def test_with_detached_io_buffer(self):
         with io.StringIO() as stream:
             wrapper = io.TextIOWrapper(stream, 'UTF-8')
-            if sys.version_info >= (2, 7):
-                wrapper.detach()
-                exc_type = ValueError if PYTHON else AttributeError
-            else:
-                wrapper.buffer = None
-                exc_type = AttributeError
+            wrapper.detach()
+            exc_type = ValueError if PYTHON else AttributeError
             assert_raises(exc_type, wrapper.isatty)
             assert_false(isatty(wrapper))
 

--- a/utest/utils/test_dotdict.py
+++ b/utest/utils/test_dotdict.py
@@ -1,9 +1,10 @@
 import unittest
+from collections import OrderedDict
 
+from robot.utils import IRONPYTHON, DotDict
 from robot.utils.asserts import (assert_equal, assert_false, assert_not_equal,
                                  assert_raises, assert_true)
-from robot.utils import DotDict, IRONPYTHON
-from collections import OrderedDict
+
 
 class TestDotDict(unittest.TestCase):
 

--- a/utest/utils/test_dotdict.py
+++ b/utest/utils/test_dotdict.py
@@ -2,8 +2,8 @@ import unittest
 
 from robot.utils.asserts import (assert_equal, assert_false, assert_not_equal,
                                  assert_raises, assert_true)
-from robot.utils import DotDict, OrderedDict, IRONPYTHON
-
+from robot.utils import DotDict, IRONPYTHON
+from collections import OrderedDict
 
 class TestDotDict(unittest.TestCase):
 


### PR DESCRIPTION
Resolves https://github.com/robotframework/robotframework/issues/2276.

Here's another branch with added Travis CI testing (thanks to @Brian-Williams for https://github.com/robotframework/robotframework/pull/2676!):

https://travis-ci.org/hugovk/robotframework/builds/287879614

Python 2.7, 3.3, 3.4, 3.5, 3.6, PyPy3 all pass. PyPy and Jython fail, but they do on latest master as well:

https://travis-ci.org/hugovk/robotframework/builds/287879614