### PR TITLE
New keyword in buildin lib: Repeat keyword and ignore errors

### DIFF
--- a/atest/robot/standard_libraries/builtin/repeat_keyword.robot
+++ b/atest/robot/standard_libraries/builtin/repeat_keyword.robot
@@ -73,6 +73,12 @@ Repeat Keyword With Pass Execution After Continuable Failure
 Repeat Keyword And Ignore Errors
     ${tc} =    Check Test Case    ${TESTNAME}
 
+Repeat Keyword And Ignore Failure With Pass Execution
+    ${tc} =    Check Test Case    ${TESTNAME}
+
+Repeat Keyword And Ignore Failure On Third Round
+    ${tc} =    Check Test Case    ${TESTNAME}
+
 *** Keywords ***
 Check Repeated Messages
     [Arguments]    ${kw}    ${count}    ${msg}=${None}

--- a/atest/robot/standard_libraries/builtin/repeat_keyword.robot
+++ b/atest/robot/standard_libraries/builtin/repeat_keyword.robot
@@ -70,6 +70,9 @@ Repeat Keyword With Pass Execution After Continuable Failure
     ${tc} =    Check Test Case    ${TEST_NAME}
     Length Should Be    ${tc.kws[0].kws}    2
 
+Repeat Keyword And Ignore Errors
+    ${tc} =    Check Test Case    ${TESTNAME}
+
 *** Keywords ***
 Check Repeated Messages
     [Arguments]    ${kw}    ${count}    ${msg}=${None}

--- a/atest/testdata/standard_libraries/builtin/repeat_keyword.robot
+++ b/atest/testdata/standard_libraries/builtin/repeat_keyword.robot
@@ -80,6 +80,10 @@ Repeat Keyword With Pass Execution After Continuable Failure
     [Documentation]    FAIL Continuable
     Repeat Keyword    3x    First Continuable Failure And Then Pass Execution
 
+Repeat Keyword And Ignore Errors
+    [Documentation]  FAIL  3 tests out of 3 tests failed.
+    Repeat Keyword And Ignore Errors  3x  Fail
+
 *** Keywords ***
 Keyword Failing On Third Run
     ${COUNT} =    Evaluate    ${COUNT} + 1

--- a/atest/testdata/standard_libraries/builtin/repeat_keyword.robot
+++ b/atest/testdata/standard_libraries/builtin/repeat_keyword.robot
@@ -81,7 +81,7 @@ Repeat Keyword With Pass Execution After Continuable Failure
     Repeat Keyword    3x    First Continuable Failure And Then Pass Execution
 
 Repeat Keyword And Ignore Errors
-    [Documentation]  FAIL  3 tests out of 3 tests failed.
+    [Documentation]  FAIL  3 out of 3 executions failed.
     Repeat Keyword And Ignore Errors  3x  Fail
 
 Repeat Keyword And Ignore Failure With Pass Execution
@@ -89,7 +89,7 @@ Repeat Keyword And Ignore Failure With Pass Execution
     Repeat Keyword And Ignore Errors    3x    Log    Message
 
 Repeat Keyword And Ignore Failure On Third Round
-    [Documentation]    FAIL 998 tests out of 1000 tests failed.
+    [Documentation]    FAIL 998 out of 1000 executions failed.
     Set Suite Variable    ${COUNT}  0
     Repeat Keyword And Ignore Errors    1000 times    Keyword Failing On Third Run
 

--- a/atest/testdata/standard_libraries/builtin/repeat_keyword.robot
+++ b/atest/testdata/standard_libraries/builtin/repeat_keyword.robot
@@ -84,6 +84,15 @@ Repeat Keyword And Ignore Errors
     [Documentation]  FAIL  3 tests out of 3 tests failed.
     Repeat Keyword And Ignore Errors  3x  Fail
 
+Repeat Keyword And Ignore Failure With Pass Execution
+    [Documentation]    PASS
+    Repeat Keyword And Ignore Errors    3x    Log    Message
+
+Repeat Keyword And Ignore Failure On Third Round
+    [Documentation]    FAIL 998 tests out of 1000 tests failed.
+    Set Suite Variable    ${COUNT}  0
+    Repeat Keyword And Ignore Errors    1000 times    Keyword Failing On Third Run
+
 *** Keywords ***
 Keyword Failing On Third Run
     ${COUNT} =    Evaluate    ${COUNT} + 1

--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -1901,7 +1901,7 @@ class _RunKeyword(_BuiltInBase):
 
         Specifying ``repeat`` as a timeout is new in Robot Framework 3.0.
         """
-        _, keywords = self._repeat_keyword(repeat, name, *args)
+        keywords, _ = self._get_keywords_and_repeat_count(repeat, name, *args)
         self._run_keywords(keywords)
 
     @run_keyword_variant(resolve=2)
@@ -1921,7 +1921,7 @@ class _RunKeyword(_BuiltInBase):
         | Repeat Keyword And Ignore Errors | ${var}    | Some Keyword | arg1 | arg2 |
         | Repeat Keyword And Ignore Errors | 2 minutes | Some Keyword | arg1 | arg2 |
         """
-        repeat_count, keywords = self._repeat_keyword(repeat, name, *args)
+        keywords, repeat_count = self._get_keywords_and_repeat_count(repeat, name, *args)
         passing, failures_count = True, 0
         for kw, args in keywords:
             status, _ = self.run_keyword_and_ignore_error(kw, *args)
@@ -1929,9 +1929,9 @@ class _RunKeyword(_BuiltInBase):
                 failures_count += 1
                 passing = False
         if not passing:
-            raise AssertionError("%d tests out of %d tests failed." % (failures_count, repeat_count))
+            raise AssertionError("%d out of %d executions failed." % (failures_count, repeat_count))
 
-    def _repeat_keyword(self, repeat, name, *args):
+    def _get_keywords_and_repeat_count(self, repeat, name, *args):
         count = 0
         try:
             count = self._get_repeat_count(repeat)
@@ -1942,7 +1942,7 @@ class _RunKeyword(_BuiltInBase):
             keywords = self._keywords_repeated_by_timeout(timeout, name, args)
         else:
             keywords = self._keywords_repeated_by_count(count, name, args)
-        return count, keywords
+        return keywords, count
 
     def _get_repeat_count(self, times, require_postfix=False):
         times = normalize(str(times))


### PR DESCRIPTION
Provided pull request for issue #2633 . @PWojtal let me know if this is the expected behavior.