### PR TITLE
Allow arguments to display in libdoc HTML documentation

### DIFF
--- a/src/robot/running/handlers.py
+++ b/src/robot/running/handlers.py
@@ -251,7 +251,7 @@ class _JavaInitHandler(_JavaHandler):
 class EmbeddedArgumentsHandler(object):
 
     def __init__(self, name_regexp, orig_handler):
-        self.arguments = ArgumentSpec()  # Show empty argument spec for Libdoc
+        self.arguments = orig_handler.arguments or ArgumentSpec()  # Show empty argument spec for Libdoc
         self._orig_handler = orig_handler
         self.name_regexp = name_regexp
 


### PR DESCRIPTION
Solves issue #2715 

![screen shot 2017-11-15 at 2 28 45 pm](https://user-images.githubusercontent.com/6739247/32855979-6ee8ed0a-ca11-11e7-9cae-6c8a4024018c.png)
