### PR TITLE
Documentation fix: add forgotten extension .robot

### DIFF
--- a/doc/userguide/src/CreatingTestData/CreatingTestSuites.rst
+++ b/doc/userguide/src/CreatingTestData/CreatingTestSuites.rst
@@ -55,7 +55,7 @@ contains are processed recursively as follows:
 - Directories with the name :file:`CVS` are ignored (case-sensitive).
 - Files not having one of the `recognized extensions`__ (:file:`.html`,
   :file:`.xhtml`, :file:`.htm`, :file:`.tsv`, :file:`.txt`, :file:`.rst`,
-  or :file:`.rest`) are ignored (case-insensitive).
+  :file:`.rest` or :file:`.robot`) are ignored (case-insensitive).
 - Other files and directories are processed.
 
 If a file or directory that is processed does not contain any test


### PR DESCRIPTION
There is the list in the section "Test suite directories" has the list of ignored extensions. Although there is a link in the sentence with the actual list of supported extensions, I think it makes sense to keep the list up-to-date anywhere in the documentation.