### PR TITLE
Fix a warning message of keyword  'Take Screenshot' when using wxPython 4

### DIFF
--- a/src/robot/libraries/Screenshot.py
+++ b/src/robot/libraries/Screenshot.py
@@ -346,7 +346,10 @@ class ScreenshotTaker(object):
             self._wx_app_reference = wx.App(False)
         context = wx.ScreenDC()
         width, height = context.GetSize()
-        bitmap = wx.Bitmap(width, height, -1)
+        if wx.__version__ >= '4':
+            bitmap = wx.Bitmap(width, height, -1)
+        else:
+            bitmap = wx.EmptyBitmap(width, height, -1)
         memory = wx.MemoryDC()
         memory.SelectObject(bitmap)
         memory.Blit(0, 0, width, height, context, -1, -1)

--- a/src/robot/libraries/Screenshot.py
+++ b/src/robot/libraries/Screenshot.py
@@ -346,7 +346,7 @@ class ScreenshotTaker(object):
             self._wx_app_reference = wx.App(False)
         context = wx.ScreenDC()
         width, height = context.GetSize()
-        bitmap = wx.EmptyBitmap(width, height, -1)
+        bitmap = wx.Bitmap(width, height, -1)
         memory = wx.MemoryDC()
         memory.SelectObject(bitmap)
         memory.Blit(0, 0, width, height, context, -1, -1)


### PR DESCRIPTION
Use :class:`wx.Bitmap` instead of `wx.EmptyBitmap` due to a warning message below in execution:

wxPyDeprecationWarning: Call to deprecated item EmptyBitmap. Use :class:`wx.Bitmap` instead
  bitmap = wx.EmptyBitmap(width, height, -1)

The version of wxPython 4.0.0b2 (the latest one).