### PR TITLE
Added Run Keyword With Maximum Time keyword in BuiltIn library

### DIFF
--- a/atest/robot/standard_libraries/builtin/run_keyword_with_maximum_time.robot
+++ b/atest/robot/standard_libraries/builtin/run_keyword_with_maximum_time.robot
@@ -1,0 +1,34 @@
+*** Settings ***
+Suite Setup       Run Tests    ${EMPTY}    standard_libraries/builtin/run_keyword_with_maximum_time.robot
+Resource          atest_resource.robot
+
+*** Test Cases ***
+Run Keyword With Maximum Time Failing On Library Keyword
+    Check Test Case    ${TESTNAME}
+
+Run Keyword With Maximum Time Passing On Library Keyword
+    Check Test Case    ${TESTNAME}
+
+Run Keyword With Maximum Time Failing On User Defined Keyword
+    Check Test Case    ${TESTNAME}
+
+Run Keyword With Maximum Time Passing On User Defined Keyword
+    Check Test Case    ${TESTNAME}
+
+Run Keyword With Maximum Time With Failing On Customizable Timeout Keyword
+    Check Test Case    ${TESTNAME}
+
+Run Keyword With Maximum Time With Passing On Customizable Timeout Keyword
+    Check Test Case    ${TESTNAME}
+
+Run Keyword With Maximum Time Failing in Setup
+    Check Test Case    ${TESTNAME}
+
+Run Keyword With Maximum Time Passing in Setup
+    Check Test Case    ${TESTNAME}
+
+Run Keyword With Maximum Time Failing in Teardown
+    Check Test Case    ${TESTNAME}
+
+Run Keyword With Maximum Time Passing in Teardown
+    Check Test Case    ${TESTNAME}

--- a/atest/testdata/standard_libraries/builtin/run_keyword_with_maximum_time.robot
+++ b/atest/testdata/standard_libraries/builtin/run_keyword_with_maximum_time.robot
@@ -1,0 +1,61 @@
+*** Test Cases ***
+Run Keyword With Maximum Time Failing On Library Keyword
+    [Documentation]    FAIL
+    ...    Keyword timeout 1 second exceeded.
+    Run Keyword With Maximum Time  1 second  Sleep  2 seconds
+
+Run Keyword With Maximum Time Passing On Library Keyword
+    Run Keyword With Maximum Time  2 seconds  Sleep  1 second
+
+Run Keyword With Maximum Time Failing On User Defined Keyword
+    [Documentation]    FAIL
+    ...    Keyword timeout 1 second exceeded.
+    Run Keyword With Maximum Time  1 second  Long Executing Keyword
+
+Run Keyword With Maximum Time Passing On User Defined Keyword
+    Run Keyword With Maximum Time  3 seconds  Long Executing Keyword
+
+Run Keyword With Maximum Time With Failing On Customizable Timeout Keyword
+    [Documentation]    FAIL
+    ...    Keyword timeout 500 milliseconds exceeded.
+    Run Keyword With Maximum Time  1 second  Keyword With Customizable Timeout  0.5 seconds
+
+Run Keyword With Maximum Time With Passing On Customizable Timeout Keyword
+    Run Keyword With Maximum Time  3 seconds  Keyword With Customizable Timeout  2.5 seconds
+
+Run Keyword With Maximum Time Failing in Setup
+    [Documentation]    FAIL
+    ...    Setup failed:
+    ...    Keyword timeout 1 second exceeded.
+    [Setup]  Run Keyword With Maximum Time  1 second  Long Executing Keyword
+    No Operation
+
+Run Keyword With Maximum Time Passing in Setup
+    [Setup]  Run Keyword With Maximum Time  3 second  Long Executing Keyword
+    No Operation
+
+Run Keyword With Maximum Time Failing in Teardown
+    [Documentation]    FAIL
+    ...    Keyword teardown failed:
+    ...    Keyword timeout 1 second exceeded.
+    Keyword With Teardown Fail
+
+Run Keyword With Maximum Time Passing in Teardown
+    Keyword With Teardown Pass
+
+*** Keywords ***
+Long Executing Keyword
+    Sleep  2
+
+Keyword With Customizable Timeout
+    [Arguments]    ${timeout}
+    [Timeout]    ${timeout}
+    Sleep  2
+
+Keyword With Teardown Fail
+    No Operation
+    [Teardown]  Run Keyword With Maximum Time  1 second  Long Executing Keyword
+
+Keyword With Teardown Pass
+    No Operation
+    [Teardown]  Run Keyword With Maximum Time  3 second  Long Executing Keyword


### PR DESCRIPTION
PR for #2376 
We had requests for something like this and implemented it as @pekkaklarck suggested: a new keyword that uses Robot's timeout logic.
If it is decided to be included in the next version of RF, I would update the User Guide also.