### PR TITLE
Introduce an option for Tidy to set the max line length (Fix #1891)

### DIFF
--- a/atest/robot/tidy/tidy_maxlinelength.robot
+++ b/atest/robot/tidy/tidy_maxlinelength.robot
@@ -1,0 +1,15 @@
+*** Settings ***
+Resource    tidy_resource.robot
+Test Setup        Create Directory     ${TEMP}
+Test Teardown     Remove Directory     ${TEMP}    recursive=True
+
+*** Test Cases ***
+Custom maxlinelength for test suite
+    [Template]    Run tidy with golden file and check result
+    -m 120 -f txt               golden_120_maxlinelength.robot
+    -m 120 -f txt --usepipes    golden_pipes_120_maxlinelength.robot
+
+Custom maxlinelength for resource
+    [Template]    Run tidy with golden resource file and check result
+    -m 120 -f txt               golden_resource_120_maxlinelength.robot
+    -m 120 -f txt --usepipes    golden_pipes_resource_120_maxlinelength.robot

--- a/atest/testdata/tidy/__init__.robot
+++ b/atest/testdata/tidy/__init__.robot
@@ -2,8 +2,8 @@
 Force Tags        tag1    tag2
 
 *** Variables ***
-MyVar             val1    val2    val3    val4    val5    val6    val6
-...               val7    val8    val9    # var comment
+MyVar             val1    val2    val3    val4    val5    val6    val6    val7
+...               val8    val9    # var comment
 
 *** Keywords ***
 unicode äö§ name

--- a/atest/testdata/tidy/else_tidy.robot
+++ b/atest/testdata/tidy/else_tidy.robot
@@ -32,21 +32,14 @@ Test Case With Line Continuation Before Expression
     ...    ELSE    No Operation
 
 Test Case With Long Internal Lines
-    Some Keyword    1    2    3    4    5    6
-    ...    7    8    9    10    11    12
-    ...    13    14    15    16    17    18
-    ...    ELSE IF    1    2    3    4    5
-    ...    6    7    8    9    10    11
-    ...    12    13    14    15    16    17
-    ...    18
-    ...    ELSE IF    1    2    3    4    5
-    ...    6    7    8    9    10    11
-    ...    12    13    14    15    16    17
-    ...    18
-    ...    ELSE    1    2    3    4    5
-    ...    6    7    8    9    10    11
-    ...    12    13    14    15    16    17
-    ...    18
+    Some Keyword    1    2    3    4    LooooooooooooooooooongArg    5    6    7
+    ...    8    9    10    11    12    13    14    15    16    17    18
+    ...    ELSE IF    1    2    3    4    LooooooooooooooooooongArg    5    6
+    ...    7    8    9    10    11    12    13    14    15    16    17    18
+    ...    ELSE IF    1    2    3    4    LooooooooooooooooooongArg    5    6
+    ...    7    8    9    10    11    12    13    14    15    16    17    18
+    ...    ELSE    1    2    3    4    LooooooooooooooooooongArg    5    6    7
+    ...    8    9    10    11    12    13    14    15    16    17    18
 
 Escaping
     Log Many    \ELSE    \ELSE IF    \AND
@@ -79,5 +72,5 @@ Keyword With Line Continuation Before Expression
 Keyword With Long Line
     Run Keyword If    expression    No Operation
     ...    ELSE IF    expression    No Operation
-    ...    ELSE    No Operation    1    2    3    4
+    ...    ELSE    No Operation    1    2    3    4    LooooooooooooooooooongArg
     ...    5    6

--- a/atest/testdata/tidy/else_untidy.robot
+++ b/atest/testdata/tidy/else_untidy.robot
@@ -21,10 +21,10 @@ Test Case With Line Continuation Before Expression
     ...    expression    No Operation    ELSE    No Operation
 
 Test Case With Long Internal Lines
-    Some Keyword  1  2  3  4  5  6  7  8  9  10  11  12  13  14  15  16  17  18
-    ...  ELSE IF  1  2  3  4  5  6  7  8  9  10  11  12  13  14  15  16  17  18
-    ...  ELSE IF  1  2  3  4  5  6  7  8  9  10  11  12  13  14  15  16  17  18
-    ...  ELSE     1  2  3  4  5  6  7  8  9  10  11  12  13  14  15  16  17  18
+    Some Keyword  1  2  3  4  LooooooooooooooooooongArg  5  6  7  8  9  10  11  12  13  14  15  16  17  18
+    ...  ELSE IF  1  2  3  4  LooooooooooooooooooongArg  5  6  7  8  9  10  11  12  13  14  15  16  17  18
+    ...  ELSE IF  1  2  3  4  LooooooooooooooooooongArg  5  6  7  8  9  10  11  12  13  14  15  16  17  18
+    ...  ELSE     1  2  3  4  LooooooooooooooooooongArg  5  6  7  8  9  10  11  12  13  14  15  16  17  18
 
 Escaping
     Log Many    \ELSE    \ELSE IF    \AND
@@ -48,4 +48,4 @@ Keyword With Line Continuation Before Expression
     ...    expression    No Operation    ELSE    No Operation
 
 Keyword With Long Line
-    Run Keyword If    expression    No Operation    ELSE IF     expression    No Operation    ELSE    No Operation    1    2    3    4    5    6
+    Run Keyword If    expression    No Operation    ELSE IF     expression    No Operation    ELSE    No Operation    1    2    3    4    LooooooooooooooooooongArg    5    6

--- a/atest/testdata/tidy/golden.html
+++ b/atest/testdata/tidy/golden.html
@@ -182,6 +182,13 @@ td.name, th.name {
 </tr>
 <tr>
 <td class="name"></td>
+<td>Really really really really really really long keyword</td>
+<td>${really really really really really really really long arg}</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td class="name"></td>
 <td>[Teardown]</td>
 <td>1 minute</td>
 <td>args</td>

--- a/atest/testdata/tidy/golden.tsv
+++ b/atest/testdata/tidy/golden.tsv
@@ -14,6 +14,7 @@ MyVar	val1	val2	val3	val4	val5	val6	val7
 My Test Case	[Documentation]	This is a long comment that spans several columns					
 	My TC Step 1	my step arg	# step 1 comment				
 	My TC Step 2	my step 2 arg	second \ arg	# step 2 comment			
+	Really really really really really really long keyword	${really really really really really really really long arg}					
 	[Teardown]	1 minute	args				
 							
 Another Test	Log Many	Non-ASCII: ääöö§§	${CURDIR}				

--- a/atest/testdata/tidy/golden_120_maxlinelength.robot
+++ b/atest/testdata/tidy/golden_120_maxlinelength.robot
@@ -1,15 +1,12 @@
 *** Settings ***
-Library           MyLibrary    argument    WITH NAME    My Alias
-...               # My library comment
-Variables         MyVariables    args    args 2    args 3    args 4    args 5
-...               args 6    args 7    args 8    args 9    args 10    args 11
-...               args 12
+Library           MyLibrary    argument    WITH NAME    My Alias    # My library comment
+Variables         MyVariables    args    args 2    args 3    args 4    args 5    args 6    args 7    args 8    args 9
+...               args 10    args 11    args 12
 Resource          MyResource args that are part of the name
 
 *** Variables ***
 # standalone      comment
-MyVar             val1    val2    val3    val4    val5    val6    val7    val8
-...               val9    val10    # var comment
+MyVar             val1    val2    val3    val4    val5    val6    val7    val8    val9    val10    # var comment
 # standalone
 
 *** Test Cases ***
@@ -30,12 +27,12 @@ My Keyword
     [Tags]    keyword    tags
     # Comment row
     # Comment row 2
-    My Step 1    args    args 2    args 3    args 4    args 5    args 6
-    ...    args 7    args 8    args 9    # step 1 comment
-    : FOR    ${param1}    ${param2}    IN    ${data 1}    ${data 2}    ${data 3}
-    ...    ${data 4}    ${data 5}    ${data 6}    # FOR comment
-    \    Loop Step    args    args 2    args 3    args 4    args 5    args 6
-    \    ...    args 7    args 8    args 9    # loop step comment
+    My Step 1    args    args 2    args 3    args 4    args 5    args 6    args 7    args 8    args 9
+    ...    # step 1 comment
+    : FOR    ${param1}    ${param2}    IN    ${data 1}    ${data 2}    ${data 3}    ${data 4}    ${data 5}    ${data 6}
+    ...    # FOR comment
+    \    Loop Step    args    args 2    args 3    args 4    args 5    args 6    args 7    args 8    args 9
+    \    ...    # loop step comment
     \    Loop Step 2
     My Step 2    my step 2 arg    second arg    # step 2 comment
     [Return]    args 1    args 2

--- a/atest/testdata/tidy/golden_pipes_120_maxlinelength.robot
+++ b/atest/testdata/tidy/golden_pipes_120_maxlinelength.robot
@@ -1,15 +1,12 @@
 | *** Settings *** |
-| Library        | MyLibrary | argument | WITH NAME | My Alias |
-| ...            | # My library comment |
-| Variables      | MyVariables | args | args 2 | args 3 | args 4 | args 5 |
-| ...            | args 6 | args 7 | args 8 | args 9 | args 10 | args 11 |
-| ...            | args 12 |
+| Library        | MyLibrary | argument | WITH NAME | My Alias | # My library comment |
+| Variables      | MyVariables | args | args 2 | args 3 | args 4 | args 5 | args 6 | args 7 | args 8 | args 9 |
+| ...            | args 10 | args 11 | args 12 |
 | Resource       | MyResource args that are part of the name |
 
 | *** Variables *** |
 | # standalone   | comment |
-| MyVar          | val1 | val2 | val3 | val4 | val5 | val6 | val7 | val8 |
-| ...            | val9 | val10 | # var comment |
+| MyVar          | val1 | val2 | val3 | val4 | val5 | val6 | val7 | val8 | val9 | val10 | # var comment |
 | # standalone   |
 
 | *** Test Cases *** |
@@ -30,12 +27,11 @@
 |    | [Tags] | keyword | tags |
 |    | # Comment row |
 |    | # Comment row 2 |
-|    | My Step 1 | args | args 2 | args 3 | args 4 | args 5 | args 6 | args 7 |
-|    | ... | args 8 | args 9 | # step 1 comment |
-|    | : FOR | ${param1} | ${param2} | IN | ${data 1} | ${data 2} | ${data 3} |
-|    | ... | ${data 4} | ${data 5} | ${data 6} | # FOR comment |
-|    |    | Loop Step | args | args 2 | args 3 | args 4 | args 5 | args 6 |
-|    |    | ... | args 7 | args 8 | args 9 | # loop step comment |
+|    | My Step 1 | args | args 2 | args 3 | args 4 | args 5 | args 6 | args 7 | args 8 | args 9 | # step 1 comment |
+|    | : FOR | ${param1} | ${param2} | IN | ${data 1} | ${data 2} | ${data 3} | ${data 4} | ${data 5} | ${data 6} |
+|    | ... | # FOR comment |
+|    |    | Loop Step | args | args 2 | args 3 | args 4 | args 5 | args 6 | args 7 | args 8 | args 9 |
+|    |    | ... | # loop step comment |
 |    |    | Loop Step 2 |
 |    | My Step 2 | my step 2 arg | second arg | # step 2 comment |
 |    | [Return] | args 1 | args 2 |

--- a/atest/testdata/tidy/golden_pipes_resource.robot
+++ b/atest/testdata/tidy/golden_pipes_resource.robot
@@ -1,24 +1,26 @@
 | *** Settings *** |
-| Library        | MyLibrary | argument | WITH NAME | My Alias | # My library comment |
-| Variables      | MyVariables | args | args 2 | args 3 | args 4 | args 5 | args 6 |
-| ...            | args 7 | args 8 | args 9 | args 10 | args 11 | args 12 |
+| Library        | MyLibrary | argument | WITH NAME | My Alias |
+| ...            | # My library comment |
+| Variables      | MyVariables | args | args 2 | args 3 | args 4 | args 5 |
+| ...            | args 6 | args 7 | args 8 | args 9 | args 10 | args 11 |
+| ...            | args 12 |
 | Resource       | MyResource args that are part of the name |
 
 | *** Variables *** |
-| MyVar          | val1 | val2 | val3 | val4 | val5 | val6 | val6 |
-| ...            | val7 | val8 | val9 | # var comment |
+| MyVar          | val1 | val2 | val3 | val4 | val5 | val6 | val6 | val7 |
+| ...            | val8 | val9 | # var comment |
 
 | *** Keywords *** |
 | My Keyword |
 |    | [Documentation] | Documentation | # Comment for doc |
 |    | # Comment row |
 |    | # Comment row 2 |
-|    | My Step 1 | args | args 2 | args 3 | args 4 | args 5 | args 6 |
-|    | ... | args 7 | args 8 | args 9 | # step 1 comment |
+|    | My Step 1 | args | args 2 | args 3 | args 4 | args 5 | args 6 | args 7 |
+|    | ... | args 8 | args 9 | # step 1 comment |
 |    | : FOR | ${param1} | ${param2} | IN | ${data 1} | ${data 2} | ${data 3} |
 |    | ... | ${data 4} | ${data 5} | ${data 6} |
-|    |    | Loop Step | args | args 2 | args 3 | args 4 | args 5 |
-|    |    | ... | args 6 | args 7 | args 8 | args 9 | # loop step comment |
+|    |    | Loop Step | args | args 2 | args 3 | args 4 | args 5 | args 6 |
+|    |    | ... | args 7 | args 8 | args 9 | # loop step comment |
 |    |    | Loop Step 2 |
 |    | My Step 2 | my step 2 arg | ${CURDIR} | # step 2 comment |
 |    | [Return] | args 1 | args 2 |

--- a/atest/testdata/tidy/golden_pipes_resource_120_maxlinelength.robot
+++ b/atest/testdata/tidy/golden_pipes_resource_120_maxlinelength.robot
@@ -1,0 +1,21 @@
+| *** Settings *** |
+| Library        | MyLibrary | argument | WITH NAME | My Alias | # My library comment |
+| Variables      | MyVariables | args | args 2 | args 3 | args 4 | args 5 | args 6 | args 7 | args 8 | args 9 |
+| ...            | args 10 | args 11 | args 12 |
+| Resource       | MyResource args that are part of the name |
+
+| *** Variables *** |
+| MyVar          | val1 | val2 | val3 | val4 | val5 | val6 | val6 | val7 | val8 | val9 | # var comment |
+
+| *** Keywords *** |
+| My Keyword |
+|    | [Documentation] | Documentation | # Comment for doc |
+|    | # Comment row |
+|    | # Comment row 2 |
+|    | My Step 1 | args | args 2 | args 3 | args 4 | args 5 | args 6 | args 7 | args 8 | args 9 | # step 1 comment |
+|    | : FOR | ${param1} | ${param2} | IN | ${data 1} | ${data 2} | ${data 3} | ${data 4} | ${data 5} | ${data 6} |
+|    |    | Loop Step | args | args 2 | args 3 | args 4 | args 5 | args 6 | args 7 | args 8 | args 9 |
+|    |    | ... | # loop step comment |
+|    |    | Loop Step 2 |
+|    | My Step 2 | my step 2 arg | ${CURDIR} | # step 2 comment |
+|    | [Return] | args 1 | args 2 |

--- a/atest/testdata/tidy/golden_resource.robot
+++ b/atest/testdata/tidy/golden_resource.robot
@@ -1,12 +1,14 @@
 *** Settings ***
-Library           MyLibrary    argument    WITH NAME    My Alias    # My library comment
-Variables         MyVariables    args    args 2    args 3    args 4    args 5    args 6
-...               args 7    args 8    args 9    args 10    args 11    args 12
+Library           MyLibrary    argument    WITH NAME    My Alias
+...               # My library comment
+Variables         MyVariables    args    args 2    args 3    args 4    args 5
+...               args 6    args 7    args 8    args 9    args 10    args 11
+...               args 12
 Resource          MyResource args that are part of the name
 
 *** Variables ***
-MyVar             val1    val2    val3    val4    val5    val6    val6
-...               val7    val8    val9    # var comment
+MyVar             val1    val2    val3    val4    val5    val6    val6    val7
+...               val8    val9    # var comment
 
 *** Keywords ***
 My Keyword
@@ -17,8 +19,8 @@ My Keyword
     ...    args 7    args 8    args 9    # step 1 comment
     : FOR    ${param1}    ${param2}    IN    ${data 1}    ${data 2}    ${data 3}
     ...    ${data 4}    ${data 5}    ${data 6}
-    \    Loop Step    args    args 2    args 3    args 4    args 5
-    \    ...    args 6    args 7    args 8    args 9    # loop step comment
+    \    Loop Step    args    args 2    args 3    args 4    args 5    args 6
+    \    ...    args 7    args 8    args 9    # loop step comment
     \    Loop Step 2
     My Step 2    my step 2 arg    ${CURDIR}    # step 2 comment
     [Return]    args 1    args 2

--- a/atest/testdata/tidy/golden_resource_120_maxlinelength.robot
+++ b/atest/testdata/tidy/golden_resource_120_maxlinelength.robot
@@ -1,0 +1,22 @@
+*** Settings ***
+Library           MyLibrary    argument    WITH NAME    My Alias    # My library comment
+Variables         MyVariables    args    args 2    args 3    args 4    args 5    args 6    args 7    args 8    args 9
+...               args 10    args 11    args 12
+Resource          MyResource args that are part of the name
+
+*** Variables ***
+MyVar             val1    val2    val3    val4    val5    val6    val6    val7    val8    val9    # var comment
+
+*** Keywords ***
+My Keyword
+    [Documentation]    Documentation    # Comment for doc
+    # Comment row
+    # Comment row 2
+    My Step 1    args    args 2    args 3    args 4    args 5    args 6    args 7    args 8    args 9
+    ...    # step 1 comment
+    : FOR    ${param1}    ${param2}    IN    ${data 1}    ${data 2}    ${data 3}    ${data 4}    ${data 5}    ${data 6}
+    \    Loop Step    args    args 2    args 3    args 4    args 5    args 6    args 7    args 8    args 9
+    \    ...    # loop step comment
+    \    Loop Step 2
+    My Step 2    my step 2 arg    ${CURDIR}    # step 2 comment
+    [Return]    args 1    args 2

--- a/atest/testdata/tidy/golden_two_spaces.robot
+++ b/atest/testdata/tidy/golden_two_spaces.robot
@@ -6,8 +6,8 @@ Resource        MyResource args that are part of the name
 
 *** Variables ***
 # standalone    comment
-MyVar           val1  val2  val3  val4  val5  val6  val7
-...             val8  val9  val10  # var comment
+MyVar           val1  val2  val3  val4  val5  val6  val7  val8  val9  val10
+...             # var comment
 # standalone
 
 *** Test Cases ***
@@ -15,6 +15,8 @@ My Test Case
   [Documentation]  This is a long comment that spans several columns
   My TC Step 1  my step arg  # step 1 comment
   My TC Step 2  my step 2 arg  second \ arg  # step 2 comment
+  Really really really really really really long keyword
+  ...  ${really really really really really really really long arg}
   [Teardown]  1 minute  args
 
 Another Test
@@ -26,12 +28,12 @@ My Keyword
   [Tags]  keyword  tags
   # Comment row
   # Comment row 2
-  My Step 1  args  args 2  args 3  args 4  args 5  args 6
-  ...  args 7  args 8  args 9  # step 1 comment
-  : FOR  ${param1}  ${param2}  IN  ${data 1}  ${data 2}  ${data 3}
-  ...  ${data 4}  ${data 5}  ${data 6}  # FOR comment
-  \  Loop Step  args  args 2  args 3  args 4  args 5
-  \  ...  args 6  args 7  args 8  args 9  # loop step comment
+  My Step 1  args  args 2  args 3  args 4  args 5  args 6  args 7  args 8
+  ...  args 9  # step 1 comment
+  : FOR  ${param1}  ${param2}  IN  ${data 1}  ${data 2}  ${data 3}  ${data 4}
+  ...  ${data 5}  ${data 6}  # FOR comment
+  \  Loop Step  args  args 2  args 3  args 4  args 5  args 6  args 7  args 8
+  \  ...  args 9  # loop step comment
   \  Loop Step 2
   My Step 2  my step 2 arg  second arg  # step 2 comment
   [Return]  args 1  args 2

--- a/doc/userguide/src/SupportingTools/Tidy.rst
+++ b/doc/userguide/src/SupportingTools/Tidy.rst
@@ -57,7 +57,13 @@ Options
                   - *unix*: use Unix line separators (LF)
 
                   New in Robot Framework 2.7.6.
- -h, --help       Show this help.
+ -m, --maxlinelength <number>
+                 The line length before the line is split onto the next line.
+                 Only available with space separated and pipe (|) separated
+                 txt output file format. Tidy reformats test suites to have 80
+                 character long lines by default.
+                 New in Robot Framework 3.0.3.
+ -h, --help      Show this help.
 
 Alternative execution
 ~~~~~~~~~~~~~~~~~~~~~

--- a/src/robot/writer/datafilewriter.py
+++ b/src/robot/writer/datafilewriter.py
@@ -54,7 +54,8 @@ class WritingContext(object):
     _formats = [txt_format, html_format, tsv_format, robot_format]
 
     def __init__(self, datafile, format='', output=None, pipe_separated=False,
-                 txt_separating_spaces=4, line_separator='\n'):
+                 txt_separating_spaces=4, line_separator='\n',
+                 max_line_length=80):
         """
         :param datafile: The datafile to be written.
         :type datafile: :py:class:`~robot.parsing.model.TestCaseFile`,
@@ -70,6 +71,8 @@ class WritingContext(object):
         :param int txt_separating_spaces: Number of separating spaces between
             cells in space separated format.
         :param str line_separator: Line separator used in output files.
+        :param int max_line_length: Maximum length of the line before
+            splittling
 
         If `output` is not given, an output file is created based on the source
         of the given datafile and value of `format`. Examples:
@@ -86,6 +89,7 @@ class WritingContext(object):
         self.datafile = datafile
         self.pipe_separated = pipe_separated
         self.line_separator = line_separator
+        self.max_line_length = max_line_length
         self._given_output = output
         self.format = self._validate_format(format) or self._format_from_file()
         self.txt_separating_spaces = txt_separating_spaces

--- a/src/robot/writer/filewriters.py
+++ b/src/robot/writer/filewriters.py
@@ -76,12 +76,17 @@ class _DataFileWriter(object):
 class SpaceSeparatedTxtWriter(_DataFileWriter):
 
     def __init__(self, configuration):
-        formatter = TxtFormatter(configuration.txt_column_count)
         self._separator = ' ' * configuration.txt_separating_spaces
+        formatter = TxtFormatter(configuration.txt_column_count,
+                                 configuration.max_line_length,
+                                 self._make_row)
         _DataFileWriter.__init__(self, formatter, configuration)
 
+    def _make_row(self, row):
+        return self._separator.join(row).rstrip() + '\n'
+
     def _write_row(self, row):
-        line = self._separator.join(row).rstrip() + '\n'
+        line = self._make_row(row)
         self._output.write(line)
 
 
@@ -89,14 +94,21 @@ class PipeSeparatedTxtWriter(_DataFileWriter):
     _separator = ' | '
 
     def __init__(self, configuration):
-        formatter = PipeFormatter(configuration.txt_column_count)
+        formatter = PipeFormatter(configuration.txt_column_count,
+                                  configuration.max_line_length,
+                                  self._make_row)
         _DataFileWriter.__init__(self, formatter, configuration)
 
-    def _write_row(self, row):
+    def _make_row(self, row):
         row = self._separator.join(row)
         if row:
             row = '| ' + row + ' |'
-        self._output.write(row + '\n')
+        row += '\n'
+        return row
+
+    def _write_row(self, row):
+        row = self._make_row(row)
+        self._output.write(row)
 
 
 class TsvFileWriter(_DataFileWriter):

--- a/src/robot/writer/formatters.py
+++ b/src/robot/writer/formatters.py
@@ -50,7 +50,7 @@ class _DataFileFormatter(object):
 
     def _split_rows(self, original_rows, table):
         for original in original_rows:
-            for split in self._splitter.split(original, table.type):
+            for split in self._splitter.split(original, table):
                 yield split
 
     def _should_align_columns(self, table):
@@ -98,6 +98,13 @@ class TsvFormatter(_DataFileFormatter):
 class TxtFormatter(_DataFileFormatter):
     _test_or_keyword_name_width = 18
     _setting_and_variable_name_width = 14
+
+    def __init__(self, column_count, max_line_length, make_row):
+        _DataFileFormatter.__init__(self, column_count=column_count)
+        self._max_line_length = max_line_length
+        self._make_row = make_row
+        self._splitter = RowSplitter(column_count, self._split_multiline_doc,
+                                     self._max_line_length, make_row=self._make_row, format_row=self._format_row)
 
     def _format_row(self, row, table=None):
         row = self._escape(row)


### PR DESCRIPTION
PR for #1891.

Tidy currently reformats suites with eight cells per line regardless of
line length. This enhancement adds a `--maxlinelength` argument to tidy
that splits the line at the specified line length when possible.

A summary of changes introduced in this commit:

* Introduced a `--maxlinelength` option for Tidy
* `--maxlinelength` defaults to 80 characters by default
* It is only applicable to space separated and pipe separated robot
files. Tabs can have a configurable length, and many 3rd party HTML
formatters exist already which can do a very good job.
* Updated existing test data to have the correct default line length
(80 characters)
* Added new tests and new test data to test custom line length
* Updated usage text for Tidy with information about the option
* Update the userguide
* This PR however introduces a tighter coupling between rowsplitter.py,
formatters.py and filewriters.py. It may not be desirable.

Changes to the rowsplitter logic:
Originally, the row splitter would either split the row at 8 cells or split
depending on the presence of IF, ELSE, etc. so that they begin on a new
line.

Now, it calculates the line length based on how the row and the table
would be formatted, and calculates split indices based on that. It would
always split at 80 characters by default. And it will only use the new logic for
space and pipe separated txt files.