### PR TITLE
Provide setuptools extra command build_rf_docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,5 +102,10 @@ setup(
     package_data = {'robot': PACKAGE_DATA},
     packages     = PACKAGES,
     scripts      = SCRIPTS,
-    cmdclass     = {'install_scripts': custom_install_scripts}
+    cmdclass     = {'install_scripts': custom_install_scripts},
+    entry_points = {
+        'distutils.commands': [
+            'build_rf_docs = robot.libdocpkg.setup_command:BuildLibdoc',
+        ],
+    }
 )

--- a/src/robot/libdocpkg/setup_command.py
+++ b/src/robot/libdocpkg/setup_command.py
@@ -1,0 +1,39 @@
+import sys
+import os.path
+from distutils.cmd import Command
+import robot.libdoc
+
+class BuildLibdoc(Command):
+    description = 'Build Robotframework library documentation'
+    user_options = [
+            ('libraries=', 'L', 'Library names'),
+            ('output-dir=', 'o', 'Output directory'),
+    ]
+
+    # assume the first part of the package is the library name
+    def _guess_library_names(self):
+        library_names = list()
+        for package in self.distribution.packages:
+            name = package.split('.')[0]
+            if name not in library_names:
+                library_names.append(name)
+        return library_names
+
+    def initialize_options(self):
+        self.libraries = self._guess_library_names()
+        self.output_dir = 'docs'
+
+    def finalize_options(self):
+        self.output_dir = os.path.abspath(self.output_dir)
+        self.mkpath(self.output_dir)
+        self.ensure_string_list('libraries')
+
+    def run(self):
+        # add all package_dir directories to the module path, so libdoc can
+        # import the library properly
+        for path in self.distribution.package_dir.values():
+            sys.path.insert(0, path)
+
+        for lib in self.libraries:
+            html_file = os.path.join(self.output_dir, lib + '.html')
+            robot.libdoc.libdoc(lib, html_file)


### PR DESCRIPTION
Provide an entry point for a setuptools extra command to ease the
generation of the library documentation. A user/developer just have to
call "setup.py build_rf_docs" of a robotframework library to build its
documention.

This fixes #1685.

Signed-off-by: Michael Walle <michael.walle@kontron.com>