### PR TITLE
Screenshot enhancements

### DIFF
--- a/atest/robot/standard_libraries/screenshot/take_screenshot.robot
+++ b/atest/robot/standard_libraries/screenshot/take_screenshot.robot
@@ -15,18 +15,6 @@ Basename May Be Defined
     ${tc}=  Check Test Case  ${TESTNAME}
     Check Embedding In Log  ${tc.kws[0].kws[0].msgs[1]}  foo_1.jpg
 
-Screenshot With Png Extension
-    ${tc}=  Check Test Case  ${TESTNAME}
-    Check Embedding In Log  ${tc.kws[0].kws[0].msg[1]}  screenshot_1.png
-
-Png Screenshot Quality
-    ${tc}=  Check Test Case  ${TESTNAME}
-    Check Embedding In Log  ${tc.kws[0].kws[0].msg[1]}  foo_1.png
-    
-Jpeg Screenshot Quality
-    ${tc}=  Check Test Case  ${TESTNAME}
-    Check Embedding In Log  ${tc.kws[0].kws[0].msg[1]}  foo_3.jpg
-
 Basename With Extension Turns Off Index Generation
     ${tc}=  Check Test Case  ${TESTNAME}
     Check Embedding In Log  ${tc.kws[0].kws[0].msgs[1]}  xxx.jpg
@@ -42,6 +30,16 @@ Basename With Non-existing Directories Fails
 Without Embedding
     ${tc}=  Check Test Case  ${TESTNAME}
     Check Linking In Log  ${tc.kws[0].msgs[1]}  no_embed.jpeg
+
+Png Screenshot Is Embedded in Log File
+    ${tc}=  Check Test Case  ${TESTNAME}
+    Check Embedding In Log  ${tc.kws[0].kws[0].msgs[1]}  screenshot_1.png
+
+Jpg Screenshot Quality
+    Check Test Case  ${TESTNAME}
+
+Png Screenshot Quality
+    Check Test Case  ${TESTNAME}
 
 *** Keywords ***
 Check Embedding In Log

--- a/atest/robot/standard_libraries/screenshot/take_screenshot.robot
+++ b/atest/robot/standard_libraries/screenshot/take_screenshot.robot
@@ -23,7 +23,7 @@ Png Screenshot Quality
     ${tc}=  Check Test Case  ${TESTNAME}
     Check Embedding In Log  ${tc.kws[0].kws[0].msg[1]}  foo_1.png
     
-Jpeg Screenshot
+Jpeg Screenshot Quality
     ${tc}=  Check Test Case  ${TESTNAME}
     Check Embedding In Log  ${tc.kws[0].kws[0].msg[1]}  foo_3.jpg
 

--- a/atest/robot/standard_libraries/screenshot/take_screenshot.robot
+++ b/atest/robot/standard_libraries/screenshot/take_screenshot.robot
@@ -19,13 +19,13 @@ Screenshot With Png Extension
     ${tc}=  Check Test Case  ${TESTNAME}
     Check Embedding In Log  ${tc.kws[0].kws[0].msg[1]}  screenshot_1.png
 
-Screenshot Png Size Compare
-    ${tc}=  Check Test Case  ${TESTNAME}
-    Check Embedding In Log  ${tc.kws[0].kws[0].msg[1]}  foo.png
-    
-Screenshot Jpeg Size Compare
+Png Screenshot Quality
     ${tc}=  Check Test Case  ${TESTNAME}
     Check Embedding In Log  ${tc.kws[0].kws[0].msg[1]}  foo_1.png
+    
+Jpeg Screenshot
+    ${tc}=  Check Test Case  ${TESTNAME}
+    Check Embedding In Log  ${tc.kws[0].kws[0].msg[1]}  foo_3.jpg
 
 Basename With Extension Turns Off Index Generation
     ${tc}=  Check Test Case  ${TESTNAME}

--- a/atest/robot/standard_libraries/screenshot/take_screenshot.robot
+++ b/atest/robot/standard_libraries/screenshot/take_screenshot.robot
@@ -15,6 +15,18 @@ Basename May Be Defined
     ${tc}=  Check Test Case  ${TESTNAME}
     Check Embedding In Log  ${tc.kws[0].kws[0].msgs[1]}  foo_1.jpg
 
+Screenshot With Png Extension
+    ${tc}=  Check Test Case  ${TESTNAME}
+    Check Embedding In Log  ${tc.kws[0].kws[0].msg[1]}  screenshot_1.png
+
+Screenshot Png Size Compare
+    ${tc}=  Check Test Case  ${TESTNAME}
+    Check Embedding In Log  ${tc.kws[0].kws[0].msg[1]}  foo.png
+    
+Screenshot Jpeg Size Compare
+    ${tc}=  Check Test Case  ${TESTNAME}
+    Check Embedding In Log  ${tc.kws[0].kws[0].msg[1]}  foo_1.png
+
 Basename With Extension Turns Off Index Generation
     ${tc}=  Check Test Case  ${TESTNAME}
     Check Embedding In Log  ${tc.kws[0].kws[0].msgs[1]}  xxx.jpg

--- a/atest/testdata/standard_libraries/screenshot/screenshot_resource.robot
+++ b/atest/testdata/standard_libraries/screenshot/screenshot_resource.robot
@@ -18,5 +18,7 @@ Save Start Time
 
 Screenshots Should Exist
     [Arguments]  ${directory}  @{files}
-    @{actual files}=  List Directory  ${directory}  *.jp*g  absolute
-    Lists Should Be Equal  ${actual files}  ${files}
+    @{actual_png_files}=  List Directory  ${directory}  *.png  absolute
+    @{actual_jpeg_files}=  List Directory  ${directory}  *.jp*g  absolute
+    @{all_files}=  Combine Lists  ${actual_png_files}  ${actual_jpeg_files}
+    List Should Contain Sub List  ${files}  ${all_files}

--- a/atest/testdata/standard_libraries/screenshot/take_screenshot.robot
+++ b/atest/testdata/standard_libraries/screenshot/take_screenshot.robot
@@ -11,10 +11,8 @@ ${SECOND_SCREENSHOT}  ${BASENAME}_2.jpg
 ${FIRST_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo_1.jpg
 ${SECOND_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo_2.jpg
 ${PNG_SCREENSHOT}  ${BASENAME}_1.png
-${PNG_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo.png
+${PNG_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo_1.png
 ${JPEG_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo_3.jpg
-${PNG_FORMAT}  png
-${JPEG_FORMAT}  jpg
 
 *** Test Cases ***
 Screenshot Is Embedded in Log File
@@ -34,10 +32,10 @@ Screenshot With Png Extension
     Screenshots Should Exist  ${OUTPUTDIR}  ${PNG_SCREENSHOT}
 
 Png Screenshot Quality
-    Compare Size  ${PNG_CUSTOM_SCREENSHOT}  ${PNG_FORMAT}
-
+    Compare Size  ${PNG_CUSTOM_SCREENSHOT}  png
+    
 Jpg Screenshot Quality
-    Compare Size  ${JPEG_CUSTOM_SCREENSHOT}  ${JPEG_FORMAT}
+    Compare Size  ${JPEG_CUSTOM_SCREENSHOT}  jpg
 
 Basename With Extension Turns Off Index Generation
     Repeat Keyword  3  Take Screenshot  xxx.jpg
@@ -64,9 +62,9 @@ Take Screenshot And Verify  [Arguments]  @{expected files}
 
 Compare Size 
     [Arguments]  ${screenshot_name}  ${screenshot_format}
-    Take Screenshot  ${screenshot_name}  ${screenshot_format}  quality=100
+    Take Screenshot  ${screenshot_name}  ${screenshot_format}  quality=0
     ${first}=  Get File Size  ${screenshot_name}
-    Take Screenshot  ${screenshot_name}  ${screenshot_format}  quality=1
+    Take Screenshot  ${screenshot_name}  ${screenshot_format}  quality=0
     ${second}=  Get File Size  ${screenshot_name}
     ${result}=  Evaluate  ${second} * 100 / ${first}
     Should Be True  ${result} < 30

--- a/atest/testdata/standard_libraries/screenshot/take_screenshot.robot
+++ b/atest/testdata/standard_libraries/screenshot/take_screenshot.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Suite Setup     Remove Files  ${OUTPUTDIR}/*.jp*g  ${OUTPUTDIR}/*.png
-Test Setup	Save Start Time
+Test Setup	    Save Start Time
 Test Teardown   Remove Files  ${OUTPUTDIR}/*.jp*g  ${OUTPUTDIR}/*.png
 Resource        screenshot_resource.robot
 
@@ -11,31 +11,19 @@ ${SECOND_SCREENSHOT}  ${BASENAME}_2.jpg
 ${FIRST_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo_1.jpg
 ${SECOND_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo_2.jpg
 ${PNG_SCREENSHOT}  ${BASENAME}_1.png
-${PNG_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo_1.png
-${JPEG_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo_3.jpg
 
 *** Test Cases ***
 Screenshot Is Embedded in Log File
-    ${path}=  Take Screenshot and Verify  ${FIRST_SCREENSHOT} 
+    ${path}=  Take Screenshot and Verify  jpg  ${FIRST_SCREENSHOT}
     Should Be Equal  ${path}  ${FIRST_SCREENSHOT}
 
 Each Screenshot Gets Separate Index
-    Take Screenshot and Verify  ${FIRST_SCREENSHOT} 
-    Take Screenshot and Verify  ${FIRST_SCREENSHOT}  ${SECOND_SCREENSHOT} 
+    Take Screenshot and Verify  jpg  ${FIRST_SCREENSHOT}
+    Take Screenshot and Verify  jpg  ${FIRST_SCREENSHOT}  ${SECOND_SCREENSHOT}
 
 Basename May Be Defined
     Repeat Keyword  2  Take Screenshot  foo
     Screenshots Should Exist  ${OUTPUTDIR}  ${FIRST_CUSTOM_SCREENSHOT}  ${SECOND_CUSTOM_SCREENSHOT}
-
-Screenshot With Png Extension
-    Take Screenshot  image_format=png
-    Screenshots Should Exist  ${OUTPUTDIR}  ${PNG_SCREENSHOT}
-
-Png Screenshot Quality
-    Compare Size  ${PNG_CUSTOM_SCREENSHOT}  png
-    
-Jpg Screenshot Quality
-    Compare Size  ${JPEG_CUSTOM_SCREENSHOT}  jpg
 
 Basename With Extension Turns Off Index Generation
     Repeat Keyword  3  Take Screenshot  xxx.jpg
@@ -53,18 +41,34 @@ Basename With Non-existing Directories Fails
 Without Embedding
     Take Screenshot Without Embedding  no_embed.jpeg
 
+Png Screenshot Is Embedded in Log File
+    ${path}=  Take Screenshot and Verify  png  ${PNG_SCREENSHOT}
+    Should Be Equal  ${path}  ${PNG_SCREENSHOT}
+
+Jpg Screenshot Quality
+    Take Screenshots And Compare Size  jpg
+
+Png Screenshot Quality
+    Take Screenshots And Compare Size  png
 
 *** Keywords ***
-Take Screenshot And Verify  [Arguments]  @{expected files}
-    ${path}=  Take Screenshot
+Take Screenshot And Verify  [Arguments]  ${format}  @{expected files}
+    ${path}=  Take Screenshot  image_format=${format}
     Screenshots Should Exist  ${OUTPUTDIR}  @{expected files}
     [Return]  ${path}
 
-Compare Size 
-    [Arguments]  ${screenshot_name}  ${screenshot_format}
-    Take Screenshot  ${screenshot_name}  ${screenshot_format}  quality=0
-    ${first}=  Get File Size  ${screenshot_name}
-    Take Screenshot  ${screenshot_name}  ${screenshot_format}  quality=0
-    ${second}=  Get File Size  ${screenshot_name}
-    ${result}=  Evaluate  ${second} * 100 / ${first}
-    Should Be True  ${result} < 30
+Take Screenshots And Compare Size
+    [Arguments]  ${format}
+    ${low_quality_size}=  Take Screenshot And Get Size  ${format}  quality=0
+    ${high_quality_size}=  Take Screenshot And Get Size  ${format}  quality=100
+    ${size_delta}=  Evaluate  ${high_quality_size} / ${low_quality_size}
+    Should Be True  ${size_delta} > 2
+
+Take Screenshot And Get Size
+    [Arguments]  ${format}  ${quality}
+    ${path}=  Take Screenshot  image_format=${format}  quality=${quality}
+    ${status}  ${size}=  Run Keyword and Ignore Error  Get File Size  ${path}
+    Run Keyword If  '${status}' == 'FAIL'
+    ...  Run Keywords  Set Test Documentation  PASS Changing the image format quality is not supported on this platform.  AND
+    ...                Pass Execution  Changing the image format quality is not supported on this platform.
+    [Return]  ${size}

--- a/atest/testdata/standard_libraries/screenshot/take_screenshot.robot
+++ b/atest/testdata/standard_libraries/screenshot/take_screenshot.robot
@@ -1,7 +1,7 @@
 *** Settings ***
-Suite Setup     Remove Files  ${OUTPUTDIR}/*.jp*g
-Test Setup      Save Start Time
-Test Teardown   Remove Files  ${OUTPUTDIR}/*.jp*g
+Suite Setup     Remove Files  ${OUTPUTDIR}/*.jp*g  ${OUTPUTDIR}/*.png
+test Setup	Save Start Time 
+Test Teardown   Remove Files  ${OUTPUTDIR}/*.jp*g  ${OUTPUTDIR}/*.png
 Resource        screenshot_resource.robot
 
 *** Variables ***
@@ -10,7 +10,9 @@ ${FIRST_SCREENSHOT}  ${BASENAME}_1.jpg
 ${SECOND_SCREENSHOT}  ${BASENAME}_2.jpg
 ${FIRST_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo_1.jpg
 ${SECOND_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo_2.jpg
-
+${PNG_SCREENSHOT}  ${BASENAME}_1.png
+${PNG_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo.png
+${PERCENT}  30
 
 *** Test Cases ***
 Screenshot Is Embedded in Log File
@@ -25,6 +27,27 @@ Basename May Be Defined
     Repeat Keyword  2  Take Screenshot  foo
     Screenshots Should Exist  ${OUTPUTDIR}  ${FIRST_CUSTOM_SCREENSHOT}  ${SECOND_CUSTOM_SCREENSHOT}
 
+Screenshot With Png Extension
+    Take Screenshot  image_format=png
+    Screenshots Should Exist  ${OUTPUTDIR}  ${PNG_SCREENSHOT}
+
+Screenshot Png Size Compare
+    Take Screenshot  ${PNG_CUSTOM_SCREENSHOT}  png  quality=100
+    ${first}=  Get File Size  ${PNG_CUSTOM_SCREENSHOT}
+    Take Screenshot  ${PNG_CUSTOM_SCREENSHOT}  png  quality=1
+    ${second}=  Get File Size  ${PNG_CUSTOM_SCREENSHOT}
+    ${result}=  Evaluate  ${second}*100/${first}
+    ${status}=  Evaluate  ${result} < ${PERCENT}
+
+Screenshot Jpg Size Compare
+    Take Screenshot  ${FIRST_CUSTOM_SCREENSHOT}  jpg  quality=100
+    ${first}=  Get File Size  ${FIRST_CUSTOM_SCREENSHOT}
+    Take Screenshot  ${FIRST_CUSTOM_SCREENSHOT}  jpg  quality=1
+    ${second}=  Get File Size  ${FIRST_CUSTOM_SCREENSHOT}
+    ${result}=  Evaluate  ${second}*100/${first}
+    ${status}=  Evaluate  ${result} < ${PERCENT}
+    Log  Smaller size is ${status} 
+
 Basename With Extension Turns Off Index Generation
     Repeat Keyword  3  Take Screenshot  xxx.jpg
     Repeat Keyword  2  Take Screenshot  yyy.jpeg
@@ -32,7 +55,7 @@ Basename With Extension Turns Off Index Generation
 
 Screenshot Width Can Be Given
     Take Screenshot  width=300px
-    Screenshots Should Exist  ${OUTPUTDIR}  ${FIRST_SCREENSHOT}
+    Screenshots Should Exist  ${OUTPUTDIR}  ${FIRST_SCREENSHOT} 
 
 Basename With Non-existing Directories Fails
     [Documentation]  FAIL Directory '${OUTPUTDIR}${/}non-existing' where to save the screenshot does not exist
@@ -42,8 +65,10 @@ Without Embedding
     Take Screenshot Without Embedding  no_embed.jpeg
 
 
+
 *** Keywords ***
 Take Screenshot And Verify  [Arguments]  @{expected files}
     ${path}=  Take Screenshot
     Screenshots Should Exist  ${OUTPUTDIR}  @{expected files}
     [Return]  ${path}
+

--- a/atest/testdata/standard_libraries/screenshot/take_screenshot.robot
+++ b/atest/testdata/standard_libraries/screenshot/take_screenshot.robot
@@ -13,6 +13,8 @@ ${SECOND_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo_2.jpg
 ${PNG_SCREENSHOT}  ${BASENAME}_1.png
 ${PNG_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo.png
 ${JPEG_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo_3,jpg
+${PNG_FORMAT}  png
+${JPEG_FORMAT}  jpg
 
 *** Test Cases ***
 Screenshot Is Embedded in Log File
@@ -32,20 +34,10 @@ Screenshot With Png Extension
     Screenshots Should Exist  ${OUTPUTDIR}  ${PNG_SCREENSHOT}
 
 Png Screenshot Quality
-    Take Screenshot  ${PNG_CUSTOM_SCREENSHOT}  png  quality=100
-    ${first}=  Get File Size  ${PNG_CUSTOM_SCREENSHOT}
-    Take Screenshot  ${PNG_CUSTOM_SCREENSHOT}  png  quality=1
-    ${second}=  Get File Size  ${PNG_CUSTOM_SCREENSHOT}
-    ${result}=  Evaluate  ${second} * 100 / ${first}
-    ${status}=  Evaluate  ${result} < 30
+    Compare Size  ${PNG_CUSTOM_SCREENSHOT}  ${PNG_FORMAT}
 
 Jpg Screenshot Quality
-    Take Screenshot  ${FIRST_CUSTOM_SCREENSHOT}  jpg  quality=100
-    ${first}=  Get File Size  ${FIRST_CUSTOM_SCREENSHOT}
-    Take Screenshot  ${FIRST_CUSTOM_SCREENSHOT}  jpg  quality=1
-    ${second}=  Get File Size  ${FIRST_CUSTOM_SCREENSHOT}
-    ${result}=  Evaluate  ${second} * 100 / ${first}
-    ${status}=  Evaluate  ${result} < 30 
+    Compare Size  ${JPEG_CUSTOM_SCREENSHOT}  ${JPEG_FORMAT}
 
 Basename With Extension Turns Off Index Generation
     Repeat Keyword  3  Take Screenshot  xxx.jpg
@@ -69,3 +61,12 @@ Take Screenshot And Verify  [Arguments]  @{expected files}
     ${path}=  Take Screenshot
     Screenshots Should Exist  ${OUTPUTDIR}  @{expected files}
     [Return]  ${path}
+
+Compare Size 
+    [Arguments]  ${screenshot_name}  ${image_format}
+    Take Screenshot  ${screenshot_name}  ${screenshot_format}  quality=100
+    ${first}=  Get File Size  ${screenshot_name}
+    Take Screenshot  ${screenshot_name}  ${screenshot_format}  quality=1
+    ${second}=  Get File Size  ${screenshot_name}
+    ${result}=  Evaluate  ${second} * 100 / ${first}
+    Should Be True  ${result} < 30

--- a/atest/testdata/standard_libraries/screenshot/take_screenshot.robot
+++ b/atest/testdata/standard_libraries/screenshot/take_screenshot.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Suite Setup     Remove Files  ${OUTPUTDIR}/*.jp*g  ${OUTPUTDIR}/*.png
-Test Setup	    Save Start Time
+Test Setup      Save Start Time
 Test Teardown   Remove Files  ${OUTPUTDIR}/*.jp*g  ${OUTPUTDIR}/*.png
 Resource        screenshot_resource.robot
 

--- a/atest/testdata/standard_libraries/screenshot/take_screenshot.robot
+++ b/atest/testdata/standard_libraries/screenshot/take_screenshot.robot
@@ -12,7 +12,7 @@ ${FIRST_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo_1.jpg
 ${SECOND_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo_2.jpg
 ${PNG_SCREENSHOT}  ${BASENAME}_1.png
 ${PNG_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo.png
-${JPEG_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo_3,jpg
+${JPEG_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo_3.jpg
 ${PNG_FORMAT}  png
 ${JPEG_FORMAT}  jpg
 
@@ -63,7 +63,7 @@ Take Screenshot And Verify  [Arguments]  @{expected files}
     [Return]  ${path}
 
 Compare Size 
-    [Arguments]  ${screenshot_name}  ${image_format}
+    [Arguments]  ${screenshot_name}  ${screenshot_format}
     Take Screenshot  ${screenshot_name}  ${screenshot_format}  quality=100
     ${first}=  Get File Size  ${screenshot_name}
     Take Screenshot  ${screenshot_name}  ${screenshot_format}  quality=1

--- a/atest/testdata/standard_libraries/screenshot/take_screenshot.robot
+++ b/atest/testdata/standard_libraries/screenshot/take_screenshot.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Suite Setup     Remove Files  ${OUTPUTDIR}/*.jp*g  ${OUTPUTDIR}/*.png
-test Setup	Save Start Time 
+Test Setup	Save Start Time
 Test Teardown   Remove Files  ${OUTPUTDIR}/*.jp*g  ${OUTPUTDIR}/*.png
 Resource        screenshot_resource.robot
 
@@ -12,7 +12,7 @@ ${FIRST_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo_1.jpg
 ${SECOND_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo_2.jpg
 ${PNG_SCREENSHOT}  ${BASENAME}_1.png
 ${PNG_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo.png
-${PERCENT}  30
+${JPEG_CUSTOM_SCREENSHOT}  ${OUTPUTDIR}${/}foo_3,jpg
 
 *** Test Cases ***
 Screenshot Is Embedded in Log File
@@ -31,22 +31,21 @@ Screenshot With Png Extension
     Take Screenshot  image_format=png
     Screenshots Should Exist  ${OUTPUTDIR}  ${PNG_SCREENSHOT}
 
-Screenshot Png Size Compare
+Png Screenshot Quality
     Take Screenshot  ${PNG_CUSTOM_SCREENSHOT}  png  quality=100
     ${first}=  Get File Size  ${PNG_CUSTOM_SCREENSHOT}
     Take Screenshot  ${PNG_CUSTOM_SCREENSHOT}  png  quality=1
     ${second}=  Get File Size  ${PNG_CUSTOM_SCREENSHOT}
-    ${result}=  Evaluate  ${second}*100/${first}
-    ${status}=  Evaluate  ${result} < ${PERCENT}
+    ${result}=  Evaluate  ${second} * 100 / ${first}
+    ${status}=  Evaluate  ${result} < 30
 
-Screenshot Jpg Size Compare
+Jpg Screenshot Quality
     Take Screenshot  ${FIRST_CUSTOM_SCREENSHOT}  jpg  quality=100
     ${first}=  Get File Size  ${FIRST_CUSTOM_SCREENSHOT}
     Take Screenshot  ${FIRST_CUSTOM_SCREENSHOT}  jpg  quality=1
     ${second}=  Get File Size  ${FIRST_CUSTOM_SCREENSHOT}
-    ${result}=  Evaluate  ${second}*100/${first}
-    ${status}=  Evaluate  ${result} < ${PERCENT}
-    Log  Smaller size is ${status} 
+    ${result}=  Evaluate  ${second} * 100 / ${first}
+    ${status}=  Evaluate  ${result} < 30 
 
 Basename With Extension Turns Off Index Generation
     Repeat Keyword  3  Take Screenshot  xxx.jpg
@@ -55,7 +54,7 @@ Basename With Extension Turns Off Index Generation
 
 Screenshot Width Can Be Given
     Take Screenshot  width=300px
-    Screenshots Should Exist  ${OUTPUTDIR}  ${FIRST_SCREENSHOT} 
+    Screenshots Should Exist  ${OUTPUTDIR}  ${FIRST_SCREENSHOT}
 
 Basename With Non-existing Directories Fails
     [Documentation]  FAIL Directory '${OUTPUTDIR}${/}non-existing' where to save the screenshot does not exist
@@ -65,10 +64,8 @@ Without Embedding
     Take Screenshot Without Embedding  no_embed.jpeg
 
 
-
 *** Keywords ***
 Take Screenshot And Verify  [Arguments]  @{expected files}
     ${path}=  Take Screenshot
     Screenshots Should Exist  ${OUTPUTDIR}  @{expected files}
     [Return]  ${path}
-

--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -915,7 +915,7 @@ class _Verify(_BuiltInBase):
         Examples:
         | Should Contain | ${output}    | PASS  |
         | Should Contain | ${some list} | value | msg=Failure! | values=False |
-        | Should Contain | ${some list} | value | case_insensitive=True |
+        | Should Contain | ${some list} | value | ignore_case=True |
         """
         orig_container = container
         if is_truthy(ignore_case) and is_string(item):

--- a/src/robot/libraries/Screenshot.py
+++ b/src/robot/libraries/Screenshot.py
@@ -153,7 +153,7 @@ class Screenshot(object):
         self._given_screenshot_dir = path
         return old
 
-    def take_screenshot(self, name="screenshot", width="800px", filetype="jpeg", quality=100):
+    def take_screenshot(self, name="screenshot", width="800px", image_format="jpeg", quality=100):
         """Takes a screenshot in JPEG or PNG format and embeds it into the log file.
 
         Name of the file where the screenshot is stored is derived from the
@@ -168,43 +168,54 @@ class Screenshot(object):
 
         ``width`` specifies the size of the screenshot in the log file.
 
+        ``image_format`` can be either jpg, jpeg or png.
+
+        ``quality`` can take values in range [0, 100]. In case of JPEG format it can drastically reduce
+        the file size of the image. If the format is PNG, which uses lossless compression, the quality is
+        indirectly proportional with compression. As standard PNG compression is in range [0, 9], when
+        setting quality to 0 is equivalent to compression value 9 and when setting quality 100 is equivalent
+        to compression value 0.
+
+        The ``quality`` argument does not work on OSX's screencapture, Jython or IronPython.
+
         Examples: (LOGDIR is determined automatically by the library)
-        | Take Screenshot |                  |     | # LOGDIR/screenshot_1.jpg (index automatically incremented) |
-        | Take Screenshot | mypic            |     | # LOGDIR/mypic_1.jpg (index automatically incremented) |
-        | Take Screenshot | ${TEMPDIR}/mypic |     | # /tmp/mypic_1.jpg (index automatically incremented) |
-        | Take Screenshot | pic.jpg          |     | # LOGDIR/pic.jpg (always uses this file) |
-        | Take Screenshot | images/login.jpg | 80% | # Specify both name and width. |
-        | Take Screenshot | width=550px      |     | # Specify only width. |
+        | Take Screenshot |                  |            | # LOGDIR/screenshot_1.jpg (index automatically incremented) |
+        | Take Screenshot | mypic            |            | # LOGDIR/mypic_1.jpg (index automatically incremented) |
+        | Take Screenshot | ${TEMPDIR}/mypic |            | # /tmp/mypic_1.jpg (index automatically incremented) |
+        | Take Screenshot | pic.jpg          |            | # LOGDIR/pic.jpg (always uses this file) |
+        | Take Screenshot | images/login.jpg | 80%        | # Specify both name and width. |
+        | Take Screenshot | width=550px      |            | # Specify only width. |
+        | Take Screenshot | image_format=png | quality=50 | # Specify both image format and quality. |
 
         The path where the screenshot is saved is returned.
         """
-        path = self._save_screenshot(name, filetype, quality)
+        path = self._save_screenshot(name, image_format.lower(), quality)
         self._embed_screenshot(path, width)
         return path
 
-    def take_screenshot_without_embedding(self, name="screenshot"):
+    def take_screenshot_without_embedding(self, name="screenshot", image_format="jpeg", quality=100):
         """Takes a screenshot and links it from the log file.
 
         This keyword is otherwise identical to `Take Screenshot` but the saved
         screenshot is not embedded into the log file. The screenshot is linked
         so it is nevertheless easily available.
         """
-        path = self._save_screenshot(name)
+        path = self._save_screenshot(name, image_format.lower(), quality)
         self._link_screenshot(path)
         return path
 
-    def _save_screenshot(self, basename, filetype, quality, directory=None):
-        path = self._get_screenshot_path(basename, directory, filetype)
+    def _save_screenshot(self, basename, image_format, quality, directory=None):
+        path = self._get_screenshot_path(basename, directory, image_format)
         if self._screenshot_taker.module != 'scrot':
-            quality = self._convert_quality(filetype, quality)
-        return self._screenshot_to_file(path, filetype, quality)
+            quality = self._convert_quality(image_format, quality)
+        return self._screenshot_to_file(path, image_format, quality)
 
-    def _screenshot_to_file(self, path, filetype, quality):
+    def _screenshot_to_file(self, path, image_format, quality):
         path = self._validate_screenshot_path(path)
         logger.debug('Using %s module/tool for taking screenshot.'
                      % self._screenshot_taker.module)
         try:
-            self._screenshot_taker(path, filetype, quality)
+            self._screenshot_taker(path, image_format, quality)
         except:
             logger.warn('Taking screenshot failed: %s\n'
                         'Make sure tests are run with a physical or virtual '
@@ -218,14 +229,14 @@ class Screenshot(object):
                                "does not exist" % os.path.dirname(path))
         return path
 
-    def _get_screenshot_path(self, basename, directory, filetype):
+    def _get_screenshot_path(self, basename, directory, image_format):
         directory = self._norm_path(directory) if directory else self._screenshot_dir
         if basename.lower().endswith(('.jpg', '.jpeg', '.png')):
             return os.path.join(directory, basename)
         index = 0
         while True:
             index += 1
-            path = os.path.join(directory, "%s_%d.%s" % (basename, index, filetype))
+            path = os.path.join(directory, "%s_%d.%s" % (basename, index, image_format))
             if not os.path.exists(path):
                 return path
 
@@ -240,8 +251,12 @@ class Screenshot(object):
                     % (link, path), html=True)
 
     @staticmethod
-    def _convert_quality(filetype, quality):
-        if filetype.lower() == 'png':
+    def _convert_quality(image_format, quality):
+        """
+        PNG uses compression with values in range [0, 9]. Thus the quality
+        must be converted accordingly.
+        """
+        if image_format == 'png':
             if quality == 100:
                 return 0
             return 9 - (int(quality) / 11)
@@ -256,13 +271,13 @@ class ScreenshotTaker(object):
         self.module = self._screenshot.__name__.split('_')[1]
         self._wx_app_reference = None
 
-    def __call__(self, path, filetype, quality):
-        self._screenshot(path, filetype, quality)
+    def __call__(self, path, image_format, quality):
+        self._screenshot(path, image_format, quality)
 
     def __nonzero__(self):
         return self.module != 'no'
 
-    def test(self, path=None, filetype=None, quality=None):
+    def test(self, path=None, image_format=None, quality=None):
         if not self:
             print("Cannot take screenshots.")
             return False
@@ -272,7 +287,7 @@ class ScreenshotTaker(object):
             return True
         print("Taking test screenshot to '%s'." % path)
         try:
-            self(path, filetype, quality)
+            self(path, image_format, quality)
         except:
             print("Failed: %s" % get_error_message())
             return False
@@ -313,13 +328,14 @@ class ScreenshotTaker(object):
             if module:
                 return screenshot_taker
 
-    def _java_screenshot(self, path):
+    def _java_screenshot(self, path, image_format, quality):
         size = Toolkit.getDefaultToolkit().getScreenSize()
         rectangle = Rectangle(0, 0, size.width, size.height)
         image = Robot().createScreenCapture(rectangle)
-        ImageIO.write(image, 'jpg', File(path))
+        print('!!!!! %s    %s', image_format, path)
+        ImageIO.write(image, image_format, File(path))
 
-    def _cli_screenshot(self, path):
+    def _cli_screenshot(self, path, image_format, quality):
         bmp = Bitmap(Screen.PrimaryScreen.Bounds.Width,
                      Screen.PrimaryScreen.Bounds.Height)
         graphics = Graphics.FromImage(bmp)
@@ -327,10 +343,15 @@ class ScreenshotTaker(object):
             graphics.CopyFromScreen(0, 0, 0, 0, bmp.Size)
         finally:
             graphics.Dispose()
-            bmp.Save(path, Imaging.ImageFormat.Jpeg)
+            if image_format == 'png':
+                bmp.Save(path, Imaging.ImageFormat.Png)
+            else:
+                bmp.Save(path, Imaging.ImageFormat.Jpeg)
 
-    def _osx_screenshot(self, path):
-        if self._call('screencapture', '-t', 'jpg', path) != 0:
+    def _osx_screenshot(self, path, image_format, quality):
+        if image_format == 'jpeg':
+            image_format = 'jpg'
+        if self._call('screencapture', '-t', image_format, path) != 0:
             raise RuntimeError("Using 'screencapture' failed.")
 
     def _call(self, *command):
@@ -344,14 +365,14 @@ class ScreenshotTaker(object):
     def _scrot(self):
         return os.sep == '/' and self._call('scrot', '--version') == 0
 
-    def _scrot_screenshot(self, path, filetype, quality):
+    def _scrot_screenshot(self, path, image_format, quality):
         if not path.endswith(('.jpg', '.jpeg', '.png')):
             raise RuntimeError("Scrot requires extension to be '.jpg', "
                                "'.jpeg' or '.png', got '%s'." % os.path.splitext(path)[1])
         if self._call('scrot', '-q %s' % quality, path) != 0:
             raise RuntimeError("Using 'scrot' failed.")
 
-    def _wx_screenshot(self, path, filetype, quality):
+    def _wx_screenshot(self, path, image_format, quality):
         if not self._wx_app_reference:
             self._wx_app_reference = wx.App(False)
         context = wx.ScreenDC()
@@ -365,7 +386,7 @@ class ScreenshotTaker(object):
         memory.Blit(0, 0, width, height, context, -1, -1)
         memory.SelectObject(wx.NullBitmap)
         image = bitmap.ConvertToImage()
-        if filetype.lower() == 'png':
+        if image_format == 'png':
             image.SetOption(wx.IMAGE_OPTION_PNG_COMPRESSION_LEVEL, quality)
             image.SaveFile(path, wx.BITMAP_TYPE_PNG)
         else:
@@ -373,15 +394,15 @@ class ScreenshotTaker(object):
             image.SaveFile(path, wx.BITMAP_TYPE_JPEG)
 
     @staticmethod
-    def _gtk_quality(filetype, quality):
+    def _gtk_quality(image_format, quality):
         quality_setting = {}
-        if filetype.lower() == 'png':
+        if image_format == 'png':
             quality_setting['compression'] = str(quality)
         else:
             quality_setting['quality'] = str(quality)
         return quality_setting
 
-    def _gtk_screenshot(self, path, filetype, quality):
+    def _gtk_screenshot(self, path, image_format, quality):
         window = gdk.get_default_root_window()
         if not window:
             raise RuntimeError('Taking screenshot failed.')
@@ -391,13 +412,13 @@ class ScreenshotTaker(object):
                                   0, 0, 0, 0, width, height)
         if not pb:
             raise RuntimeError('Taking screenshot failed.')
-        quality_setting = self._gtk_quality(filetype, quality)
-        pb.save(path, filetype, quality_setting)
+        quality_setting = self._gtk_quality(image_format, quality)
+        pb.save(path, image_format, quality_setting)
 
     @staticmethod
     def _pil_quality_covert(quality):
         """
-        PIL has the image quality, on a scale from 1 (worst) to 95 (best)
+        PIL has the image quality on a scale from 1 (worst) to 95 (best)
         """
         if quality == 0:
             return 1
@@ -405,9 +426,9 @@ class ScreenshotTaker(object):
             return 95
         return quality
 
-    def _pil_screenshot(self, path, filetype, quality):
+    def _pil_screenshot(self, path, image_format, quality):
         quality = self._pil_quality_covert(quality)
-        if filetype.lower() == 'png':
+        if image_format == 'png':
             ImageGrab.grab().save(path, 'PNG', compress_level=quality)
         else:
             ImageGrab.grab().save(path, 'JPEG', quality=quality)
@@ -423,4 +444,4 @@ if __name__ == "__main__":
                  % os.path.basename(sys.argv[0]))
     path = sys.argv[1] if sys.argv[1] != 'test' else None
     module = sys.argv[2] if len(sys.argv) > 2 else None
-    ScreenshotTaker(module).test(path)
+    ScreenshotTaker(module).test(path, 'jpeg', 100)

--- a/src/robot/libraries/Screenshot.py
+++ b/src/robot/libraries/Screenshot.py
@@ -171,10 +171,7 @@ class Screenshot(object):
         ``image_format`` can be either jpg, jpeg or png.
 
         ``quality`` can take values in range [0, 100]. In case of JPEG format it can drastically reduce
-        the file size of the image. If the format is PNG, which uses lossless compression, the quality is
-        indirectly proportional with compression. As standard PNG compression is in range [0, 9], when
-        setting quality to 0 is equivalent to compression value 9 and when setting quality 100 is equivalent
-        to compression value 0.
+        the file size of the image.
 
         The ``quality`` argument does not work on OSX's screencapture, Jython or IronPython.
 

--- a/src/robot/libraries/Screenshot.py
+++ b/src/robot/libraries/Screenshot.py
@@ -153,7 +153,7 @@ class Screenshot(object):
         self._given_screenshot_dir = path
         return old
 
-    def take_screenshot(self, name="screenshot", width="800px"):
+    def take_screenshot(self, name="screenshot", width="800px", filetype="jpeg", quality=100):
         """Takes a screenshot in JPEG format and embeds it into the log file.
 
         Name of the file where the screenshot is stored is derived from the
@@ -178,7 +178,7 @@ class Screenshot(object):
 
         The path where the screenshot is saved is returned.
         """
-        path = self._save_screenshot(name)
+        path = self._save_screenshot(name, filetype, quality)
         self._embed_screenshot(path, width)
         return path
 
@@ -193,16 +193,16 @@ class Screenshot(object):
         self._link_screenshot(path)
         return path
 
-    def _save_screenshot(self, basename, directory=None):
+    def _save_screenshot(self, basename, filetype, quality, directory=None):
         path = self._get_screenshot_path(basename, directory)
-        return self._screenshot_to_file(path)
+        return self._screenshot_to_file(path, filetype, quality)
 
-    def _screenshot_to_file(self, path):
+    def _screenshot_to_file(self, path, filetype, quality):
         path = self._validate_screenshot_path(path)
         logger.debug('Using %s module/tool for taking screenshot.'
                      % self._screenshot_taker.module)
         try:
-            self._screenshot_taker(path)
+            self._screenshot_taker(path, filetype, quality)
         except:
             logger.warn('Taking screenshot failed: %s\n'
                         'Make sure tests are run with a physical or virtual '
@@ -246,8 +246,8 @@ class ScreenshotTaker(object):
         self.module = self._screenshot.__name__.split('_')[1]
         self._wx_app_reference = None
 
-    def __call__(self, path):
-        self._screenshot(path)
+    def __call__(self, path, filetype, quality):
+        self._screenshot(path, filetype, quality)
 
     def __nonzero__(self):
         return self.module != 'no'
@@ -356,7 +356,7 @@ class ScreenshotTaker(object):
         memory.SelectObject(wx.NullBitmap)
         bitmap.SaveFile(path, wx.BITMAP_TYPE_JPEG)
 
-    def _gtk_screenshot(self, path):
+    def _gtk_screenshot(self, path, filetype, quality):
         window = gdk.get_default_root_window()
         if not window:
             raise RuntimeError('Taking screenshot failed.')
@@ -366,7 +366,7 @@ class ScreenshotTaker(object):
                                   0, 0, 0, 0, width, height)
         if not pb:
             raise RuntimeError('Taking screenshot failed.')
-        pb.save(path, 'jpeg')
+        pb.save(path, filetype, {'quality': str(quality)})
 
     def _pil_screenshot(self, path):
         ImageGrab.grab().save(path, 'JPEG')

--- a/src/robot/libraries/Screenshot.py
+++ b/src/robot/libraries/Screenshot.py
@@ -195,7 +195,8 @@ class Screenshot(object):
 
     def _save_screenshot(self, basename, filetype, quality, directory=None):
         path = self._get_screenshot_path(basename, directory, filetype)
-        quality = self._convert_quality(filetype, quality)
+        if self._screenshot_taker.module != 'scrot':
+            quality = self._convert_quality(filetype, quality)
         return self._screenshot_to_file(path, filetype, quality)
 
     def _screenshot_to_file(self, path, filetype, quality):
@@ -343,11 +344,11 @@ class ScreenshotTaker(object):
     def _scrot(self):
         return os.sep == '/' and self._call('scrot', '--version') == 0
 
-    def _scrot_screenshot(self, path, quality):
+    def _scrot_screenshot(self, path, filetype, quality):
         if not path.endswith(('.jpg', '.jpeg', '.png')):
             raise RuntimeError("Scrot requires extension to be '.jpg', "
                                "'.jpeg' or '.png', got '%s'." % os.path.splitext(path)[1])
-        if self._call('scrot', '-q %s' % quality, '--silent', path) != 0:
+        if self._call('scrot', '-q %s' % quality, path) != 0:
             raise RuntimeError("Using 'scrot' failed.")
 
     def _wx_screenshot(self, path, filetype, quality):

--- a/src/robot/libraries/Screenshot.py
+++ b/src/robot/libraries/Screenshot.py
@@ -153,7 +153,7 @@ class Screenshot(object):
         self._given_screenshot_dir = path
         return old
 
-    def take_screenshot(self, name="screenshot", width="800px", image_format="jpeg", quality=100):
+    def take_screenshot(self, name="screenshot", width="800px", image_format="jpg", quality=100):
         """Takes a screenshot in JPEG or PNG format and embeds it into the log file.
 
         Name of the file where the screenshot is stored is derived from the
@@ -193,7 +193,7 @@ class Screenshot(object):
         self._embed_screenshot(path, width)
         return path
 
-    def take_screenshot_without_embedding(self, name="screenshot", image_format="jpeg", quality=100):
+    def take_screenshot_without_embedding(self, name="screenshot", image_format="jpg", quality=100):
         """Takes a screenshot and links it from the log file.
 
         This keyword is otherwise identical to `Take Screenshot` but the saved

--- a/src/robot/libraries/Screenshot.py
+++ b/src/robot/libraries/Screenshot.py
@@ -194,12 +194,8 @@ class Screenshot(object):
         return path
 
     def _save_screenshot(self, basename, filetype, quality, directory=None):
-<<<<<<< HEAD
         path = self._get_screenshot_path(basename, directory, filetype)
         quality = self._convert_quality(filetype, quality)
-=======
-        path = self._get_screenshot_path(basename, directory,filetype)
->>>>>>> 28fd4b9a9d1dd72087c13be61f1382ced847f933
         return self._screenshot_to_file(path, filetype, quality)
 
     def _screenshot_to_file(self, path, filetype, quality):
@@ -228,7 +224,7 @@ class Screenshot(object):
         index = 0
         while True:
             index += 1
-	    path = os.path.join(directory, "%s_%d.%s" % (basename, index, filetype))
+            path = os.path.join(directory, "%s_%d.%s" % (basename, index, filetype))
             if not os.path.exists(path):
                 return path
 
@@ -242,12 +238,13 @@ class Screenshot(object):
         logger.info("Screenshot saved to '<a href=\"%s\">%s</a>'."
                     % (link, path), html=True)
 
-    def _convert_quality(self, filetype, quality):
-	if filetype.lower() == 'png':
-	    if quality == 100:
-		return 0
-	    return 9 - (int(quality) / 11)
-	return int(quality)
+    @staticmethod
+    def _convert_quality(filetype, quality):
+        if filetype.lower() == 'png':
+            if quality == 100:
+                return 0
+            return 9 - (int(quality) / 11)
+        return int(quality)
 
 
 @py2to3
@@ -264,7 +261,7 @@ class ScreenshotTaker(object):
     def __nonzero__(self):
         return self.module != 'no'
 
-    def test(self, path=None):
+    def test(self, path=None, filetype=None, quality=None):
         if not self:
             print("Cannot take screenshots.")
             return False
@@ -274,7 +271,7 @@ class ScreenshotTaker(object):
             return True
         print("Taking test screenshot to '%s'." % path)
         try:
-            self(path)
+            self(path, filetype, quality)
         except:
             print("Failed: %s" % get_error_message())
             return False
@@ -341,22 +338,6 @@ class ScreenshotTaker(object):
                                    stderr=subprocess.STDOUT)
         except OSError:
             return -1
-    
-    def convert_quality(self, filetype, quality):
-	if filetype.lower() == 'png':
-	    if quality == 100:
-		return 0
-	    return 9 - (int(quality) / 11)
-	return quality	
-
-    def _gtk_quality(self, filetype, quality):
-	qualitydict ={}	
-	if filetype=="jpeg":
-	    qualitydict['quality']=str(self.convert_quality(filetype, quality))
-	    return qualitydict
-	elif filetype=="png":
-	    qualitydict['compression']=str(self.convert_quality(filetype, quality))
-	    return qualitydict
 
     @property
     def _scrot(self):
@@ -390,13 +371,14 @@ class ScreenshotTaker(object):
             image.SetOption(wx.IMAGE_OPTION_QUALITY, quality)
             image.SaveFile(path, wx.BITMAP_TYPE_JPEG)
 
-    def _gtk_quality(self, filetype, quality):
-    	quality_setting = {}
-    	if filetype.lower() == 'png':
-    	    quality_setting['compression']=str(quality)
+    @staticmethod
+    def _gtk_quality(filetype, quality):
+        quality_setting = {}
+        if filetype.lower() == 'png':
+            quality_setting['compression'] = str(quality)
         else:
-            quality_setting['quality']=str(quality)
-    	return quality_setting
+            quality_setting['quality'] = str(quality)
+        return quality_setting
 
     def _gtk_screenshot(self, path, filetype, quality):
         window = gdk.get_default_root_window()
@@ -408,15 +390,22 @@ class ScreenshotTaker(object):
                                   0, 0, 0, 0, width, height)
         if not pb:
             raise RuntimeError('Taking screenshot failed.')
-<<<<<<< HEAD
         quality_setting = self._gtk_quality(filetype, quality)
         pb.save(path, filetype, quality_setting)
-=======
-	
-        pb.save(path, filetype, self._gtk_quality(filetype, quality))
->>>>>>> 28fd4b9a9d1dd72087c13be61f1382ced847f933
+
+    @staticmethod
+    def _pil_quality_covert(quality):
+        """
+        PIL has the image quality, on a scale from 1 (worst) to 95 (best)
+        """
+        if quality == 0:
+            return 1
+        elif quality >= 95:
+            return 95
+        return quality
 
     def _pil_screenshot(self, path, filetype, quality):
+        quality = self._pil_quality_covert(quality)
         if filetype.lower() == 'png':
             ImageGrab.grab().save(path, 'PNG', compress_level=quality)
         else:

--- a/src/robot/libraries/Screenshot.py
+++ b/src/robot/libraries/Screenshot.py
@@ -329,13 +329,18 @@ class ScreenshotTaker(object):
                 return screenshot_taker
 
     def _java_screenshot(self, path, image_format, quality):
+        if quality != 100:
+            raise RuntimeError('Changing the image format quality is not supported '
+                               'on this platform.')
         size = Toolkit.getDefaultToolkit().getScreenSize()
         rectangle = Rectangle(0, 0, size.width, size.height)
         image = Robot().createScreenCapture(rectangle)
-        print('!!!!! %s    %s', image_format, path)
         ImageIO.write(image, image_format, File(path))
 
     def _cli_screenshot(self, path, image_format, quality):
+        if quality != 100:
+            raise RuntimeError('Changing the image format quality is not supported '
+                               'on this platform.')
         bmp = Bitmap(Screen.PrimaryScreen.Bounds.Width,
                      Screen.PrimaryScreen.Bounds.Height)
         graphics = Graphics.FromImage(bmp)
@@ -349,6 +354,9 @@ class ScreenshotTaker(object):
                 bmp.Save(path, Imaging.ImageFormat.Jpeg)
 
     def _osx_screenshot(self, path, image_format, quality):
+        if quality != 100:
+            raise RuntimeError('Changing the image format quality is not supported '
+                               'on this platform.')
         if image_format == 'jpeg':
             image_format = 'jpg'
         if self._call('screencapture', '-t', image_format, path) != 0:

--- a/src/robot/libraries/Screenshot.py
+++ b/src/robot/libraries/Screenshot.py
@@ -206,7 +206,7 @@ class Screenshot(object):
 
     def _save_screenshot(self, basename, image_format, quality, directory=None):
         path = self._get_screenshot_path(basename, directory, image_format)
-        if self._screenshot_taker.module != 'scrot':
+        if self._screenshot_taker.module not in ['cli', 'java', 'darwin', 'scrot']:
             quality = self._convert_quality(image_format, quality)
         return self._screenshot_to_file(path, image_format, quality)
 
@@ -259,7 +259,7 @@ class Screenshot(object):
         if image_format == 'png':
             if quality == 100:
                 return 0
-            return 9 - (int(quality) / 11)
+            return int(9 - (int(quality) / 11))
         return int(quality)
 
 
@@ -329,7 +329,7 @@ class ScreenshotTaker(object):
                 return screenshot_taker
 
     def _java_screenshot(self, path, image_format, quality):
-        if quality != 100:
+        if int(quality) != 100:
             raise RuntimeError('Changing the image format quality is not supported '
                                'on this platform.')
         size = Toolkit.getDefaultToolkit().getScreenSize()
@@ -338,7 +338,7 @@ class ScreenshotTaker(object):
         ImageIO.write(image, image_format, File(path))
 
     def _cli_screenshot(self, path, image_format, quality):
-        if quality != 100:
+        if int(quality) != 100:
             raise RuntimeError('Changing the image format quality is not supported '
                                'on this platform.')
         bmp = Bitmap(Screen.PrimaryScreen.Bounds.Width,
@@ -354,7 +354,7 @@ class ScreenshotTaker(object):
                 bmp.Save(path, Imaging.ImageFormat.Jpeg)
 
     def _osx_screenshot(self, path, image_format, quality):
-        if quality != 100:
+        if int(quality) != 100:
             raise RuntimeError('Changing the image format quality is not supported '
                                'on this platform.')
         if image_format == 'jpeg':
@@ -423,19 +423,7 @@ class ScreenshotTaker(object):
         quality_setting = self._gtk_quality(image_format, quality)
         pb.save(path, image_format, quality_setting)
 
-    @staticmethod
-    def _pil_quality_covert(quality):
-        """
-        PIL has the image quality on a scale from 1 (worst) to 95 (best)
-        """
-        if quality == 0:
-            return 1
-        elif quality >= 95:
-            return 95
-        return quality
-
     def _pil_screenshot(self, path, image_format, quality):
-        quality = self._pil_quality_covert(quality)
         if image_format == 'png':
             ImageGrab.grab().save(path, 'PNG', compress_level=quality)
         else:
@@ -452,4 +440,4 @@ if __name__ == "__main__":
                  % os.path.basename(sys.argv[0]))
     path = sys.argv[1] if sys.argv[1] != 'test' else None
     module = sys.argv[2] if len(sys.argv) > 2 else None
-    ScreenshotTaker(module).test(path, 'jpeg', 100)
+    ScreenshotTaker(module).test(path, 'jpg', 100)


### PR DESCRIPTION
PR for https://github.com/robotframework/robotframework/issues/2835.

Added two arguments to `Take Screenshot` and `Take Screenshot Without Embedding` keywords: `image_format` [jpg, jpeg, png] and `quality` [0-100]. The different approach between PNG and JPEG compression/quality is handled internally and the end user would not have to care about that.

The quality can only be customized when using gtk, wx, pil and scrot. Unfortunately it does not work 'out of the box' with Jython, IronPython and OSX. 