### PR TITLE
Named-only arguments in dictionary error tests

### DIFF
--- a/atest/testdata/standard_libraries/collections/dictionary.robot
+++ b/atest/testdata/standard_libraries/collections/dictionary.robot
@@ -235,28 +235,28 @@ Pop From Dictionary With Default
 Check invalid dictionary argument errors
     [Template]    Validate invalid argument error
     Copy dictionary
-    Dictionary Should Contain Item             string    1    I'm not a dict, I'm string.    a    b
-    Dictionaries Should Be Equal               string    1    I'm not a dict, I'm string.    ${D2}
-    Dictionaries Should Be Equal               string    2    ${D2}    I'm not a dict, I'm string.
-    Dictionary Should Contain Key              string    1    I'm not a dict, I'm string.    a
-    Dictionary Should Contain Sub Dictionary   string    1    I'm not a dict, I'm string.    ${D2}
-    Dictionary Should Contain Sub Dictionary   string    2    ${D2}    I'm not a dict, I'm string.
-    Dictionary Should Contain Value            string    1    I'm not a dict, I'm string.    a
-    Dictionary Should Not Contain Key          string    1    I'm not a dict, I'm string.    a
-    Dictionary Should Not Contain Value        string    1    I'm not a dict, I'm string.    a
+    Dictionary Should Contain Item             a    b
+    Dictionaries Should Be Equal               ${D2}
+    Dictionaries Should Be Equal               I'm not a dict, I'm string.    argument=${D2}    position=2
+    Dictionary Should Contain Key              a
+    Dictionary Should Contain Sub Dictionary   ${D2}
+    Dictionary Should Contain Sub Dictionary   I'm not a dict, I'm string.    argument=${D2}    position=2
+    Dictionary Should Contain Value            a
+    Dictionary Should Not Contain Key          a
+    Dictionary Should Not Contain Value        a
     Get Dictionary Items
     Get Dictionary Keys
     Get Dictionary Values
-    Get from dictionary                        string    1    I'm not a dict, I'm string.    a
-    Keep in dictionary                         string    1    I'm not a dict, I'm string.    a
+    Get from dictionary                        a
+    Keep in dictionary                         a
     Log Dictionary
-    Pop From Dictionary                        string    1    I'm not a dict, I'm string.    a
-    Remove From Dictionary                     string    1    I'm not a dict, I'm string.    a
-    Set To Dictionary                          string    1    I'm not a dict, I'm string.    a    b
+    Pop From Dictionary                        a
+    Remove From Dictionary                     a
+    Set To Dictionary                          a    b
 
 *** Keywords ***
 Validate invalid argument error
-    [Arguments]  ${keyword}    ${type}=string    ${position}=1    ${argument}=I'm not a dict, I'm a string.    @{args}
+    [Arguments]  ${keyword}    @{args}    ${argument}=I'm not a dict, I'm a string.    ${type}=string    ${position}=1
     Run keyword and expect error
     ...    TypeError: Expected argument ${position} to be a dictionary or dictionary-like, got ${type} instead.
     ...    ${keyword}    ${argument}    @{args}

--- a/atest/testdata/standard_libraries/collections/dictionary.robot
+++ b/atest/testdata/standard_libraries/collections/dictionary.robot
@@ -235,28 +235,28 @@ Pop From Dictionary With Default
 Check invalid dictionary argument errors
     [Template]    Validate invalid argument error
     Copy dictionary
-    Dictionary Should Contain Item             a    b
-    Dictionaries Should Be Equal               ${D2}
-    Dictionaries Should Be Equal               I'm not a dict, I'm string.    argument=${D2}    position=2
-    Dictionary Should Contain Key              a
-    Dictionary Should Contain Sub Dictionary   ${D2}
-    Dictionary Should Contain Sub Dictionary   I'm not a dict, I'm string.    argument=${D2}    position=2
-    Dictionary Should Contain Value            a
-    Dictionary Should Not Contain Key          a
-    Dictionary Should Not Contain Value        a
+    Dictionary Should Contain Item             I'm not a dict, I'm string.    a    b
+    Dictionaries Should Be Equal               I'm not a dict, I'm string.    ${D2}
+    Dictionaries Should Be Equal               ${D2}    I'm not a dict, I'm string.    position=2
+    Dictionary Should Contain Key              I'm not a dict, I'm string.    a
+    Dictionary Should Contain Sub Dictionary   I'm not a dict, I'm string.    ${D2}
+    Dictionary Should Contain Sub Dictionary   ${D2}    I'm not a dict, I'm string.    position=2
+    Dictionary Should Contain Value            I'm not a dict, I'm string.    a
+    Dictionary Should Not Contain Key          I'm not a dict, I'm string.    a
+    Dictionary Should Not Contain Value        I'm not a dict, I'm string.    a
     Get Dictionary Items
     Get Dictionary Keys
     Get Dictionary Values
-    Get from dictionary                        a
-    Keep in dictionary                         a
+    Get from dictionary                        I'm not a dict, I'm string.    a
+    Keep in dictionary                         I'm not a dict, I'm string.    a
     Log Dictionary
-    Pop From Dictionary                        a
-    Remove From Dictionary                     a
-    Set To Dictionary                          a    b
+    Pop From Dictionary                        I'm not a dict, I'm string.    a
+    Remove From Dictionary                     I'm not a dict, I'm string.    a
+    Set To Dictionary                          I'm not a dict, I'm string.    a    b
 
 *** Keywords ***
 Validate invalid argument error
-    [Arguments]  ${keyword}    @{args}    ${argument}=I'm not a dict, I'm a string.    ${type}=string    ${position}=1
+    [Arguments]  ${keyword}    ${argument}=I'm not a dict, I'm a string.    @{args}    ${type}=string    ${position}=1
     Run keyword and expect error
     ...    TypeError: Expected argument ${position} to be a dictionary or dictionary-like, got ${type} instead.
     ...    ${keyword}    ${argument}    @{args}

--- a/atest/testdata/standard_libraries/collections/list.robot
+++ b/atest/testdata/standard_libraries/collections/list.robot
@@ -553,38 +553,38 @@ List Should Not Contain Value, Value Found And Own Error Message Glob
 
 Check List Error
     [Template]    Validate invalid argument error
-    Append to list                        string    1    I am a string. Not a list.    xyz
-    Combine Lists                         string    1    I am a string. Not a list.    I am a string. Not a list.
-    Combine Lists                         string    2    ${L0}    I am a string. Not a list.
-    Combine Lists                         string    1    I am a string. Not a list.    ${L0}
+    Append to list                        xyz
+    Combine Lists                         I am a string. Not a list.
+    Combine Lists                         I am a string. Not a list.    argument=${L0}    position=2
+    Combine Lists                         ${L0}
     Copy list
-    Count values in list                  string    1    I am a string. Not a list.    xyz
-    Get from list                         string    1    I am a string. Not a list.    0
-    Get Index From List                   string    1    I am a string. Not a list.    a
-    Get Match Count                       string    1    I am a string. Not a list.    abc
-    Get Matches                           string    1    I am a string. Not a list.    abc
+    Count values in list                  xyz
+    Get from list                         0
+    Get Index From List                   a
+    Get Match Count                       abc
+    Get Matches                           abc
     Get slice from list
-    Insert into list                      string    1    I am a string. Not a list.    0    a
-    List Should Contain Sub List          string    1    I am a string. Not a list.    ${L0}
-    List Should Contain Sub List          string    2    ${L0}    I am a string. Not a list.
-    List should contain value             string    1    I am a string. Not a list.    a
-    List Should Not Contain Duplicates    string    1    xyz
-    List Should Not Contain Value         string    1    I am a string. Not a list.    x
-    Lists Should Be Equal                 string    1    I am a string. Not a list.    ${L0}
-    Lists Should Be Equal                 string    2    ${L0}    I am a string. Not a list.
+    Insert into list                      0    a
+    List Should Contain Sub List          ${L0}
+    List Should Contain Sub List          I am a string. Not a list.    argument=${L0}    position=2
+    List should contain value             a
+    List Should Not Contain Duplicates    argument=xyz
+    List Should Not Contain Value         x
+    Lists Should Be Equal                 ${L0}
+    Lists Should Be Equal                 I am a string. Not a list.    argument=${L0}    position=2
     Log List
     Remove Duplicates
-    Remove From List                      string    1    I am a string. Not a list.    0
-    Remove Values From List               string    1    I am a string. Not a list.    a
+    Remove From List                      0
+    Remove Values From List               a
     Reverse List
-    Set List Value                        string    1    I am a string. Not a list.    0    a
-    Should Contain Match                  string    1    I am a string. Not a list.    a
-    Should Not Contain Match              string    1    I am a string. Not a list.    xyz
+    Set List Value                        0    a
+    Should Contain Match                  a
+    Should Not Contain Match              xyz
     Sort List
 
 *** Keywords ***
 Validate invalid argument error
-    [Arguments]    ${keyword}    ${type}=string    ${position}=1    ${argument}=I'm not a list, I'm a string.    @{args}
+    [Arguments]    ${keyword}    @{args}    ${argument}=I'm not a list, I'm a string.    ${type}=string    ${position}=1
     Run keyword and expect error
     ...    TypeError: Expected argument ${position} to be a list or list-like, got ${type} instead.
     ...    ${keyword}    ${argument}    @{args}

--- a/atest/testdata/standard_libraries/collections/list.robot
+++ b/atest/testdata/standard_libraries/collections/list.robot
@@ -555,36 +555,36 @@ Check List Error
     [Template]    Validate invalid argument error
     Append to list                        xyz
     Combine Lists                         I am a string. Not a list.
-    Combine Lists                         I am a string. Not a list.    argument=${L0}    position=2
-    Combine Lists                         ${L0}
+    Combine Lists                         ${L0}    I am a string. Not a list.    position=2
+    Combine Lists                         I am a string. Not a list.    ${L0}
     Copy list
-    Count values in list                  xyz
-    Get from list                         0
-    Get Index From List                   a
-    Get Match Count                       abc
-    Get Matches                           abc
+    Count values in list                  I am a string. Not a list.    xyz
+    Get from list                         I am a string. Not a list.    0
+    Get Index From List                   I am a string. Not a list.    a
+    Get Match Count                       I am a string. Not a list.    abc
+    Get Matches                           I am a string. Not a list.    abc
     Get slice from list
-    Insert into list                      0    a
-    List Should Contain Sub List          ${L0}
-    List Should Contain Sub List          I am a string. Not a list.    argument=${L0}    position=2
-    List should contain value             a
-    List Should Not Contain Duplicates    argument=xyz
-    List Should Not Contain Value         x
-    Lists Should Be Equal                 ${L0}
-    Lists Should Be Equal                 I am a string. Not a list.    argument=${L0}    position=2
+    Insert into list                      I am a string. Not a list.    0    a
+    List Should Contain Sub List          I am a string. Not a list.    ${L0}
+    List Should Contain Sub List          ${L0}    I am a string. Not a list.    position=2
+    List should contain value             I am a string. Not a list.    a
+    List Should Not Contain Duplicates    xyz
+    List Should Not Contain Value         I am a string. Not a list.    x
+    Lists Should Be Equal                 I am a string. Not a list.    ${L0}
+    Lists Should Be Equal                 ${L0}    I am a string. Not a list.    position=2
     Log List
     Remove Duplicates
-    Remove From List                      0
-    Remove Values From List               a
+    Remove From List                      I am a string. Not a list.    0
+    Remove Values From List               I am a string. Not a list.    a
     Reverse List
-    Set List Value                        0    a
-    Should Contain Match                  a
-    Should Not Contain Match              xyz
+    Set List Value                        I am a string. Not a list.    0    a
+    Should Contain Match                  I am a string. Not a list.    a
+    Should Not Contain Match              I am a string. Not a list.    xyz
     Sort List
 
 *** Keywords ***
 Validate invalid argument error
-    [Arguments]    ${keyword}    @{args}    ${argument}=I'm not a list, I'm a string.    ${type}=string    ${position}=1
+    [Arguments]    ${keyword}    ${argument}=I'm not a list, I'm a string.    @{args}    ${type}=string    ${position}=1
     Run keyword and expect error
     ...    TypeError: Expected argument ${position} to be a list or list-like, got ${type} instead.
     ...    ${keyword}    ${argument}    @{args}


### PR DESCRIPTION
Changing list and dictionary tests for argument error to use named-only arguments.