### PR TITLE
Add normalize path to USER env. var in path_expansion test case.

### DIFF
--- a/atest/testdata/standard_libraries/operating_system/path_expansion.robot
+++ b/atest/testdata/standard_libraries/operating_system/path_expansion.robot
@@ -25,4 +25,5 @@ Get OS Independent Home Path
     ${homepath}=    Get Environment Variable    HOMEPATH    NotSet
     ${homedrive}=    Get Environment Variable    HOMEDRIVE    NotSet
     ${home}=    Get Environment Variable    HOME    ${homedrive}${homepath}
+    ${home}=    Normalize Path    ${home}
     [Return]    ${home}


### PR DESCRIPTION
Without this change, there were two test failures on Fedora Linux 28.