### PR TITLE
Adds enum support to the typeconverter.

### DIFF
--- a/atest/testdata/keywords/type_conversion/PythonAnnotations.py
+++ b/atest/testdata/keywords/type_conversion/PythonAnnotations.py
@@ -1,3 +1,10 @@
+from enum import Enum
+
+
+class Foo(Enum):
+    BAR = 1
+
+
 def integer(argument: int, expected=None):
     _validate_type(argument, expected)
 
@@ -23,6 +30,10 @@ def dictionary(argument: dict, expected=None):
 
 
 def set_(argument: set, expected=None):
+    _validate_type(argument, expected)
+
+
+def enum_(argument: Foo, expected=None):
     _validate_type(argument, expected)
 
 

--- a/atest/testdata/keywords/type_conversion/python_annotations.robot
+++ b/atest/testdata/keywords/type_conversion/python_annotations.robot
@@ -99,6 +99,14 @@ String None is converted to None object
     Dictionary
     Set
 
+Enum
+    Enum          BAR                 Foo.BAR
+
+Invalid Enum
+    Run Keyword And Expect Error
+    ...    ValueError: Argument 'argument' cannot be converted to Foo, got 'foobar'.
+    ...    Enum    foobar
+
 *** Keywords ***
 Conversion Should Fail
     [Arguments]    ${kw}    ${arg}

--- a/atest/testdata/keywords/type_conversion/python_annotations.robot
+++ b/atest/testdata/keywords/type_conversion/python_annotations.robot
@@ -103,16 +103,15 @@ Enum
     Enum          BAR                 Foo.BAR
 
 Invalid Enum
-    Run Keyword And Expect Error
-    ...    ValueError: Argument 'argument' cannot be converted to Foo, got 'foobar'.
-    ...    Enum    foobar
+    [Template]    Conversion Should Fail
+    Enum          foobar    type=Foo
 
 *** Keywords ***
 Conversion Should Fail
-    [Arguments]    ${kw}    ${arg}
+    [Arguments]    ${kw}    ${arg}    ${type}=${kw.lower()}
     ${error} =    Run Keyword And Expect Error    *    ${kw}    ${arg}
     Should Be Equal    ${error}
-    ...    ValueError: Argument 'argument' cannot be converted to ${kw.lower()}, got '${arg}'.
+    ...    ValueError: Argument 'argument' cannot be converted to ${type}, got '${arg}'.
 
 Non-string is not converted
     [Arguments]    ${kw}

--- a/src/robot/running/arguments/typeconverter.py
+++ b/src/robot/running/arguments/typeconverter.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 
 from ast import literal_eval
+from enum import EnumMeta
 
 from robot.utils import is_string
 
@@ -39,12 +40,17 @@ class TypeConverter(object):
     def _convert(self, name, value):
         if name not in self._argspec.types or not is_string(value):
             return value
+        if value.upper() == 'NONE':
+            return None
         type_ = self._argspec.types[name]
+        if isinstance(type_, EnumMeta):
+            try:
+                return type_[value]
+            except KeyError:
+                self._raise_convert_failed(name, type_.__name__, value)
         converter = self._converters.get(type_)
         if not converter:
             return value
-        if value.upper() == 'NONE':
-            return None
         return converter(name, value)
 
     def _convert_int(self, name, value):


### PR DESCRIPTION
This PR adds Enum support to the typeconverter and relevant tests.

Because the `enum` I added for the test starts with an upper case character I wasn't able to use the existing template for the expected failure.