### PR TITLE
Changed _import_by_path to use path.remove() instead of path.pop()

### DIFF
--- a/src/robot/utils/importer.py
+++ b/src/robot/utils/importer.py
@@ -243,7 +243,7 @@ class ByPathImporter(_Importer):
         try:
             return self._import(module_name)
         finally:
-            sys.path.pop(0)
+            sys.path.remove(module_dir)
 
 
 class NonDottedImporter(_Importer):


### PR DESCRIPTION
Currently, if robot imports a module by path, and that module prepends to sys.path, robot will pop the incorrect path from sys.path. I have changed this function to use remove() instead to fix this issue.