### PR TITLE
Support deep copies with `Copy List` and `Copy Dictionary` #2850

### DIFF
--- a/atest/testdata/standard_libraries/collections/dictionary.robot
+++ b/atest/testdata/standard_libraries/collections/dictionary.robot
@@ -38,6 +38,10 @@ Copy Dictionary
     Remove From Dictionary    ${copy}    a    ${3}
     Compare To Expected String    ${copy}    {'b':2}
     Compare To Expected String    ${D3}    {'a': 1, 'b': 2, 3: None}
+    ${inner_dict} =    Create Dictionary    c=${D4C}
+    ${deep_copy} =    Copy Dictionary    ${inner_dict}    deepcopy=${True}
+    Set To Dictionary    ${D4C}    d=3
+    Compare To Expected String    ${deep_copy}    {'c':{'a': '1', 'b': '2'}}
 
 Get Dictionary Keys
     ${keys} =    Get Dictionary Keys    ${D3B}
@@ -274,5 +278,7 @@ Create Dictionaries For Testing
     Set Test Variable    \${D3}
     ${D3B}    Create Dictionary    a=${1}    b=${2}    c=
     Set Test Variable    \${D3B}
+    ${D4C} =    Create Dictionary    a=1    b=2
+    Set Test Variable    \${D4C}
     ${BIG} =    Evaluate    {'a': 1, 'B': 2, 3: [42], 'd': '', '': 'e', (): {}}
     Set Test Variable    \${BIG}

--- a/atest/testdata/standard_libraries/collections/list.robot
+++ b/atest/testdata/standard_libraries/collections/list.robot
@@ -137,6 +137,10 @@ Copy List
     ${copy} =    Copy List    ${L2}
     Append To List    ${L2}    1    2    3
     Compare To Expected String    ${copy}    ['1', 2]
+    ${inner_list} =    Create List    ${6}   ${L5C}
+    ${deep_copy} =   Copy List    ${inner_list}    deepcopy=${True}
+    Append To List    ${L5C}    7
+    Compare To Expected String    ${deep_copy}    [6, ['4', 5]]
 
 Reserve List
     Reverse List    ${LONG}
@@ -602,6 +606,8 @@ Create Lists For The Tests
     Set Test Variable    \${L3B}
     ${L4} =    Create List    41    ${42}    43    44
     Set Test Variable    \${L4}
+    ${L5C} =    Create List   4   ${5}
+    Set Test Variable    \${L5C}
     ${LONG} =    Combine Lists    ${L1}    ${L2}    ${L4}    ${L2}
     Set Test Variable    \${LONG}
     ${STRINGS} =    Create List    a    B    b    wOrD    WOrd

--- a/src/robot/libraries/Collections.py
+++ b/src/robot/libraries/Collections.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import copy
 from robot.api import logger
 from robot.utils import (is_dict_like, is_list_like, is_number, is_string, is_truthy, plural_or_not,
                          seq2str, seq2str2, type_name, unic, Matcher)
@@ -261,13 +262,17 @@ class _List(object):
         except ValueError:
             return -1
 
-    def copy_list(self, list_):
+    def copy_list(self, list_, deepcopy=False):
         """Returns a copy of the given list.
 
         The given list is never altered by this keyword.
+
+        The type of the copy can be altered by deepcopy argument:
+        | True | Return a deep copy of the list |
+        | False | Return a shallow copy of the list |
         """
         self._validate_list(list_)
-        return list_[:]
+        return copy.deepcopy(list_) if deepcopy else list_[:]
 
     def reverse_list(self, list_):
         """Reverses the given list in place.
@@ -556,13 +561,17 @@ class _Dictionary(object):
         remove_keys = [k for k in dictionary if k not in keys]
         self.remove_from_dictionary(dictionary, *remove_keys)
 
-    def copy_dictionary(self, dictionary):
+    def copy_dictionary(self, dictionary, deepcopy=False):
         """Returns a copy of the given dictionary.
 
         The given dictionary is never altered by this keyword.
+
+        The type of the copy can be altered by deepcopy argument:
+        | True | Return a deep copy of the list |
+        | False | Return a shallow copy of the list |
         """
         self._validate_dictionary(dictionary)
-        return dictionary.copy()
+        return copy.deepcopy(dictionary) if deepcopy else dictionary.copy()
 
     def get_dictionary_keys(self, dictionary):
         """Returns keys of the given ``dictionary``.


### PR DESCRIPTION
Implemented deepcopy optional arguments for `Copy List` and `Copy Dictionary`. 

Acceptance tests also extened to test deepcopy argument