### PR TITLE
libraries/Telnet: fix window size by unifying order of rows and columns

### DIFF
--- a/src/robot/libraries/Telnet.py
+++ b/src/robot/libraries/Telnet.py
@@ -429,7 +429,7 @@ class Telnet(object):
             return int(cols), int(rows)
         except ValueError:
             raise ValueError("Invalid window size '%s'. Should be "
-                             "<rows>x<columns>." % window_size)
+                             "<columns>x<row>." % window_size)
 
     def _get_connection(self, *args):
         """Can be overridden to use a custom connection."""
@@ -1165,11 +1165,11 @@ class TelnetConnection(telnetlib.Telnet):
 class TerminalEmulator(object):
 
     def __init__(self, window_size=None, newline="\r\n"):
-        self._rows, self._columns = window_size or (200, 200)
+        self._columns, self._rows = window_size or (200, 200)
         self._newline = newline
         self._stream = pyte.Stream()
-        self._screen = pyte.HistoryScreen(self._rows,
-                                          self._columns,
+        self._screen = pyte.HistoryScreen(self._columns,
+                                          self._rows,
                                           history=100000)
         self._stream.attach(self._screen)
         self._buffer = ''


### PR DESCRIPTION
This patch fix inconsistency in row and column parameter across Telnet
library. Without this patch users following documentation cannot
correctly set terminal emulator, because window_size is interpreted in
incorrect order.

Signed-off-by: Piotr Król <piotr.krol@3mdeb.com>