### PR TITLE
Fixed issue #2952 - signal handler registered outside Python causes e…

### DIFF
--- a/src/robot/running/signalhandler.py
+++ b/src/robot/running/signalhandler.py
@@ -56,8 +56,8 @@ class _StopSignalMonitor(object):
 
     def __exit__(self, *exc_info):
         if self._can_register_signal:
-            signal.signal(signal.SIGINT, self._orig_sigint)
-            signal.signal(signal.SIGTERM, self._orig_sigterm)
+            signal.signal(signal.SIGINT, self._orig_sigint or signal.SIG_DFL)
+            signal.signal(signal.SIGTERM, self._orig_sigterm or signal.SIG_DFL)
 
     @property
     def _can_register_signal(self):

--- a/utest/running/test_signalhandler.py
+++ b/utest/running/test_signalhandler.py
@@ -115,18 +115,13 @@ class TestRestoringOriginalHandlers(unittest.TestCase):
         If a signal isn't registered within Python, signal.getsignal() returns None.
         This tests to make sure _StopSignalMonitor.__exit__ can handle that.
         """
-        try:
-            with _StopSignalMonitor() as monitor:
-                assert_equal(self.get_int(), monitor)
-                assert_equal(self.get_term(), monitor)
-                monitor._orig_sigint = None
-                monitor._orig_sigterm = None
-                assert_equal(None, monitor._orig_sigint)
-                assert_equal(None, monitor._orig_sigterm)
-        except TypeError:
-            raise AssertionError
-        else:
-            pass
+        with _StopSignalMonitor() as monitor:
+            assert_equal(self.get_int(), monitor)
+            assert_equal(self.get_term(), monitor)
+            monitor._orig_sigint = None
+            monitor._orig_sigterm = None
+            assert_equal(None, monitor._orig_sigint)
+            assert_equal(None, monitor._orig_sigterm)
         assert_equal(self.get_int(), signal.SIG_DFL)
         assert_equal(self.get_term(), signal.SIG_DFL)
 

--- a/utest/running/test_signalhandler.py
+++ b/utest/running/test_signalhandler.py
@@ -110,6 +110,26 @@ class TestRestoringOriginalHandlers(unittest.TestCase):
         assert_equal(self.get_int(), self.orig_int)
         assert_equal(self.get_term(), self.orig_term)
 
+    def test_registered_outside_python(self):
+        """
+        If a signal isn't registered within Python, signal.getsignal() returns None.
+        This tests to make sure _StopSignalMonitor.__exit__ can handle that.
+        """
+        try:
+            with _StopSignalMonitor() as monitor:
+                assert_equal(self.get_int(), monitor)
+                assert_equal(self.get_term(), monitor)
+                monitor._orig_sigint = None
+                monitor._orig_sigterm = None
+                assert_equal(None, monitor._orig_sigint)
+                assert_equal(None, monitor._orig_sigterm)
+        except TypeError:
+            raise AssertionError
+        else:
+            pass
+        assert_equal(self.get_int(), signal.SIG_DFL)
+        assert_equal(self.get_term(), signal.SIG_DFL)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixing issue #2952

For the solution, I also went with restoring signal.SIG_DFL, not signal.SIG_IGN when self._orig_sigint/sigterm are 'None'.

I couldn't figure out a nice way to register a signal outside of Python during test execution so I went with mocking for the test. I created an instance of the _StopSignalMonitor then set self._orig_sigint/sigterm to 'None' as if they had been set to 'None' in __enter__. On __exit__, we should no longer get the TypeError from signal.signal().

 If there is a better and/or cleaner way to do this, I'd love to know!
