### PR TITLE
add time attribute into the testsuite element

### DIFF
--- a/src/robot/reporting/xunitwriter.py
+++ b/src/robot/reporting/xunitwriter.py
@@ -51,7 +51,8 @@ class XUnitFileWriter(ResultVisitor):
                  'tests': tests,
                  'errors': '0',
                  'failures': failures,
-                 'skipped': skipped}
+                 'skipped': skipped,
+                 'time': self._time_as_seconds(suite.elapsedtime)}
         self._writer.start('testsuite', attrs)
 
     def _get_stats(self, statistics):


### PR DESCRIPTION
Add `time` attribute into the `<testsuite>` element of the Xunit output file.