### PR TITLE
Iterate through list of connections to return right one

### DIFF
--- a/src/robot/utils/connectioncache.py
+++ b/src/robot/utils/connectioncache.py
@@ -102,7 +102,8 @@ class ConnectionCache(object):
         except ValueError:
             raise RuntimeError("Non-existing index or alias '%s'."
                                % alias_or_index)
-        return self._connections[index-1]
+        return next((x for x in self._connections
+                             if x.config._config['index'].value == index), None)
 
     __getitem__ = get_connection
 
@@ -154,8 +155,6 @@ class ConnectionCache(object):
         try:
             index = int(index)
         except TypeError:
-            raise ValueError
-        if not 0 < index <= len(self._connections):
             raise ValueError
         return index
 


### PR DESCRIPTION
This is an attempt to solve a new bug seen in SSHLibrary
3.2.0. Issue filed here:

  https://github.com/robotframework/SSHLibrary/issues/279

Signed-off-by: Jamo Luhrsen <jluhrsen@redhat.com>