### PR TITLE
Adding sort option to Get Dictionary Keys Keyword

### DIFF
--- a/atest/robot/standard_libraries/collections/dictionary.robot
+++ b/atest/robot/standard_libraries/collections/dictionary.robot
@@ -34,7 +34,10 @@ Shallow Copy Dictionary
 Deep Copy Dictionary
     Check Test Case    ${TEST NAME}
 
-Get Dictionary Keys
+Get Dictionary Keys Sorted
+    Check Test Case    ${TEST NAME}
+
+Get Dictionary Keys Unsorted
     Check Test Case    ${TEST NAME}
 
 Get Dictionary Values

--- a/atest/testdata/standard_libraries/collections/dictionary.robot
+++ b/atest/testdata/standard_libraries/collections/dictionary.robot
@@ -56,9 +56,13 @@ Deep Copy Dictionary
     Should Be Equal    ${a['x1']['x2']}    2
     Should Be Equal    ${b['x1']['x2']}    3
 
-Get Dictionary Keys
+Get Dictionary Keys Sorted
     ${keys} =    Get Dictionary Keys    ${D3B}
     Compare To Expected String    ${keys}    ['a', 'b', 'c']
+
+Get Dictionary Keys Unsorted
+    ${keys} =    Get Dictionary Keys    ${D3B}    sort_keys=${False}
+    Compare To Expected String    ${keys}    ['b', 'a', 'c']
 
 Get Dictionary Values
     ${values} =    Get Dictionary Values    ${D3B}
@@ -289,7 +293,7 @@ Create Dictionaries For Testing
     Set Test Variable    \${D2B}
     ${D3}    Create Dictionary    a=${1}    b=${2}    ${3}=${None}
     Set Test Variable    \${D3}
-    ${D3B}    Create Dictionary    a=${1}    b=${2}    c=
+    ${D3B}    Create Dictionary    b=${2}    a=${1}    c=
     Set Test Variable    \${D3B}
     ${BIG} =    Evaluate    {'a': 1, 'B': 2, 3: [42], 'd': '', '': 'e', (): {}}
     Set Test Variable    \${BIG}

--- a/src/robot/libraries/Collections.py
+++ b/src/robot/libraries/Collections.py
@@ -576,22 +576,31 @@ class _Dictionary(object):
             return copy.deepcopy(dictionary)
         return dictionary.copy()
 
-    def get_dictionary_keys(self, dictionary):
+    def get_dictionary_keys(self, dictionary, sort_keys=True):
         """Returns keys of the given ``dictionary``.
 
-        If keys are sortable, they are returned in sorted order. The given
-        ``dictionary`` is never altered by this keyword.
+        If the optional value sort_keys is set to False, the returned
+        keys are in order they appear in dictionary.
+        New option in Robot Framework 3.1.2.
+        
+        The given ``dictionary`` is never altered by this keyword.
 
         Example:
         | ${keys} = | Get Dictionary Keys | ${D3} |
         =>
         | ${keys} = ['a', 'b', 'c']
+
+        | ${keys} = | Get Dictionary Keys | ${D3} | sort_keys=${False}
+        =>
+        | ${keys} = ['b', 'a', 'c']
         """
         self._validate_dictionary(dictionary)
-        # TODO: Possibility to disable sorting. Can be handy with OrderedDicts.
         keys = dictionary.keys()
         try:
-            return sorted(keys)
+            if sort_keys:
+                return sorted(keys)
+            else:
+                return list(keys)
         except TypeError:
             return list(keys)
 


### PR DESCRIPTION
Adding option of returning dictionary keys as they appear in dictionary, instead of sorted.