### PR TITLE
fix #3122: support of PyYaml 5.1

### DIFF
--- a/doc/userguide/src/CreatingTestData/ResourceAndVariableFiles.rst
+++ b/doc/userguide/src/CreatingTestData/ResourceAndVariableFiles.rst
@@ -566,8 +566,8 @@ The following example demonstrates a simple YAML file:
       with spaces: kolme
 
 .. note:: Using YAML files with Robot Framework requires `PyYAML
-          <http://pyyaml.org>`_ module to be installed. If you have
-          pip_ installed, you can install it simply by running
+          <http://pyyaml.org>`_ module to be installed in version 5.1. 
+          If you have pip_ installed, you can install it simply by running
           `pip install pyyaml`.
 
           YAML support is new in Robot Framework 2.9. Starting from

--- a/src/robot/variables/filesetter.py
+++ b/src/robot/variables/filesetter.py
@@ -74,7 +74,7 @@ class YamlImporter(object):
 
     def _import(self, path):
         with io.open(path, encoding='UTF-8') as stream:
-            variables = yaml.load(stream)
+            variables = yaml.full_load(stream)
         if not is_dict_like(variables):
             raise DataError('YAML variable file must be a mapping, got %s.'
                             % type_name(variables))

--- a/src/robot/variables/filesetter.py
+++ b/src/robot/variables/filesetter.py
@@ -74,7 +74,7 @@ class YamlImporter(object):
 
     def _import(self, path):
         with io.open(path, encoding='UTF-8') as stream:
-            variables = yaml.full_load(stream)
+            variables = yaml.load(stream) if yaml.__version__[0]=='3' else yaml.full_load(stream)  #pyyaml 3.x is from 2006
         if not is_dict_like(variables):
             raise DataError('YAML variable file must be a mapping, got %s.'
                             % type_name(variables))

--- a/tasks.py
+++ b/tasks.py
@@ -169,7 +169,7 @@ def init_labels(ctx, username=None, password=None):
 
 
 @task
-def jar(ctx, jython_version='2.7.0', pyyaml_version='3.11', remove_dist=False):
+def jar(ctx, jython_version='2.7.0', pyyaml_version='5.1', remove_dist=False):
     """Create JAR distribution.
 
     Downloads Jython JAR and PyYAML if needed.


### PR DESCRIPTION
fix #3122 switch to PyYaml 5.1 FullLoader, which loads the full YAML language and avoids arbitrary code execution.