### PR TITLE
robottime: Honor the SOURCE_DATE_EPOCH environment variable.

### DIFF
--- a/src/robot/utils/robottime.py
+++ b/src/robot/utils/robottime.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 
 import datetime
+import os
 import time
 import re
 
@@ -395,6 +396,8 @@ class TimestampCache(object):
 
     # Seam for mocking
     def _get_epoch(self):
+        if os.getenv('SOURCE_DATE_EPOCH'):
+            return float(os.getenv('SOURCE_DATE_EPOCH'))
         return time.time()
 
     def _use_cache(self, secs, *separators):

--- a/utest/output/test_logger.py
+++ b/utest/output/test_logger.py
@@ -46,7 +46,7 @@ class TestLogger(unittest.TestCase):
         logger = LoggerMock(('Hello, world!', 'INFO'))
         self.logger.register_logger(logger)
         self.logger.write('Hello, world!', 'INFO')
-        assert_true(logger.msg.timestamp.startswith('20'))
+        assert_true(hasattr(logger.msg, 'timestamp'))
 
     def test_write_to_one_logger_with_trace_level(self):
         logger = LoggerMock(('expected message', 'TRACE'))


### PR DESCRIPTION
Honoring the SOURCE_DATE_EPOCH environment variable allows building
the documentation using libdoc reproducibly, by setting the generated
timestamp to a fixed value.

For more background on reproducible builds and the SOURCE_DATE_EPOCH
environment variable, see:
https://reproducible-builds.org/specs/source-date-epoch/.

* src/robot/utils/robottime.py: import `os'.
(TimestampCache._get_epoch): Retrieve date from SOURCE_DATE_EPOCH if
it is defined, otherwise from time.time().
* utest/output/test_logger.py (TestLogger.test_write_to_one_logger):
Check for the existence of a timestamp attribute instead of checking
for its content as the later is easy to break when using the
SOURCE_DATE_EPOCH environment variable.