### PR TITLE
Ensure creation of missing directories for ROBOT_SYSLOG_FILE and Libdoc outputs

### DIFF
--- a/atest/robot/libdoc/cli.robot
+++ b/atest/robot/libdoc/cli.robot
@@ -15,6 +15,10 @@ Override name and version
     --name MyName --version 42 String ${OUTHTML}    HTML    MyName    42
     -n MyName -v 42 -f xml BuiltIn ${OUTHTML}       XML     MyName    42
 
+Missing destination subdirectory is created
+    String ${NEWDIR_HTML}                HTML    String    path=${NEWDIR_HTML}
+    String ${NEWDIR_XML}                 XML     String    path=${NEWDIR_XML}
+
 Relative path with Python libraries
     [Template]    NONE
     ${dir in libdoc exec dir}=    Set Variable     ${ROBOTPATH}/../TempDirInExecDir

--- a/atest/robot/libdoc/libdoc_resource.robot
+++ b/atest/robot/libdoc/libdoc_resource.robot
@@ -5,9 +5,12 @@ Library           OperatingSystem
 
 *** Variables ***
 ${TESTDATADIR}    ${DATADIR}/libdoc
-${OUTPREFIX}      %{TEMPDIR}${/}robot-libdoc-test-file
+${LIBNAME}        robot-libdoc-test-file
+${OUTPREFIX}      %{TEMPDIR}${/}${LIBNAME}
 ${OUTXML}         ${OUTPREFIX}.xml
 ${OUTHTML}        ${OUTPREFIX}.html
+${NEWDIR_XML}     %{TEMPDIR}${/}tempdir${/}${LIBNAME}.xml
+${NEWDIR_HTML}    %{TEMPDIR}${/}tempdir${/}${LIBNAME}.html
 
 *** Keywords ***
 Run Libdoc And Set Output

--- a/src/robot/utils/robotio.py
+++ b/src/robot/utils/robotio.py
@@ -14,12 +14,14 @@
 #  limitations under the License.
 
 import io
+import os.path
 
 from .platform import PY3
 
 
 def file_writer(path=None, encoding='UTF-8', newline=None):
     if path:
+        _ensure_destination_directory_exists(path)
         f = io.open(path, 'w', encoding=encoding, newline=newline)
     else:
         f = io.StringIO(newline=newline)
@@ -41,3 +43,17 @@ def binary_file_writer(path=None):
     getvalue = f.getvalue
     f.getvalue = lambda encoding='UTF-8': getvalue().decode(encoding)
     return f
+
+
+def _ensure_destination_directory_exists(path):
+    if not os.path.exists(path):
+        base, ext = path.rsplit(os.sep, 1)
+        if PY3:
+            os.makedirs(base, exist_ok=True)
+        else:
+            try:
+                os.makedirs(base)
+            except OSError as e:
+                import errno
+                if e.errno != errno.EEXIST:
+                    raise


### PR DESCRIPTION
This PR contains a fix for #2767. The acceptance test is only for Libdoc, as I  couldn't find any tests regarding `ROBOT_SYSLOG_FILE`. Ought to be fine though, since the same code is used for the two scenarios. 