### PR TITLE
Option to set ROBOT_LIBRARY_SCOPE dynamically (feature request #3167)

### DIFF
--- a/src/robot/model/imports.py
+++ b/src/robot/model/imports.py
@@ -23,7 +23,7 @@ from .itemlist import ItemList
 class Import(object):
     ALLOWED_TYPES = ('Library', 'Resource', 'Variables')
 
-    def __init__(self, type, name, args=(), alias=None, source=None):
+    def __init__(self, type, name, args=(), alias=None, source=None, scope=None):
         if type not in self.ALLOWED_TYPES:
             raise ValueError("Invalid import type '%s'. Should be one of %s."
                              % (type, seq2str(self.ALLOWED_TYPES, lastsep=' or ')))
@@ -32,6 +32,7 @@ class Import(object):
         self.args = args
         self.alias = alias
         self.source = source
+        self.scope = scope
 
     @property
     def directory(self):
@@ -52,11 +53,12 @@ class Imports(ItemList):
     def __init__(self, source, imports=None):
         ItemList.__init__(self, Import, {'source': source}, items=imports)
 
-    def library(self, name, args=(), alias=None):
-        self.create('Library', name, args, alias)
+    def library(self, name, args=(), alias=None, source=None, scope=None):
+        self.create('Library', name, args, alias, source, scope)
 
     def resource(self, path):
         self.create('Resource', path)
 
     def variables(self, path, args=()):
         self.create('Variables', path, args)
+

--- a/src/robot/parsing/settings.py
+++ b/src/robot/parsing/settings.py
@@ -264,12 +264,13 @@ class Metadata(Setting):
 
 class _Import(Setting):
 
-    def __init__(self, parent, name, args=None, alias=None, comment=None):
+    def __init__(self, parent, name, args=None, alias=None, comment=None, scope=None):
         self.parent = parent
         self.name = name
         self.args = args or []
         self.alias = alias
         self._set_comment(comment)
+        self.scope = scope
 
     def reset(self):
         pass
@@ -295,10 +296,10 @@ class _Import(Setting):
 
 class Library(_Import):
 
-    def __init__(self, parent, name, args=None, alias=None, comment=None):
+    def __init__(self, parent, name, args=None, alias=None, comment=None, scope=None):
         if args and not alias:
             args, alias = self._split_possible_alias(args)
-        _Import.__init__(self, parent, name, args, alias, comment)
+        _Import.__init__(self, parent, name, args, alias, comment, scope)
 
     def _split_possible_alias(self, args):
         if len(args) > 1 and args[-2] == 'WITH NAME':
@@ -375,3 +376,4 @@ class MetadataList(_DataList):
 
     def populate(self, name, value, comment):
         self._add(Metadata(self._parent, name, value, comment, joined=True))
+

--- a/src/robot/running/importer.py
+++ b/src/robot/running/importer.py
@@ -23,7 +23,7 @@ from robot.utils import normpath, seq2str2, is_string
 from .builder import ResourceFileBuilder
 from .handlerstore import HandlerStore
 from .testlibraries import TestLibrary
-
+from .libraryscopes import LibraryScope
 
 class Importer(object):
 
@@ -38,7 +38,7 @@ class Importer(object):
         for lib in self._library_cache.values():
             lib.close_global_listeners()
 
-    def import_library(self, name, args, alias, variables):
+    def import_library(self, name, args, alias, variables, scope):
         lib = TestLibrary(name, args, variables, create_handlers=False)
         positional, named = lib.positional_args, lib.named_args
         lib = self._import_library(name, positional, named, lib)
@@ -46,6 +46,9 @@ class Importer(object):
             alias = variables.replace_scalar(alias)
             lib = self._copy_library(lib, alias)
             LOGGER.info("Imported library '%s' with name '%s'" % (name, alias))
+        if scope:
+            lib.scope = LibraryScope(lib._libcode, lib, scope)
+            LOGGER.info("Changed library '%s' scope to '%s'" % (name, scope))  
         return lib
 
     def import_resource(self, path):
@@ -147,3 +150,4 @@ class ImportCache(object):
 
     def _is_path(self, key):
         return is_string(key) and os.path.isabs(key) and os.path.exists(key)
+

--- a/src/robot/running/libraryscopes.py
+++ b/src/robot/running/libraryscopes.py
@@ -18,7 +18,9 @@ import inspect
 from robot.utils import normalize, unic
 
 
-def LibraryScope(libcode, library):
+def LibraryScope(libcode, library, scope=None):
+    if scope:
+        _set_scope(libcode, scope)
     scope = _get_scope(libcode)
     if scope == 'global':
         return GlobalScope(library)
@@ -32,6 +34,10 @@ def _get_scope(libcode):
         return 'global'
     scope = getattr(libcode, 'ROBOT_LIBRARY_SCOPE', '')
     return normalize(unic(scope), ignore='_')
+
+
+def _set_scope(libcode, scope):
+    setattr(libcode, 'ROBOT_LIBRARY_SCOPE', scope)
 
 
 class GlobalScope(object):
@@ -99,3 +105,4 @@ class TestCaseScope(TestSuiteScope):
 
     def __str__(self):
         return 'test case'
+

--- a/src/robot/running/namespace.py
+++ b/src/robot/running/namespace.py
@@ -118,14 +118,14 @@ class Namespace(object):
             LOGGER.info("%s already imported by suite '%s'"
                         % (msg, self._suite_name))
 
-    def import_library(self, name, args=None, alias=None, notify=True):
-        self._import_library(Library(None, name, args=args, alias=alias),
+    def import_library(self, name, args=None, alias=None, notify=True, scope=None):
+        self._import_library(Library(None, name, args=args, alias=alias, scope=scope),
                              notify=notify)
 
     def _import_library(self, import_setting, notify=True):
         name = self._resolve_name(import_setting)
-        lib = IMPORTER.import_library(name, import_setting.args,
-                                      import_setting.alias, self.variables)
+        lib = IMPORTER.import_library(name, import_setting.args, import_setting.alias, 
+                                      self.variables, import_setting.scope)
         if lib.name in self._kw_store.libraries:
             LOGGER.info("Test library '%s' already imported by suite '%s'"
                         % (lib.name, self._suite_name))
@@ -433,3 +433,4 @@ class KeywordRecommendationFinder(object):
                      for handler in library.handlers))
         # sort handlers to ensure consistent ordering between Jython and Python
         return sorted(handlers)
+


### PR DESCRIPTION
Allowing to set ROBOT_LIBRARY_SCOPE when importing custom libraries in the API.
It is an alternative way, to the hard-coded definition of ROBOT_LIBRARY_SCOPE,
in your custom library class.

For example, you'll be able to call:
suite.resource.imports.library('MyLib.py', scope='TEST SUITE')

Instead of setting ROBOT_LIBRARY_SCOPE in MyLib class:
ROBOT_LIBRARY_SCOPE = 'TEST SUITE'