### PR TITLE
testdoc: fix typo in the execution examples

### DIFF
--- a/src/robot/testdoc.py
+++ b/src/robot/testdoc.py
@@ -110,7 +110,7 @@ Jython and IronPython). It can be executed as an installed module like
 
 Examples:
 
-  python -m robot.testdoc my_test.html testdoc.html
+  python -m robot.testdoc my_test.robot testdoc.html
   jython -m robot.testdoc -N smoke_tests -i smoke path/to/my_tests smoke.html
   ipy path/to/robot/testdoc.py first_suite.txt second_suite.txt output.html
 


### PR DESCRIPTION
The test filename passed as an argument should be my_test.robot, instead
of my_test.html.

Signed-off-by: Fathi Boudra <fathi.boudra@varian.com>