### PR TITLE
List/dict syntax when using `@{list}` and `&{dict}` as embedded arguments

### DIFF
--- a/atest/robot/keywords/embedded_arguments.robot
+++ b/atest/robot/keywords/embedded_arguments.robot
@@ -30,6 +30,12 @@ Embedded Arguments as Variables
     Check Keyword Data    ${tc.kws[0]}    User \${42} Selects \${EMPTY} From Webshop    \${name}, \${item}
     Check Keyword Data    ${tc.kws[2]}    User \${name} Selects \${SPACE * 10} From Webshop    \${name}, \${item}
 
+Embedded Arguments as Lists
+    Check Test Case    ${TEST NAME}
+
+Embedded Arguments as Dicts
+    Check Test Case    ${TEST NAME}
+
 Non-Existing Variable in Embedded Arguments
     ${tc} =    Check Test Case    ${TEST NAME}
     Check Keyword Data    ${tc.kws[0]}    User \${non existing} Selects \${variables} From Webshop    status=FAIL

--- a/atest/testdata/keywords/embedded_arguments.robot
+++ b/atest/testdata/keywords/embedded_arguments.robot
@@ -1,4 +1,5 @@
 *** Settings ***
+Library           Collections
 Resource          resources/embedded_args_in_uk_1.robot
 Resource          resources/embedded_args_in_uk_2.robot
 
@@ -37,6 +38,13 @@ Embedded Arguments as Variables
     ${name}    ${item} =    User ${name} Selects ${TEST TAGS} From Webshop
     Should Be Equal    ${name}    ${42}
     Should Be True    ${item} == []
+
+Embedded Arguments as Lists
+    Sublist ["foo", 53] is in [1, 53, "foo", 25, 36, 42, 24, "bar"]
+
+Embedded Arguments as Dicts
+    Key x is in {"a": "b", "x": "y"}
+
 
 Non-Existing Variable in Embedded Arguments
     [Documentation]    FAIL Variable '${non existing}' not found.
@@ -272,3 +280,9 @@ It is totally ${same}
 
 It is totally ${same}
     Fail    Not executed
+
+Sublist @{sublist} is in @{list}
+     List Should Contain Sub List    ${list}    ${sublist}
+
+Key ${key} is in &{dictionary}
+     Dictionary Should Contain Key    ${dictionary}    ${key}

--- a/doc/userguide/src/CreatingTestData/CreatingUserKeywords.rst
+++ b/doc/userguide/src/CreatingTestData/CreatingUserKeywords.rst
@@ -492,6 +492,26 @@ names. They are, however, case-insensitive like other keywords. For
 example, the keyword in the example above could be used like
 :name:`select x from list`, but not like :name:`Select x fromlist`.
 
+Starting from Robot Framework 3.2, embedded arguments support literal
+list/dict Python syntax as long as you use `@{list}`, `&{dict}`
+respectively in keyword name.
+
+.. sourcecode:: robotframework
+
+*** Test Cases ***
+Example
+    Select cat from ['dog', 'cat', 'rabbit']
+    Get cat from {'dog': 2, 'cat': 3, 'rabbit': 0}
+
+*** Keywords ***
+Select ${animal} from @{animal_list}
+    Open Page    Pet Selection
+    Select Item From List    ${animal_list}    ${animal}
+
+Get ${animal} from &{animal_dict}
+    Open Page    Pet Selection
+    Get From Dictionary    ${animal_dict}    ${animal}
+
 Embedded arguments do not support default values or variable number of
 arguments like normal arguments do. Using variables when
 calling these keywords is possible but that can reduce readability.

--- a/src/robot/running/arguments/embedded.py
+++ b/src/robot/running/arguments/embedded.py
@@ -24,7 +24,7 @@ from robot.variables import VariableIterator
 class EmbeddedArguments(object):
 
     def __init__(self, name):
-        if '${' in name:
+        if '${' in name or '@{' in name or '&{' in name:
             self.name, self.args = EmbeddedArgumentParser().parse(name)
         else:
             self.name, self.args = None, []
@@ -43,7 +43,7 @@ class EmbeddedArgumentParser(object):
     def parse(self, string):
         args = []
         name_regexp = ['^']
-        for before, variable, string in VariableIterator(string, identifiers='$'):
+        for before, variable, string in VariableIterator(string, identifiers='$@&'):
             name, pattern = self._get_name_and_pattern(variable[2:-1])
             args.append(name)
             name_regexp.extend([re.escape(before), '(%s)' % pattern])


### PR DESCRIPTION
PR for #2699