### PR TITLE
Forgotten debug statement removed

### DIFF
--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -1210,7 +1210,6 @@ class _Verify(_BuiltInBase):
         Empty`.
         """
         length = self._get_length(item)
-        self.log('Length is %d' % length)
         return length
 
     def _get_length(self, item):


### PR DESCRIPTION
There is a log info statement in BuiltIn.py that outputs to log "Length is NN" messages when many built-in functions are called. This is most probably forgotten there and should be removed. This commit removes that debug statement.