### PR TITLE
Enable ${} translation for keywords when no assignment applies

### DIFF
--- a/src/robot/running/namespace.py
+++ b/src/robot/running/namespace.py
@@ -215,7 +215,7 @@ class Namespace(object):
 
     def get_runner(self, name):
         try:
-            return self._kw_store.get_runner(name)
+            return self._kw_store.get_runner(name, self)
         except DataError as error:
             return UserErrorHandler(error, name)
 
@@ -255,8 +255,8 @@ class KeywordStore(object):
                 return lib
         self._no_library_found(instance)
 
-    def get_runner(self, name):
-        runner = self._get_runner(name)
+    def get_runner(self, name, ns):
+        runner = self._get_runner(name, ns)
         if runner is None:
             self._raise_no_keyword_found(name)
         return runner
@@ -270,11 +270,12 @@ class KeywordStore(object):
         msg = finder.format_recommendations(msg, recommendations)
         raise KeywordError(msg)
 
-    def _get_runner(self, name):
+    def _get_runner(self, name, ns):
         if not name:
             raise DataError('Keyword name cannot be empty.')
         if not is_string(name):
             raise DataError('Keyword name must be a string.')
+        name = ns.variables.replace_string(name)
         runner = self._get_runner_from_test_case_file(name)
         if not runner and '.' in name:
             runner = self._get_explicit_runner(name)


### PR DESCRIPTION
If a keyword cannot be parsed where it should, try translating any
variables enclosed in ${}.  This is useful to provide "method-like"
syntax for an object.  An obvious usecase would be objects which have
been used as arguments to "Import Library", similar to this:

    Import Library      library     ${object}     WITH NAME    object.library
    <some method setting ${object.library} to "object.library">

    Run Keyword         ${object.library}.My Keyword

This change enables you to write this instead of the last line:

    ${object.library}.My Keyword

Note that the following is already possible before this change:

    object.library.My Keyword

However, this does not work once you try passing ${object} to a
keyword, since the keyword cannot possibly know the original name that
was given to ${object}.