### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/doc/api/code_examples/check_test_times.py
+++ b/doc/api/code_examples/check_test_times.py
@@ -8,6 +8,7 @@ took longer than given amount of seconds to execute.
 Optional `outpath` specifies where to write processed results. If not given,
 results are written over the original file.
 """
+from __future__ import print_function
 
 import sys
 from robot.api import ExecutionResult, ResultVisitor
@@ -34,4 +35,4 @@ if __name__ == '__main__':
     try:
         check_tests(*sys.argv[1:])
     except TypeError:
-        print __doc__
+        print(__doc__)

--- a/doc/api/code_examples/check_test_times.py
+++ b/doc/api/code_examples/check_test_times.py
@@ -8,7 +8,6 @@ took longer than given amount of seconds to execute.
 Optional `outpath` specifies where to write processed results. If not given,
 results are written over the original file.
 """
-from __future__ import print_function
 
 import sys
 from robot.api import ExecutionResult, ResultVisitor

--- a/doc/api/generate.py
+++ b/doc/api/generate.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import os
 import shutil
 from optparse import OptionParser
@@ -31,11 +32,11 @@ class GenerateApiDocs(object):
         os.chdir(self.BUILD_DIR)
         rc = call(['make', 'html'], shell=os.name == 'nt')
         os.chdir(orig_dir)
-        print abspath(join(self.BUILD_DIR, '_build', 'html', 'index.html'))
+        print(abspath(join(self.BUILD_DIR, '_build', 'html', 'index.html')))
         exit(rc)
 
     def create_autodoc(self):
-        print 'Generating autodoc'
+        print('Generating autodoc')
         self._clean_directory(self.AUTODOC_DIR)
         command = ['sphinx-apidoc',
                    '--output-dir', self.AUTODOC_DIR,
@@ -44,11 +45,11 @@ class GenerateApiDocs(object):
                    '--maxdepth', '2',
                    '--module-first',
                    self.ROBOT_DIR]
-        print ' '.join(command)
+        print(' '.join(command))
         call(command)
 
     def create_javadoc(self):
-        print 'Generating javadoc'
+        print('Generating javadoc')
         self._clean_directory(self.JAVA_TARGET)
         command = ['javadoc',
                    '-locale', 'en_US',
@@ -56,12 +57,12 @@ class GenerateApiDocs(object):
                    '-d', self.JAVA_TARGET,
                    '-notimestamp',
                    'org.robotframework']
-        print ' '.join(command)
+        print(' '.join(command))
         call(command)
 
     def _clean_directory(self, dirname):
         if os.path.exists(dirname):
-            print 'Cleaning', dirname
+            print('Cleaning', dirname)
             shutil.rmtree(dirname)
 
 

--- a/doc/api/generate.py
+++ b/doc/api/generate.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import os
 import shutil
 from optparse import OptionParser

--- a/doc/libraries/extract_examples.py
+++ b/doc/libraries/extract_examples.py
@@ -4,7 +4,6 @@
 
 Usage: extract_examples.py path_to_lib
 """
-from __future__ import print_function
 
 import os.path
 import sys

--- a/doc/libraries/extract_examples.py
+++ b/doc/libraries/extract_examples.py
@@ -4,6 +4,7 @@
 
 Usage: extract_examples.py path_to_lib
 """
+from __future__ import print_function
 
 import os.path
 import sys
@@ -16,12 +17,12 @@ def extract_tests(path):
 
 def initialize(path):
     lib = os.path.splitext(os.path.basename(path))[0]
-    print """\
+    print("""\
 *** Settings ***
 Library    %s
 
 *** Test Cases ***\
-""" % lib
+""" % lib)
 
 
 def read_tests(path):
@@ -35,15 +36,15 @@ def read_tests(path):
             test = line[4:].split('(')[0]
         if line.startswith('|') and line.endswith('|') and len(line) > 1:
             if test:
-                print '\n', test
+                print('\n', test)
                 test = None
-            print '|    ' + line
+            print('|    ' + line)
 
 
 if __name__ == '__main__':
     try:
         path = sys.argv[1]
     except IndexError:
-        print __doc__
+        print(__doc__)
     else:
         extract_tests(path)

--- a/doc/python/ExampleLibrary.py
+++ b/doc/python/ExampleLibrary.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 def simple_keyword():
     """Log a message"""
     print('You have used the simplest keyword.')
@@ -9,7 +8,7 @@ def greet(name):
 
 def multiply_by_two(number):
     """Returns the given number multiplied by two
-    
+
     The result is always a floating point number.
     This keyword fails if the given `number` cannot be converted to number.
     """

--- a/doc/python/ExampleLibrary.py
+++ b/doc/python/ExampleLibrary.py
@@ -1,10 +1,11 @@
+from __future__ import print_function
 def simple_keyword():
     """Log a message"""
-    print 'You have used the simplest keyword.'
+    print('You have used the simplest keyword.')
 
 def greet(name):
     """Logs a friendly greeting to person given as argument"""
-    print 'Hello %s!' % name
+    print('Hello %s!' % name)
 
 def multiply_by_two(number):
     """Returns the given number multiplied by two
@@ -15,6 +16,6 @@ def multiply_by_two(number):
     return float(number) * 2
 
 def numbers_should_be_equal(first, second):
-    print '*DEBUG* Got arguments %s and %s' % (first, second)
+    print('*DEBUG* Got arguments %s and %s' % (first, second))
     if float(first) != float(second):
         raise AssertionError('Given numbers are unequal!')

--- a/doc/python/pt2html.py
+++ b/doc/python/pt2html.py
@@ -4,6 +4,7 @@
 
 Usage:  pt2html.py
 """
+from __future__ import print_function
 
 import sys
 import os
@@ -17,7 +18,7 @@ import ug2html  # This also initializes docutils and pygments
 def create_tutorial():
     from docutils.core import publish_cmdline
 
-    print 'Creating Python Tutorial ...'
+    print('Creating Python Tutorial ...')
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
     description = 'Python Tutorial for Robot Framework Library Developers'
     arguments = '''
@@ -28,7 +29,7 @@ PythonTutorial.html
 '''.split('\n')[1:-1] 
     publish_cmdline(writer_name='html', description=description, argv=arguments)
     path = arguments[-1]
-    print os.path.abspath(path)
+    print(os.path.abspath(path))
     return path
 
 

--- a/doc/python/pt2html.py
+++ b/doc/python/pt2html.py
@@ -4,7 +4,6 @@
 
 Usage:  pt2html.py
 """
-from __future__ import print_function
 
 import sys
 import os
@@ -26,7 +25,7 @@ def create_tutorial():
 --stylesheet-path=../userguide/src/userguide.css
 PythonTutorial.rst
 PythonTutorial.html
-'''.split('\n')[1:-1] 
+'''.split('\n')[1:-1]
     publish_cmdline(writer_name='html', description=description, argv=arguments)
     path = arguments[-1]
     print(os.path.abspath(path))

--- a/doc/userguide/src/SupportingTools/LoggingLibrary.py
+++ b/doc/userguide/src/SupportingTools/LoggingLibrary.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 class LoggingLibrary:
     """Library for logging messages.
 
@@ -62,7 +63,7 @@ class LoggingLibrary:
         importing` is used.
         """
         level = self._verify_level(level) if level else self.default_level
-        print "*%s* %s" % (level, message)
+        print("*%s* %s" % (level, message))
 
     def log_two_messages(self, message1, message2, level=None):
         """Writes given messages to the log file using the specified log level.

--- a/doc/userguide/src/SupportingTools/LoggingLibrary.py
+++ b/doc/userguide/src/SupportingTools/LoggingLibrary.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 class LoggingLibrary:
     """Library for logging messages.
 


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.