### PR TITLE
fix class Matcher.py: test naming, using of fnmatch.translate, side-effects and version compatibility

### DIFF
--- a/src/robot/utils/match.py
+++ b/src/robot/utils/match.py
@@ -44,6 +44,7 @@ class Matcher(object):
     def _compile(self, pattern, regexp=False):
         if not regexp:
             pattern = fnmatch.translate(pattern)
+            pattern = pattern.replace("[", "\\[").replace("]", "\\]")
             # https://github.com/IronLanguages/ironpython2/issues/515
             if IRONPYTHON and "\\'" in pattern:
                 pattern = pattern.replace("\\'", "'")


### PR DESCRIPTION
Hi.

Matcher class uses fnmatch.translate function, but this function uses square brackets for special cases and don't escape these symbols so robot test cases having square brackets as a part of their names cannot be used with new robot framework versions because these brackets are also recognized as parts of regular expressions.

This test named as [1st_file]Multi_xml_file is passed with previous framework versions

Before patching:
`unexpected error: [ ERROR ] Suite 'StaCAMT052SplitMultiFile' contains no tests matching name 'StaCAMT052SplitMultiFile.Split Multifile.[1st_file]Multi_xml_file' in suite 'StaCAMT052SplitMultiFile.Split Multifile'.`

test=stacamt052splitmultifile.splitmultifile.[2ndfile]multixmlfile
pattern=stacamt052splitmultifile\\.splitmultifile\\.[2ndfile]multixmlfile\\Z(?ms)

After patching the test is successfully passed.

test=stacamt052splitmultifile.splitmultifile.[2ndfile]multixmlfile
pattern=stacamt052splitmultifile\\.splitmultifile\\.\\[2ndfile\\]multixmlfile\\Z(?ms)

The reason is used square brackets. [2ndfile] is any character, but only one.

You can use any other solution instead of mine. Please, fix the problem.
