### PR TITLE
Normalize `Run Process | ... | timeout=0`

### DIFF
--- a/atest/robot/standard_libraries/process/run_process_with_timeout.robot
+++ b/atest/robot/standard_libraries/process/run_process_with_timeout.robot
@@ -8,6 +8,21 @@ Finish before timeout
     Check Log Message    ${tc.kws[0].msgs[1]}    Waiting for process to complete.
     Check Log Message    ${tc.kws[0].msgs[2]}    Process completed.
 
+Finish before timeout with zero timeout
+    ${tc} =    Check Test Case    ${TESTNAME}
+    Check Log Message    ${tc.kws[0].msgs[1]}    Waiting for process to complete.
+    Check Log Message    ${tc.kws[0].msgs[2]}    Process completed.
+
+Finish before timeout with nONe timeout
+    ${tc} =    Check Test Case    ${TESTNAME}
+    Check Log Message    ${tc.kws[0].msgs[1]}    Waiting for process to complete.
+    Check Log Message    ${tc.kws[0].msgs[2]}    Process completed.
+
+Finish before timeout with negative timeout
+    ${tc} =    Check Test Case    ${TESTNAME}
+    Check Log Message    ${tc.kws[0].msgs[1]}    Waiting for process to complete.
+    Check Log Message    ${tc.kws[0].msgs[2]}    Process completed.
+
 On timeout process is terminated by default (w/ default streams)
     ${tc} =    Check Test Case    ${TESTNAME}
     Check Log Message    ${tc.kws[0].msgs[1]}    Waiting for process to complete.

--- a/atest/testdata/standard_libraries/process/run_process_with_timeout.robot
+++ b/atest/testdata/standard_libraries/process/run_process_with_timeout.robot
@@ -4,10 +4,30 @@ Suite Teardown    Remove Files    ${STDOUT}    ${STDERR}
 
 *** Variables ***
 @{COMMAND}        python    ${CURDIR}/files/timeout.py
+${ZERO_TIMEOUT}   0
+${NONE_TIMEOUT}   nONe
+${NEG_TIMEOUT}    -2 hours
 
 *** Test Cases ***
 Finish before timeout
     ${result} =    Run Process    @{COMMAND}
+    Should not be terminated    ${result}
+
+Finish before timeout with nONe timeout
+    ${result} =    Run Process    @{COMMAND}    timeout=${NONE_TIMEOUT}
+    Should not be terminated    ${result}
+
+Finish before timeout with zero timeout
+    ${result} =    Run Process    @{COMMAND}    timeout=${ZERO_TIMEOUT}
+    Should not be terminated    ${result}
+
+Finish before timeout with empty timeout
+    [Documentation]   Verifying that backwards compatibility is honored
+    ${result} =    Run Process    @{COMMAND}    timeout=${EMPTY}
+    Should not be terminated    ${result}
+
+Finish before timeout with negative timeout
+    ${result} =    Run Process    @{COMMAND}    timeout=${NEG_TIMEOUT}
     Should not be terminated    ${result}
 
 On timeout process is terminated by default (w/ default streams)

--- a/src/robot/libraries/Process.py
+++ b/src/robot/libraries/Process.py
@@ -407,7 +407,9 @@ class Process(object):
         given in
         [http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#time-format|
         various time formats] supported by Robot Framework, for example, ``42``,
-        ``42 s``, or ``1 minute 30 seconds``.
+        ``42 s``, or ``1 minute 30 seconds``. Starting from  Robot Framework 3.2
+        ``None``, zero, and negative values is same as not specifying timeout at
+        all.
 
         ``on_timeout`` defines what to do if the timeout occurs. Possible values
         and corresponding actions are explained in the table below. Notice
@@ -439,11 +441,15 @@ class Process(object):
         | ${result} =                 | Wait For Process | timeout=1min 30s | on_timeout=kill |
         | Process Should Be Stopped   |                  |                  |
         | Should Be Equal As Integers | ${result.rc}     | -9               |
+
+        Ignoring Falsy, negative, and zero values is new in Robot Framework 3.2.
         """
         process = self._processes[handle]
         logger.info('Waiting for process to complete.')
-        if timeout:
-            timeout = timestr_to_secs(timeout)
+        if not (is_truthy(timeout) and timeout):
+            timeout = 0
+        timeout = timestr_to_secs(timeout)
+        if timeout > 0:
             if not self._process_is_stopped(process, timeout):
                 logger.info('Process did not complete in %s.'
                             % secs_to_timestr(timeout))


### PR DESCRIPTION
Make `timeout` named argument accept the same values as keyword `[Timeout]` does.

`None` (case-insensitively), falsy, zero or negative values are treated
the same way as `[Timeout]` (i.e. ignored aka infinity)
This is in addition to `${None}` being already ignored.

See also robotframework/robotframework#3365

Resolves robotframework/robotframework#3366

Signed-off-by: Stavros Ntentos <133706+stdedos@users.noreply.github.com>