### PR TITLE
Fixed typo in documentation for `Get Slice From List`.

### DIFF
--- a/src/robot/libraries/Collections.py
+++ b/src/robot/libraries/Collections.py
@@ -209,9 +209,9 @@ class _List(object):
         the largest (or smallest) available index.
 
         Examples (incl. Python equivalents in comments):
-        | ${x} = | Get Slice From List | ${L5} | 2 | 4  | # L5[2:4]    |
-        | ${y} = | Get Slice From List | ${L5} | 1 |    | # L5[1:None] |
-        | ${z} = | Get Slice From List | ${L5} |   | -2 | # L5[0:-2]   |
+        | ${x} = | Get Slice From List | ${L5} | 2      | 4 | # L5[2:4]    |
+        | ${y} = | Get Slice From List | ${L5} | 1      |   | # L5[1:None] |
+        | ${z} = | Get Slice From List | ${L5} | end=-2 |   | # L5[0:-2]   |
         =>
         | ${x} = ['c', 'd']
         | ${y} = ['b', 'c', 'd', 'e']


### PR DESCRIPTION
If the `end` of slice is not explicit, the bug will follow.
![image](https://user-images.githubusercontent.com/56407674/72836368-80673180-3c9d-11ea-920b-25da37c0979a.png)

E.g. ```Get Slice From List  ${L5}  end=-2``` is correct:
![image](https://user-images.githubusercontent.com/56407674/72837095-f9b35400-3c9e-11ea-9a0b-f3c8e9c563de.png)
