### PR TITLE
Issue 3440

### DIFF
--- a/doc/userguide/src/SupportingTools/LoggingLibrary.html
+++ b/doc/userguide/src/SupportingTools/LoggingLibrary.html
@@ -854,7 +854,7 @@ libdoc = {"all_tags":[],"contains_tags":false,"doc":"<p>Library for logging mess
            title="Show tests with this tag">${$value}</a> &middot;
         {{/each}}
         <a href="javascript:resetKeywords()" class="normal-first-letter"
-           title="Show all tests">[Reset]</a>
+           title="Show all tags">[Reset]</a>
     </div>
 </script>
 

--- a/src/robot/htmldata/libdoc/libdoc.html
+++ b/src/robot/htmldata/libdoc/libdoc.html
@@ -322,7 +322,7 @@
            title="Show tests with this tag">${$value}</a> &middot;
         {{/each}}
         <a href="javascript:resetKeywords()" class="normal-first-letter"
-           title="Show all tests">[Reset]</a>
+           title="Show all tags">[Reset]</a>
     </div>
 </script>
 

--- a/src/robot/htmldata/libdoc/libdoc.html
+++ b/src/robot/htmldata/libdoc/libdoc.html
@@ -49,6 +49,12 @@
         }
         renderTemplate('keywords', libdoc);
         renderTemplate('footer', libdoc);
+        params = util.parseQueryString(window.location.search.slice(1));
+        if ("tag" in params) {
+            $(document).ready(function() {
+              tagSearch(params["tag"]);
+            })
+        }
         scrollToHash();
         $(document).bind('keydown', handleKeydown);
     });
@@ -92,6 +98,7 @@
         markMatches(tag, include);
         highlightMatches(tag, include);
         $('#keywords-container').find('.kw-row').addClass('hide-unmatched');
+        history.replaceState && history.replaceState(null, '', location.pathname + "?tag=" + tag + location.hash);
     }
 
     function doSearch() {
@@ -217,6 +224,7 @@
         }
         $('#match-count').hide();
         $('#altogether-count').show();
+        history.replaceState && history.replaceState( null, '', location.pathname + location.hash);
     }
 
     function setMatchVisibility() {


### PR DESCRIPTION
Adds functionality to automatically select tags in libdoc html documantetion if query string "tag=$tag_to_select" is passed to it.

Another commit where around this same topic as the element title said "tests" but at least in libdoc context, they where referring to document tags.

#3440 