### PR TITLE
Add support for svg image link

### DIFF
--- a/doc/userguide/src/Appendices/DocumentationFormatting.rst
+++ b/doc/userguide/src/Appendices/DocumentationFormatting.rst
@@ -203,6 +203,8 @@ The automatic conversion of URLs to links is applied to all the data
 in logs and reports, but creating images is done only for test suite,
 test case and keyword documentation, and for test suite metadata.
 
+.. note:: `.svg` image support is new in Robot Framework 3.2.
+
 Custom links and images
 -----------------------
 

--- a/doc/userguide/src/Appendices/DocumentationFormatting.rst
+++ b/doc/userguide/src/Appendices/DocumentationFormatting.rst
@@ -193,8 +193,8 @@ URLs
 
 All strings that look like URLs are automatically converted into
 clickable links. Additionally, URLs that end with extension
-:file:`.jpg`, :file:`.jpeg`, :file:`.png`, :file:`.gif` or
-:file:`.bmp` (case-insensitive) will automatically create images. For
+:file:`.jpg`, :file:`.jpeg`, :file:`.png`, :file:`.gif`, :file:`.bmp` or
+:file:`.svg` (case-insensitive) will automatically create images. For
 example, URLs like `http://example.com` are turned into links, and
 `http:///host/image.jpg` and `file:///path/chart.png`
 into images.

--- a/src/robot/utils/htmlformatters.py
+++ b/src/robot/utils/htmlformatters.py
@@ -19,7 +19,7 @@ from itertools import cycle
 
 
 class LinkFormatter(object):
-    _image_exts = ('.jpg', '.jpeg', '.png', '.gif', '.bmp')
+    _image_exts = ('.jpg', '.jpeg', '.png', '.gif', '.bmp', '.svg')
     _link = re.compile(r'\[(.+?\|.*?)\]')
     _url = re.compile(r'''
 ((^|\ ) ["'(\[{]*)           # begin of line or space and opt. any char "'([{

--- a/utest/utils/test_markuputils.py
+++ b/utest/utils/test_markuputils.py
@@ -103,7 +103,7 @@ class TestUrlsToLinks(unittest.TestCase):
     def test_image_urls(self):
         link = '(<a href="%s">%s</a>)'
         img = '(<img src="%s" title="%s">)'
-        for ext in ['jpg', 'jpeg', 'png', 'gif', 'bmp']:
+        for ext in ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'svg']:
             url = 'foo://bar/zap.%s' % ext
             uprl = url.upper()
             inp = '(%s)' % url


### PR DESCRIPTION
This PR adds .svg extensions to the list of image types that are automatically converted into &lt;img&gt; tags in documentation fields.

I modified the only unittest I found for this functionality. There didn't seem to be any existing acceptance tests.

Related to issue: #3464 