### PR TITLE
List ignore

### DIFF
--- a/atest/robot/standard_libraries/collections/list.robot
+++ b/atest/robot/standard_libraries/collections/list.robot
@@ -199,6 +199,9 @@ Lists Should Be Equal With Named Indices As Dictionary
 Lists Should Be Equal With Named Indices As Dictionary With Too Few Values
     Check Test Case    ${TEST NAME}
 
+Lists Should Be Equal Ignore Order
+    Check Test Case    ${TEST NAME}
+
 List Should Contain Sub List
     Check Test Case    ${TEST NAME}
 

--- a/atest/testdata/standard_libraries/collections/list.robot
+++ b/atest/testdata/standard_libraries/collections/list.robot
@@ -331,6 +331,12 @@ Lists Should Be Equal With Named Indices As Dictionary With Too Few Values
     ${names} =    Create Dictionary    0=a    2=c
     Lists Should Be Equal    ${L3}    ${L3B}    names=${names}
 
+Lists Should Be Equal Ignore Order
+    [Documentation]    PASS list are equal
+    ${names1} =    Create List    A    B	C	D
+    ${names2} =    Create List    D    B	C	A
+    Lists Should Be Equal    ${names1}    ${names2}    ignore_order=True
+    
 List Should Contain Sub List
     List Should Contain Sub List    ${LONG}    ${L4}
 

--- a/atest/testdata/standard_libraries/collections/list.robot
+++ b/atest/testdata/standard_libraries/collections/list.robot
@@ -332,7 +332,7 @@ Lists Should Be Equal With Named Indices As Dictionary With Too Few Values
     Lists Should Be Equal    ${L3}    ${L3B}    names=${names}
 
 Lists Should Be Equal Ignore Order
-    [Documentation]    PASS list are equal
+    [Documentation]    FAIL Lists are different:
     ${names1} =    Create List    A    B	C	D
     ${names2} =    Create List    D    B	C	A
     Lists Should Be Equal    ${names1}    ${names2}    ignore_order=True

--- a/atest/testdata/standard_libraries/collections/list.robot
+++ b/atest/testdata/standard_libraries/collections/list.robot
@@ -332,8 +332,8 @@ Lists Should Be Equal With Named Indices As Dictionary With Too Few Values
     Lists Should Be Equal    ${L3}    ${L3B}    names=${names}
 
 Lists Should Be Equal Ignore Order    
-    ${names1} =    Create List    A    B	C	D
-    ${names2} =    Create List    D    B	C	A
+    ${list1} =    Create List    A    B    C    D
+    ${list1} =    Create List    D    B    C	A
     Lists Should Be Equal    ${names1}    ${names2}    ignore_order=True
     
 List Should Contain Sub List

--- a/atest/testdata/standard_libraries/collections/list.robot
+++ b/atest/testdata/standard_libraries/collections/list.robot
@@ -331,8 +331,7 @@ Lists Should Be Equal With Named Indices As Dictionary With Too Few Values
     ${names} =    Create Dictionary    0=a    2=c
     Lists Should Be Equal    ${L3}    ${L3B}    names=${names}
 
-Lists Should Be Equal Ignore Order
-    [Documentation]    FAIL Lists are different:
+Lists Should Be Equal Ignore Order    
     ${names1} =    Create List    A    B	C	D
     ${names2} =    Create List    D    B	C	A
     Lists Should Be Equal    ${names1}    ${names2}    ignore_order=True

--- a/atest/testdata/standard_libraries/collections/list.robot
+++ b/atest/testdata/standard_libraries/collections/list.robot
@@ -333,8 +333,8 @@ Lists Should Be Equal With Named Indices As Dictionary With Too Few Values
 
 Lists Should Be Equal Ignore Order    
     ${list1} =    Create List    A    B    C    D
-    ${list1} =    Create List    D    B    C	A
-    Lists Should Be Equal    ${names1}    ${names2}    ignore_order=True
+    ${list2} =    Create List    D    B    C	A
+    Lists Should Be Equal    ${list1}    ${list2}    ignore_order=True
     
 List Should Contain Sub List
     List Should Contain Sub List    ${LONG}    ${L4}

--- a/src/robot/libraries/Collections.py
+++ b/src/robot/libraries/Collections.py
@@ -346,7 +346,7 @@ class _List(object):
                                  '%s found multiple times.' % seq2str(dupes))
 
     def lists_should_be_equal(self, list1, list2, msg=None, values=True,
-                              names=None):
+                              names=None,ignore_order=False):
         """Fails if given lists are unequal.
 
         The keyword first verifies that the lists have equal lengths, and then
@@ -387,7 +387,12 @@ class _List(object):
         default = 'Lengths are different: %d != %d' % (len1, len2)
         _verify_condition(len1 == len2, default, msg, values)
         names = self._get_list_index_name_mapping(names, len1)
-        diffs = list(self._yield_list_diffs(list1, list2, names))
+        if not ignore_order:
+            diffs = list(_yield_list_diffs(list1, list2, names))
+        else:
+            sorted_list1 = sorted(list1)
+            sorted_list2 = sorted(list2)
+            diffs = list(_yield_list_diffs(sorted_list1, sorted_list2, names))
         default = 'Lists are different:\n' + '\n'.join(diffs)
         _verify_condition(diffs == [], default, msg, values)
 

--- a/src/robot/libraries/Collections.py
+++ b/src/robot/libraries/Collections.py
@@ -346,7 +346,7 @@ class _List(object):
                                  '%s found multiple times.' % seq2str(dupes))
 
     def lists_should_be_equal(self, list1, list2, msg=None, values=True,
-                              names=None,ignore_order=False):
+                              names=None, ignore_order=False):
         """Fails if given lists are unequal.
 
         The keyword first verifies that the lists have equal lengths, and then

--- a/src/robot/libraries/Collections.py
+++ b/src/robot/libraries/Collections.py
@@ -388,11 +388,11 @@ class _List(object):
         _verify_condition(len1 == len2, default, msg, values)
         names = self._get_list_index_name_mapping(names, len1)
         if not ignore_order:
-            diffs = list(_yield_list_diffs(list1, list2, names))
+            diffs = list(self._yield_list_diffs(list1, list2, names))
         else:
             sorted_list1 = sorted(list1)
             sorted_list2 = sorted(list2)
-            diffs = list(_yield_list_diffs(sorted_list1, sorted_list2, names))
+            diffs = list(self._yield_list_diffs(sorted_list1, sorted_list2, names))
         default = 'Lists are different:\n' + '\n'.join(diffs)
         _verify_condition(diffs == [], default, msg, values)
 

--- a/src/robot/libraries/Collections.py
+++ b/src/robot/libraries/Collections.py
@@ -370,6 +370,10 @@ class _List(object):
         need to be named. It is not necessary to name all of the indices.  When
         using a dictionary, keys can be either integers or strings that can be
         converted to integers.
+        
+        Optional ``ignore_order`` argument can be used to ignore the order of the
+        elements (element index) in the list while comparing two lists. If set to 
+        true, element order will be ignored.  This option is new in RF 3.2 now.
 
         Examples:
         | ${names} = | Create List | First Name | Family Name | Email |
@@ -380,6 +384,13 @@ class _List(object):
         If the items in index 2 would differ in the above examples, the error
         message would contain a row like ``Index 2 (email): name@foo.com !=
         name@bar.com``.
+        
+        | ${list1} = | Create List | apple | cherry | banana |
+        | ${list2} = | Create List | cherry | banana | apple |
+        | Lists Should Be Equal | ${list1} | ${list2} | ignore_order=True |
+        
+        list index would be ignored while comparing two lists. Above two list 
+        will be matched. 
         """
         self._validate_lists(list1, list2)
         len1 = len(list1)
@@ -387,12 +398,10 @@ class _List(object):
         default = 'Lengths are different: %d != %d' % (len1, len2)
         _verify_condition(len1 == len2, default, msg, values)
         names = self._get_list_index_name_mapping(names, len1)
-        if not ignore_order:
-            diffs = list(self._yield_list_diffs(list1, list2, names))
-        else:
-            sorted_list1 = sorted(list1)
-            sorted_list2 = sorted(list2)
-            diffs = list(self._yield_list_diffs(sorted_list1, sorted_list2, names))
+        if ignore_order:
+            list1 = sorted(list1)
+            list2 = sorted(list2)
+        diffs = list(self._yield_list_diffs(list1, list2, names))
         default = 'Lists are different:\n' + '\n'.join(diffs)
         _verify_condition(diffs == [], default, msg, values)
 


### PR DESCRIPTION
1.  As list is mutable and if we use sort, it will alter original list.  Original list should not be altered so used sorted function instead of sort method. 

2. Instead of modify more lines in the _yield_list_diffs method to handle `name` option given by user, just passed sorted list to get the diff as we should support name argument/parameter as well.