### PR TITLE
Using seps by default when converting timestamp to secs

### DIFF
--- a/src/robot/utils/robottime.py
+++ b/src/robot/utils/robottime.py
@@ -294,7 +294,7 @@ def get_timestamp(daysep='', daytimesep=' ', timesep=':', millissep='.'):
     return TIMESTAMP_CACHE.get_timestamp(daysep, daytimesep, timesep, millissep)
 
 
-def timestamp_to_secs(timestamp, seps=None):
+def timestamp_to_secs(timestamp, seps=(' ', ':', '-', '.')):
     try:
         secs = _timestamp_to_millis(timestamp, seps) / 1000.0
     except (ValueError, OverflowError):


### PR DESCRIPTION
It was noticed, that sometimes Robot fails with the following trace:

```
...snip...
  File "/usr/local/lib/python3.7/site-packages/robot/reporting/jsmodelbuilders.py", line 66, in <genexpr>
    model = tuple(self._build_keyword(k) for k in kws)
  File "/usr/local/lib/python3.7/site-packages/robot/reporting/jsmodelbuilders.py", line 140, in build
    self._get_status(kw),
  File "/usr/local/lib/python3.7/site-packages/robot/reporting/jsmodelbuilders.py", line 53, in _get_status
    self._timestamp(item.starttime),
  File "/usr/local/lib/python3.7/site-packages/robot/reporting/jsbuildingcontext.py", line 58, in timestamp
    millis = int(timestamp_to_secs(time) * 1000)
  File "/usr/local/lib/python3.7/site-packages/robot/utils/robottime.py", line 301, in timestamp_to_secs
    raise ValueError("Invalid timestamp '%s'." % timestamp)
```
Logging shows timestamp that cannot be parsed: '2020-02-26 16:34:28.227'
So we use default seps to avoid such failure