### PR TITLE
Upgrade codecov to 1.0.6

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -39,9 +39,8 @@ jobs:
           python -m coverage xml -i
         if: always()
 
-      - uses: codecov/codecov-action@797e92895ec0eac368405352c0add9af878fe257
+      - uses: codecov/codecov-action@e34ee485244a5b5e6e4e1b96daa4a15c9073e4fc
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           name: ${{ matrix.python-version }}-${{ matrix.os }}
 
       - name: Archive coverage results


### PR DESCRIPTION
CodeCov action has been upgraded today to support:
- proper handling for pull requests
- tokenless upload functionality

See https://github.com/codecov/codecov-action/releases/tag/v1.0.6.