### PR TITLE
Fixed ArgumentParser union type handling under Python 3.5

### DIFF
--- a/src/robot/running/arguments/argumentparser.py
+++ b/src/robot/running/arguments/argumentparser.py
@@ -123,9 +123,9 @@ class PythonArgumentParser(_ArgumentParser):
                     try:
                         types = type_.__args__
                     except AttributeError:
-                        # Python 3.5's typing uses __union_params__ instead of
-                        # __args__. This can likely be safely removed after
-                        # Python 3.5 support is dropped
+                        # Python 3.5.2's typing uses __union_params__ instead 
+                        # of __args__. This block can likely be safely removed
+                        # when Python 3.5 support is dropped
                         types = type_.__union_params__
                     if len(types) == 2 and types[1] is type(None):
                         type_hints[arg] = types[0]

--- a/src/robot/running/arguments/argumentparser.py
+++ b/src/robot/running/arguments/argumentparser.py
@@ -120,7 +120,13 @@ class PythonArgumentParser(_ArgumentParser):
             if defaults[arg] is None and arg in type_hints:
                 type_ = type_hints[arg]
                 if self._is_union(type_):
-                    types = type_.__args__
+                    try:
+                        types = type_.__args__
+                    except AttributeError:
+                        # Python 3.5's typing uses __union_params__ instead of
+                        # __args__. This can likely be safely removed after
+                        # Python 3.5 support is dropped
+                        types = type_.__union_params__
                     if len(types) == 2 and types[1] is type(None):
                         type_hints[arg] = types[0]
 


### PR DESCRIPTION
This corrects a bug that causes an unhandled exception for test libraries with Optional[] parameters in Python 3.5. Included is a minimal test case for this issue: Running this in python 3.6 or python 3.5 with my change will work fine, but Python3.5 with the robot framework as-is will produce:  

```
njewers@njewers-lt:~/workspace/robottest$ python3.5 -mrobot union.robot
[ ERROR ] Unexpected error: AttributeError: type object 'Union' has no attribute '__args__'
Traceback (most recent call last):
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/utils/application.py", line 83, in _execute
    rc = self.main(arguments, **options)
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/run.py", line 439, in main
    result = suite.run(settings)
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/running/model.py", line 222, in run
    self.visit(runner)
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/model/testsuite.py", line 168, in visit
    visitor.visit_suite(self)
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/model/visitor.py", line 84, in visit_suite
    if self.start_suite(suite) is not False:
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/running/runner.py", line 74, in start_suite
    ns.handle_imports()
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/running/namespace.py", line 55, in handle_imports
    self._handle_imports(self._imports)
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/running/namespace.py", line 66, in _handle_imports
    self._import(item)
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/running/namespace.py", line 74, in _import
    action(import_setting)
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/running/namespace.py", line 128, in _import_library
    import_setting.alias, self.variables)
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/running/importer.py", line 42, in import_library
    lib = TestLibrary(name, args, variables, create_handlers=False)
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/running/testlibraries.py", line 52, in TestLibrary
    lib = libclass(libcode, name, args or [], source, variables)
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/running/testlibraries.py", line 84, in __init__
    self.init = self._create_init_handler(libcode)
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/running/testlibraries.py", line 133, in _create_init_handler
    return InitHandler(self, self._resolve_init_method(libcode))
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/running/handlers.py", line 50, in InitHandler
    return Init(library, '__init__', method, docgetter)
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/running/handlers.py", line 229, in __init__
    _PythonHandler.__init__(self, library, handler_name, handler_method)
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/running/handlers.py", line 129, in __init__
    getdoc(handler_method))
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/running/handlers.py", line 59, in __init__
    self.arguments = self._parse_arguments(handler_method)
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/running/handlers.py", line 241, in _parse_arguments
    return parser.parse(handler_method, self.library.name)
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/running/arguments/argumentparser.py", line 66, in parse
    spec.types = self._get_types(handler, annotations, spec)
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/running/arguments/argumentparser.py", line 84, in _get_types
    return self._get_type_hints(handler, annotations, spec)
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/running/arguments/argumentparser.py", line 94, in _get_type_hints
    self._remove_optional_none_type_hints(type_hints, spec.defaults)
  File "/home/njewers/.local/lib/python3.5/site-packages/robot/running/arguments/argumentparser.py", line 112, in _remove_optional_none_type_hints
    types = type_.__args__
```

I know Python 3.5 hits EOL in September, but there are still a couple of Ubuntu 16.04 test environments with Python 3.5 around out there.