### PR TITLE
Acceptance tests on Jython 2.7.2 with Java >= 9

### DIFF
--- a/atest/interpreter.py
+++ b/atest/interpreter.py
@@ -31,6 +31,7 @@ class Interpreter(object):
         self.name = name
         self.version = version
         self.version_info = tuple(int(item) for item in version.split('.'))
+        self.java_version = self._get_java_version()
 
     def _get_interpreter(self, path):
         path = path.replace('/', os.sep)
@@ -47,6 +48,23 @@ class Interpreter(object):
         name = name if 'PyPy' not in output else 'PyPy'
         version = re.match(r'\d+\.\d+\.\d+', version).group()
         return name, version
+
+    def _get_java_version(self):
+        if not self.is_jython:
+            return (-1, -1)
+        try:
+            # platform.java_ver() returns Java version in a format:
+            # ('9.0.7.1', 'Azul Systems, Inc.', ('OpenJDK 64-Bit Server VM', '9.0.7.1+1', 'Azul Systems, Inc.'), ('Windows 10', '10.0', 'amd64'))
+            # ('11.0.6', 'Ubuntu', ('OpenJDK 64-Bit Server VM', '11.0.6+10-post-Ubuntu-1ubuntu118.04.1', 'Ubuntu'), ('Linux', '4.4.0-18362-Microsoft', 'amd64'))
+            # ('1.8.0_121', 'Oracle Corporation', ('Java HotSpot(TM) 64-Bit Server VM', '25.121-b13', 'Oracle Corporation'), ('Windows 10', '10.0', 'amd64'))
+            script = 'import platform; print(platform.java_ver()[0])'
+            output = subprocess.check_output(self.interpreter + ['-c', script],
+                                             stderr=subprocess.STDOUT,
+                                             encoding='UTF-8')
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            raise ValueError('Invalid interpreter: %s' % self.path)
+        major, minor = output.strip().split('.', 2)[:2]
+        return (int(major), int(minor))
 
     @property
     def os(self):
@@ -117,6 +135,19 @@ class Interpreter(object):
         return tools_jar
 
     @property
+    def java_opts(self):
+        if not self.is_jython:
+            return None
+        java_opts = os.environ.get('JAVA_OPTS')
+        if self.version_info[:3] >= (2, 7, 2) and self.java_version[0] >= 9:
+            if not java_opts:
+                java_opts = ''
+            # https://github.com/jythontools/jython/issues/171
+            if '--add-opens' not in java_opts:
+                java_opts += ' --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED'
+        return java_opts
+
+    @property
     def is_python(self):
         return self.name == 'Python'
 
@@ -173,7 +204,11 @@ class Interpreter(object):
         return self.interpreter + [join(ROBOT_PATH, 'tidy.py')]
 
     def __str__(self):
-        return '%s %s on %s' % (self.name, self.version, self.os)
+        if self.is_jython:
+            java_version = '(Java %s) ' % '.'.join(str(ver_part) for ver_part in self.java_version)
+        else:
+            java_version = ''
+        return '%s %s %son %s' % (self.name, self.version, java_version, self.os)
 
 
 class StandaloneInterpreter(Interpreter):

--- a/atest/interpreter.py
+++ b/atest/interpreter.py
@@ -51,7 +51,7 @@ class Interpreter(object):
 
     def _get_java_version(self):
         if not self.is_jython:
-            return (-1, -1)
+            return -1, -1
         try:
             # platform.java_ver() returns Java version in a format:
             # ('9.0.7.1', 'Azul Systems, Inc.', ('OpenJDK 64-Bit Server VM', '9.0.7.1+1', 'Azul Systems, Inc.'), ('Windows 10', '10.0', 'amd64'))
@@ -64,7 +64,7 @@ class Interpreter(object):
         except (subprocess.CalledProcessError, FileNotFoundError):
             raise ValueError('Invalid interpreter: %s' % self.path)
         major, minor = output.strip().split('.', 2)[:2]
-        return (int(major), int(minor))
+        return int(major), int(minor)
 
     @property
     def os(self):

--- a/atest/run.py
+++ b/atest/run.py
@@ -111,6 +111,7 @@ def _run(args, tempdir, interpreter):
     environ = dict(os.environ,
                    TEMPDIR=tempdir,
                    CLASSPATH=interpreter.classpath or '',
+                   JAVA_OPTS=interpreter.java_opts or '',
                    PYTHONCASEOK='True')
     print('%s\n%s\n' % (interpreter, '-' * len(str(interpreter))))
     print('Running command:\n%s\n' % ' '.join(command))


### PR DESCRIPTION
When running Jython >= 2.7.2 on Java >= 9, unexpected printouts are present on stdout, set JAVA_OPTS to `--add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED` to avoid that.

References #3501.