### PR TITLE
Enable upgrade of setup-python action within 1.x version

### DIFF
--- a/.github/workflows/acceptance_tests_cpython.yml
+++ b/.github/workflows/acceptance_tests_cpython.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup python for starting the tests
-        uses: actions/setup-python@v1.1.1
+        uses: actions/setup-python@v1
         with:
           python-version: 3.6
           architecture: 'x64'
@@ -42,7 +42,7 @@ jobs:
         if: runner.os != 'Windows'
 
       - name: Setup python ${{ matrix.python-version }} for running the tests
-        uses: actions/setup-python@v1.1.1
+        uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
           architecture: 'x64'

--- a/.github/workflows/acceptance_tests_jython.yml
+++ b/.github/workflows/acceptance_tests_jython.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Python 3.6
-        uses: actions/setup-python@v1.1.1
+        uses: actions/setup-python@v1
         with:
           python-version: '3.6.x'
           architecture: 'x64'


### PR DESCRIPTION
It would be better to receive fixes to setup-python action automatically within 1.x version. @Hi-Fi, would you take a look?