### PR TITLE
Add 'lineno' and 'source' attributes to V2 listener methods

### DIFF
--- a/atest/testresources/listeners/attributeverifyinglistener.py
+++ b/atest/testresources/listeners/attributeverifyinglistener.py
@@ -14,8 +14,8 @@ OUTFILE = open(os.path.join(os.getenv('TEMPDIR'), 'listener_attrs.txt'), 'w')
 START = 'doc starttime '
 END = START + 'endtime elapsedtime status '
 SUITE = 'id longname metadata source tests suites totaltests '
-TEST = 'id longname tags critical template originalname lineno '
-KW = ' kwname libname args assign tags type '
+TEST = 'id longname tags critical template originalname source lineno '
+KW = ' kwname libname args assign tags type lineno source '
 EXPECTED_TYPES = {'tags': [basestring], 'args': [basestring],
                   'assign': [basestring], 'metadata': {basestring: basestring},
                   'tests': [basestring], 'suites': [basestring],

--- a/doc/userguide/src/ExtendingRobotFramework/ListenerInterface.rst
+++ b/doc/userguide/src/ExtendingRobotFramework/ListenerInterface.rst
@@ -160,8 +160,10 @@ it. If that is needed, `listener version 3`_ can be used instead.
    |                  |                  |   critical or not.                                             |
    |                  |                  | * `template`: The name of the template used for the test.      |
    |                  |                  |   An empty string if the test not templated.                   |
+   |                  |                  | * `source`: An absolute path of the file which contains the    |
+   |                  |                  |   test. New in RF 3.2.                                         |
    |                  |                  | * `lineno`: Line number where the test starts in the source    |
-   |                  |                  |   file. New in RF 3.2.                                         |
+   |                  |                  |   file. New in RF 3.2.                                         |
    |                  |                  | * `starttime`: Test execution execution start time.            |
    +------------------+------------------+----------------------------------------------------------------+
    | end_test         | name, attributes | Called when a test case ends.                                  |
@@ -175,6 +177,7 @@ it. If that is needed, `listener version 3`_ can be used instead.
    |                  |                  | * `tags`: Same as in `start_test`.                             |
    |                  |                  | * `critical`: Same as in `start_test`.                         |
    |                  |                  | * `template`: Same as in `start_test`.                         |
+   |                  |                  | * `source`: Same as in `start_test`                            |
    |                  |                  | * `lineno`: Same as in `start_test`.                           |
    |                  |                  | * `starttime`: Same as in `start_test`.                        |
    |                  |                  | * `endtime`: Test execution execution end time.                |
@@ -208,6 +211,10 @@ it. If that is needed, `listener version 3`_ can be used instead.
    |                  |                  |   return value is assigned to.                                 |
    |                  |                  | * `tags`: `Keyword tags`_ as a list of strings. New in RF 3.0. |
    |                  |                  | * `starttime`: Keyword execution start time.                   |
+   |                  |                  | * `source`: An absolute path of the file from where the        |
+   |                  |                  |   keyword was called. New in RF 3.2                            |
+   |                  |                  | * `lineno`: Line number where the keyword was called from.     |
+   |                  |                  |   New in RF 3.2.                                               |
    +------------------+------------------+----------------------------------------------------------------+
    | end_keyword      | name, attributes | Called when a keyword ends.                                    |
    |                  |                  |                                                                |
@@ -229,6 +236,8 @@ it. If that is needed, `listener version 3`_ can be used instead.
    |                  |                  | * `elapsedtime`: Total execution time in milliseconds as       |
    |                  |                  |   an integer                                                   |
    |                  |                  | * `status`: Keyword status as string `PASS` or `FAIL`.         |
+   |                  |                  | * `source`: Same as with `start_keyword`.                      |
+   |                  |                  | * `lineno`: Same as with `start_keyword`.                      |
    +------------------+------------------+----------------------------------------------------------------+
    | log_message      | message          | Called when an executed keyword writes a log message.          |
    |                  |                  |                                                                |

--- a/src/robot/output/listenerarguments.py
+++ b/src/robot/output/listenerarguments.py
@@ -118,17 +118,23 @@ class StartTestArguments(_ListenerArgumentsFromItem):
     def _get_extra_attributes(self, test):
         return {'critical': 'yes' if test.critical else 'no',
                 'template': test.template or '',
-                'originalname': test.data.name}
+                'originalname': test.data.name,
+                'source': test.source or '',
+        }
 
 
 class EndTestArguments(StartTestArguments):
     _attribute_names = ('id', 'longname', 'doc', 'tags', 'lineno', 'starttime',
                         'endtime', 'elapsedtime', 'status', 'message')
 
+    def _get_extra_attribute(self, test):
+        return {
+            'source': test.source or '',
+        }
 
 class StartKeywordArguments(_ListenerArgumentsFromItem):
     _attribute_names = ('kwname', 'libname', 'doc', 'assign', 'tags',
-                        'starttime')
+                        'starttime', 'source', 'lineno')
     _types = {'kw': 'Keyword', 'setup': 'Setup', 'teardown': 'Teardown',
               'for': 'For', 'foritem': 'For Item'}
 
@@ -139,4 +145,4 @@ class StartKeywordArguments(_ListenerArgumentsFromItem):
 
 class EndKeywordArguments(StartKeywordArguments):
     _attribute_names = ('kwname', 'libname', 'doc', 'args', 'assign', 'tags',
-                        'starttime', 'endtime', 'elapsedtime', 'status')
+                        'starttime', 'endtime', 'elapsedtime', 'status', 'source', 'lineno')

--- a/src/robot/result/model.py
+++ b/src/robot/result/model.py
@@ -61,12 +61,12 @@ class Keyword(model.Keyword):
 
     See the base class for documentation of attributes not documented here.
     """
-    __slots__ = ['kwname', 'libname', 'status', 'starttime', 'endtime', 'message']
+    __slots__ = ['kwname', 'libname', 'status', 'starttime', 'endtime', 'message', 'lineno', 'source']
     message_class = Message
 
     def __init__(self, kwname='', libname='', doc='', args=(), assign=(),
                  tags=(), timeout=None, type='kw',  status='FAIL',
-                 starttime=None, endtime=None):
+                 starttime=None, endtime=None, source=None, lineno=None):
         model.Keyword.__init__(self, '', doc, args, assign, tags, timeout, type)
         #: Name of the keyword without library or resource name.
         self.kwname = kwname or ''
@@ -82,6 +82,10 @@ class Keyword(model.Keyword):
         self.endtime = endtime
         #: Keyword status message. Used only if suite teardowns fails.
         self.message = ''
+        #: Source file of the keyword
+        self.source = source or ''
+        #: line number of the keyword in the source file
+        self.lineno = -1 if lineno is None else lineno
 
     @property
     def elapsedtime(self):

--- a/src/robot/running/librarykeywordrunner.py
+++ b/src/robot/running/librarykeywordrunner.py
@@ -65,6 +65,8 @@ class LibraryKeywordRunner(object):
                              args=kw.args,
                              assign=tuple(assignment),
                              tags=handler.tags,
+                             source=kw.source,
+                             lineno=kw.lineno,
                              type=kw.type)
 
     def _run(self, context, args):

--- a/src/robot/running/steprunner.py
+++ b/src/robot/running/steprunner.py
@@ -79,7 +79,7 @@ class ForInRunner(object):
 
     def run(self, data, name=None):
         result = KeywordResult(kwname=self._get_name(data),
-                               type=data.FOR_LOOP_TYPE)
+                               type=data.FOR_LOOP_TYPE, lineno=data.lineno, source=data.source)
         with StatusReporter(self._context, result):
             self._validate(data)
             self._run(data)
@@ -222,7 +222,7 @@ class ForInRunner(object):
             self._context.variables[name] = value
         name = ', '.join(format_assign_message(n, v) for n, v in variables)
         result = KeywordResult(kwname=name,
-                               type=data.FOR_ITEM_TYPE)
+                               type=data.FOR_ITEM_TYPE, lineno=data.lineno, source=data.source)
         runner = StepRunner(self._context, self._templated)
         with StatusReporter(self._context, result):
             runner.run_steps(data.keywords)

--- a/src/robot/running/userkeywordrunner.py
+++ b/src/robot/running/userkeywordrunner.py
@@ -68,7 +68,9 @@ class UserKeywordRunner(object):
                              args=kw.args,
                              assign=tuple(assignment),
                              tags=tags,
-                             type=kw.type)
+                             type=kw.type,
+                             source=kw.source,
+                             lineno=kw.lineno)
 
     def _run(self, context, args, result):
         variables = context.variables


### PR DESCRIPTION
This is related to issue #3451, even though that issue was closed. 

This does _not_ add the source and lineno information to output.xml. While that might be useful, it would bloat the size of the xml considerably. I think it would be best to get the logic necessary to include the information in the listener, and then make the problem of saving the information to output.xml as a separate issue.
