### PR TITLE
Migrate workflows to Jython 2.7.2 on Java 8

### DIFF
--- a/.github/workflows/acceptance_tests_jython.yml
+++ b/.github/workflows/acceptance_tests_jython.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         java: [ '1.8' ]
         os: [ 'ubuntu-latest', 'windows-latest' ]
-        jython-version: [ '2.7.1' ]
+        jython-version: [ '2.7.2' ]
 
         include:
           - os: windows-latest

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -68,7 +68,7 @@ jobs:
       matrix:
         java: [ '1.8' ]
         os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
-        jython-version: [ '2.7.1' ]
+        jython-version: [ '2.7.2' ]
         include:
           - os: windows-latest
             set_codepage: chcp 850


### PR DESCRIPTION
- Drop running tests on Jython 2.7.1 / Java 8
- Start runnig tests on Jython 2.7.2 / Java 8