### PR TITLE
YAMLWarning fix. Deprecated function load() replaced with safe_load()…

### DIFF
--- a/src/robot/variables/filesetter.py
+++ b/src/robot/variables/filesetter.py
@@ -80,7 +80,7 @@ class YamlImporter(object):
                             'to be installed. Typically you can install it '
                             'by running `pip install pyyaml`.')
         if yaml.__version__.split('.')[0] == '3':
-            return yaml.load(stream)
+            return yaml.safe_load(stream)
         return yaml.full_load(stream)
 
 


### PR DESCRIPTION
YAMLLoadWarning fix: Use safe_load function insted of unsafe load() function to load YAML file.

PyYAML's load function has been unsafe since the first release in May 2006.
More info:
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation