### PR TITLE
Keyword arguments not used when resolving its documentation and tags …

### DIFF
--- a/atest/robot/tags/tags_with_variables.robot
+++ b/atest/robot/tags/tags_with_variables.robot
@@ -1,0 +1,20 @@
+*** Setting ***
+Suite Setup       Run Tests    ${EMPTY}    tags/tags_with_variables.robot
+Resource          atest_resource.robot
+
+*** Test Case ***
+External variable not resolved
+    ${tc}    Check test case    ${TEST NAME}
+    Check Keyword Data  ${tc.kws[1]}  Keyword attempting external tag    tags=\${external}
+
+Argument is resolved
+    ${tc}    Check test case    ${TEST NAME}
+    Check Keyword Data  ${tc.kws[0]}    Keyword with tag argument    
+                                 ...    args=This is an argument
+                                 ...    tags=This is an argument
+
+Part of tag as argument
+    ${tc}    Check test case    ${TEST NAME}
+    Check Keyword Data  ${tc.kws[0]}    Keyword with tag to complete
+                                 ...    args=very
+                                 ...    tags=Customisable tag is very cool

--- a/atest/testdata/tags/tags_with_variables.robot
+++ b/atest/testdata/tags/tags_with_variables.robot
@@ -1,0 +1,25 @@
+*** Test Case ***
+External variable not resolved
+    ${external variable}=    Set variable    xxx
+    Keyword attempting external tag
+
+Argument is resolved
+    Keyword with tag argument    This is an argument
+
+Part of tag as argument
+    Keyword with tag to complete    very
+
+*** Keywords ***
+Keyword with tag argument
+    [Tags]    ${this tag}
+    [Arguments]    ${this tag}
+    No Operation
+
+Keyword attempting external tag
+    [Tags]    ${external}
+    No Operation
+
+Keyword with tag to complete
+    [Tags]    Customisable tag is ${tag} cool
+    [Arguments]    ${tag}
+    No Operation


### PR DESCRIPTION
…#3238
The code has been modified to resolve the arguments before executing the keyword. This required splitting the StatusReporter context manager so that any resolution errors could be put into the reporting context.
All tests have passed except Telnet tests.
New tests have been added for tags with parameters.