### PR TITLE
Issue #3579: Incomplete draft of a solution

### DIFF
--- a/src/robot/model/filter.py
+++ b/src/robot/model/filter.py
@@ -40,12 +40,13 @@ class EmptySuiteRemover(SuiteVisitor):
 class Filter(EmptySuiteRemover):
 
     def __init__(self, include_suites=None, include_tests=None,
-                 include_tags=None, exclude_tags=None):
+                 include_tags=None, exclude_tags=None, memo=None):
         EmptySuiteRemover.__init__(self)
         self.include_suites = include_suites
         self.include_tests = include_tests
         self.include_tags = include_tags
         self.exclude_tags = exclude_tags
+        self.memo = dict() if memo is None else memo
 
     @setter
     def include_suites(self, suites):
@@ -58,12 +59,12 @@ class Filter(EmptySuiteRemover):
             if not isinstance(tests, TestNamePatterns) else tests
 
     @setter
-    def include_tags(self, tags):
-        return TagPatterns(tags) if not isinstance(tags, TagPatterns) else tags
+    def include_tags(self, tag_patterns):
+        return TagPatterns(tag_patterns, self.memo) if not isinstance(tag_patterns, TagPatterns) else tag_patterns
 
     @setter
-    def exclude_tags(self, tags):
-        return TagPatterns(tags) if not isinstance(tags, TagPatterns) else tags
+    def exclude_tags(self, tag_patterns):
+        return TagPatterns(tag_patterns, self.memo) if not isinstance(tag_patterns, TagPatterns) else tag_patterns
 
     def start_suite(self, suite):
         if not self:


### PR DESCRIPTION
Employ memoization to speed up tag filtering.

- This is a first draft.
- Unit tests not edited at all.
- Not sure about storing to self._memo everywhere.
- Not sure if normalization is applied everywhere needed.
+ Normalization applied in most places.
+ Memo dictionary is passed from callers, created empty if needed.
+ Memo dictionary uses normalized pattern or tag as the key.
+ Multiple copies of the same pattern for SingleTagPattern do not duplicate matchers.
+ Each such matcher has memo dictionary to store (normalized) tag match results.
+ Calls to the same matcher with the same tag return the memoized result.
- Matcher memo should probably have different name than result memo.

Signed-off-by: Vratko Polak <vrpolak@cisco.com>