### PR TITLE
Enable tidy to preserve whitespaces

### DIFF
--- a/atest/robot/tidy/tidy.robot
+++ b/atest/robot/tidy/tidy.robot
@@ -8,6 +8,9 @@ Tidying single test case file spaces -> spaces
     Run tidy with golden file and check result    ${EMPTY}    golden.robot
     Run tidy with golden file and check result    --spacecount 2    golden_two_spaces.robot
 
+Tidying single test case file with preserved spaces
+    Run tidy with golden file and check result    --spacecount preserve    golden.robot    input=golden.robot
+
 Tidying single test case file spaces -> pipes
     Run tidy with golden file and check result    --usepipes    golden_pipes.robot
 

--- a/doc/userguide/src/SupportingTools/Tidy.rst
+++ b/doc/userguide/src/SupportingTools/Tidy.rst
@@ -40,8 +40,9 @@ Options
                   option is used. Does not process referenced resource files.
  -p, --usepipes   Use a pipe character (`|`) as a column separator in the plain
                   text format.
- -s, --spacecount <number>
+ -s, --spacecount <number|preserve>
                   The number of spaces between cells in the plain text format.
+                  To leave whitespaces unchanged use value `preserve`.
                   Default is 4.
  -l, --lineseparator <native|windows|unix>
                   Line separator to use in outputs. The default is *native*.

--- a/src/robot/tidy.py
+++ b/src/robot/tidy.py
@@ -75,8 +75,9 @@ Options
                  are processed in-place similarly as when --inplace option
                  is used. Does not process referenced resource files.
  -p --usepipes   Use pipe ('|') as a column separator in the plain text format.
- -s --spacecount number
+ -s --spacecount number|preserve
                  The number of spaces between cells in the plain text format.
+                 To leave whitespaces unchanged use value 'preserve'.
                  Default is 4.
  -l --lineseparator native|windows|unix
                  Line separator to use in outputs. The default is 'native'.
@@ -258,7 +259,7 @@ class ArgumentValidator(object):
             if spacecount < 2:
                 raise ValueError
         except ValueError:
-            raise DataError('--spacecount must be an integer greater than 1.')
+            raise DataError('--spacecount must be of value "preserve" or an integer greater than 1.')
         return spacecount
 
 

--- a/src/robot/tidy.py
+++ b/src/robot/tidy.py
@@ -259,7 +259,7 @@ class ArgumentValidator(object):
             if spacecount < 2:
                 raise ValueError
         except ValueError:
-            raise DataError('--spacecount must be of value "preserve" or an integer greater than 1.')
+            raise DataError('--spacecount must be either "preserve" or an integer greater than 1.')
         return spacecount
 
 

--- a/src/robot/tidy.py
+++ b/src/robot/tidy.py
@@ -166,7 +166,7 @@ class Tidy(SuiteStructureVisitor):
         Aligner(self.short_test_name_length,
                 self.setting_and_variable_name_length,
                 self.use_pipes,
-                self.space_count).visit(model)
+                self.space_count == 'preserve').visit(model)
         model.save(output)
 
     def visit_file(self, file):

--- a/src/robot/tidy.py
+++ b/src/robot/tidy.py
@@ -140,7 +140,7 @@ class Tidy(SuiteStructureVisitor):
     def inplace(self, *paths):
         """Tidy file(s) in-place.
 
-        :param paths: Paths of the files to to process.
+        :param paths: Paths of the files to process.
         """
         for path in paths:
             model = get_model(path)
@@ -164,7 +164,8 @@ class Tidy(SuiteStructureVisitor):
         SeparatorNormalizer(self.use_pipes, self.space_count).visit(model)
         Aligner(self.short_test_name_length,
                 self.setting_and_variable_name_length,
-                self.use_pipes).visit(model)
+                self.use_pipes,
+                self.space_count).visit(model)
         model.save(output)
 
     def visit_file(self, file):
@@ -250,6 +251,8 @@ class ArgumentValidator(object):
             raise DataError("Invalid line separator '%s'." % lineseparator)
 
     def spacecount(self, spacecount):
+        if spacecount.lower() == 'preserve':
+            return spacecount
         try:
             spacecount = int(spacecount)
             if spacecount < 2:

--- a/src/robot/tidy.py
+++ b/src/robot/tidy.py
@@ -115,6 +115,8 @@ class Tidy(SuiteStructureVisitor):
 
     def __init__(self, space_count=4, use_pipes=False,
                  line_separator=os.linesep):
+        if isinstance(space_count, str):
+            space_count = space_count.lower()
         self.space_count = space_count
         self.use_pipes = use_pipes
         self.line_separator = line_separator

--- a/src/robot/tidypkg/transformers.py
+++ b/src/robot/tidypkg/transformers.py
@@ -369,12 +369,12 @@ class Aligner(ModelTransformer):
 
     def __init__(self, short_test_name_length,
                  setting_and_variable_name_length,
-                 pipes_mode, space_count):
+                 pipes_mode, preserve_spaces):
         self.short_test_name_length = short_test_name_length
         self.setting_and_variable_name_length = \
             setting_and_variable_name_length
         self.pipes_mode = pipes_mode
-        self.space_count = space_count
+        self.preserve_spaces = preserve_spaces
 
     def visit_TestCaseSection(self, section):
         if len(section.header.data_tokens) > 1:
@@ -400,6 +400,8 @@ class Aligner(ModelTransformer):
         return statement
 
     def _should_be_aligned(self, tokens):
+        if self.preserve_spaces:
+            return False
         if not tokens:
             return False
         if len(tokens) == 1:

--- a/src/robot/tidypkg/transformers.py
+++ b/src/robot/tidypkg/transformers.py
@@ -225,7 +225,6 @@ class SeparatorNormalizer(ModelTransformer):
             else:
                 if index == 0:
                     token.value = ' ' * 4 * self.indent
-
         # The last token is always EOL, this removes all dangling whitespace
         # from the token before the EOL
         if index == line_length - 2:
@@ -393,7 +392,7 @@ class Aligner(ModelTransformer):
                             not in (Token.SEPARATOR, Token.EOL)]
             if self._should_be_aligned(value_tokens):
                 first = value_tokens[0]
-                if self.space_count != 'preserve':
+                if not self.preserve_spaces:
                     first.value = first.value.ljust(
                         self.setting_and_variable_name_length
                     )

--- a/utest/tidy/test_argument_validation.py
+++ b/utest/tidy/test_argument_validation.py
@@ -17,7 +17,7 @@ class TestArgumentValidation(unittest.TestCase):
         assert_equal(opts['spacecount'], 42)
 
     def test_invalid_space_count(self):
-        error = '--spacecount must be of value "preserve" or an integer greater than 1.'
+        error = '--spacecount must be either "preserve" or an integer greater than 1.'
         self._validate(spacecount='not a number', error=error)
         self._validate(spacecount='1', error=error)
         self._validate(spacecount='preserv', error=error)

--- a/utest/tidy/test_argument_validation.py
+++ b/utest/tidy/test_argument_validation.py
@@ -17,9 +17,14 @@ class TestArgumentValidation(unittest.TestCase):
         assert_equal(opts['spacecount'], 42)
 
     def test_invalid_space_count(self):
-        error = '--spacecount must be an integer greater than 1.'
+        error = '--spacecount must be of value "preserve" or an integer greater than 1.'
         self._validate(spacecount='not a number', error=error)
         self._validate(spacecount='1', error=error)
+        self._validate(spacecount='preserv', error=error)
+
+    def test_valid_alternative_space_count(self):
+        opts, _ = self._validate(spacecount='preserve')
+        assert_equal(opts['spacecount'], 'preserve')
 
     def test_inplace_and_recursive_cannot_be_used_together(self):
         self._validate(inplace=True, recursive=True,


### PR DESCRIPTION
I implemented changes in tidy according to issue #3353  
Now tidy accepts value `preserve` for option `--spacecount` as well as integers like before. The new value tells tidy to not mess with whitespaces and leave them as they are when producing output file. It is very helpful for RF coders that use whitespaces to align code vertically so that it is easier to read. I updated also help message to include this change and added corresponding unit and acceptance tests. Some update to documentation may also be required. I fixed also some typos.
The implementation may seem not very clever and pretty, but I am open to all criticism :)