### PR TITLE
Enum conversion with normalized names. Implements #3611

### DIFF
--- a/atest/testdata/keywords/type_conversion/Annotations.py
+++ b/atest/testdata/keywords/type_conversion/Annotations.py
@@ -11,7 +11,7 @@ from robot.api.deco import keyword
 class MyEnum(Enum):
     FOO = 1
     bar = 'xxx'
-
+    foo = 'yyy'
 
 class Unknown(object):
     pass

--- a/atest/testdata/keywords/type_conversion/KeywordDecorator.py
+++ b/atest/testdata/keywords/type_conversion/KeywordDecorator.py
@@ -18,6 +18,7 @@ from robot.utils import PY2, unicode
 class MyEnum(Enum):
     FOO = 1
     bar = 'xxx'
+    foo = 'yyy'
 
 
 class Unknown(object):

--- a/atest/testdata/keywords/type_conversion/annotations.robot
+++ b/atest/testdata/keywords/type_conversion/annotations.robot
@@ -165,13 +165,15 @@ Invalid timedelta
 Enum
 
     Enum                 FOO                       MyEnum.FOO
-    Enum                 bar                       MyEnum.bar
-    Enum                 BAR                       MyEnum.bar
+    Enum                 foo                       MyEnum.foo
+    Enum                 b a r                     MyEnum.bar
+    Enum                 BAr                       MyEnum.bar
+    Enum                 B_A_r                     MyEnum.bar
 
 Invalid Enum
     [Template]           Conversion Should Fail
-    Enum                 foobar                    type=MyEnum          error=MyEnum does not have member 'foobar'. Available: 'FOO' and 'bar'
-    Enum                 bar!                      type=MyEnum          error=MyEnum does not have member 'bar!'. Available: 'FOO' and 'bar'
+    Enum                 foobar                    type=MyEnum          error=MyEnum does not have member 'foobar'. Available: 'FOO', 'bar' and 'foo'
+    Enum                 bar!                      type=MyEnum          error=MyEnum does not have member 'bar!'. Available: 'FOO', 'bar' and 'foo'
 
 NoneType
     NoneType             None                      None

--- a/atest/testdata/keywords/type_conversion/annotations.robot
+++ b/atest/testdata/keywords/type_conversion/annotations.robot
@@ -166,11 +166,12 @@ Enum
 
     Enum                 FOO                       MyEnum.FOO
     Enum                 bar                       MyEnum.bar
+    Enum                 BAR                       MyEnum.bar
 
 Invalid Enum
     [Template]           Conversion Should Fail
-    Enum                 foobar                    type=MyEnum           error=MyEnum does not have member 'foobar'. Available: 'FOO' and 'bar'
-    Enum                 BAR                       type=MyEnum           error=MyEnum does not have member 'BAR'. Available: 'FOO' and 'bar'
+    Enum                 foobar                    type=MyEnum          error=MyEnum does not have member 'foobar'. Available: 'FOO' and 'bar'
+    Enum                 bar!                      type=MyEnum          error=MyEnum does not have member 'bar!'. Available: 'FOO' and 'bar'
 
 NoneType
     NoneType             None                      None

--- a/atest/testdata/keywords/type_conversion/keyword_decorator.robot
+++ b/atest/testdata/keywords/type_conversion/keyword_decorator.robot
@@ -173,7 +173,7 @@ Invalid Enum
     [Tags]               require-enum
     [Template]           Conversion Should Fail
     Enum                 foobar                    type=MyEnum           error=MyEnum does not have member 'foobar'. Available: 'FOO' and 'bar'
-    Enum                 BAR                       type=MyEnum           error=MyEnum does not have member 'BAR'. Available: 'FOO' and 'bar'
+    Enum                 bar!                      type=MyEnum           error=MyEnum does not have member 'bar!'. Available: 'FOO' and 'bar'
 
 NoneType
     NoneType             None                      None

--- a/atest/testdata/keywords/type_conversion/keyword_decorator.robot
+++ b/atest/testdata/keywords/type_conversion/keyword_decorator.robot
@@ -167,13 +167,16 @@ Invalid timedelta
 Enum
     [Tags]               require-enum
     Enum                 FOO                       MyEnum.FOO
-    Enum                 bar                       MyEnum.bar
+    Enum                 foo                       MyEnum.foo
+    Enum                 b a r                     MyEnum.bar
+    Enum                 BAr                       MyEnum.bar
+    Enum                 B_A_r                     MyEnum.bar
 
 Invalid Enum
     [Tags]               require-enum
     [Template]           Conversion Should Fail
-    Enum                 foobar                    type=MyEnum           error=MyEnum does not have member 'foobar'. Available: 'FOO' and 'bar'
-    Enum                 bar!                      type=MyEnum           error=MyEnum does not have member 'bar!'. Available: 'FOO' and 'bar'
+    Enum                 foobar                    type=MyEnum           error=MyEnum does not have member 'foobar'. Available: 'FOO', 'bar' and 'foo'
+    Enum                 bar!                      type=MyEnum           error=MyEnum does not have member 'bar!'. Available: 'FOO', 'bar' and 'foo'
 
 NoneType
     NoneType             None                      None

--- a/doc/userguide/src/ExtendingRobotFramework/CreatingTestLibraries.rst
+++ b/doc/userguide/src/ExtendingRobotFramework/CreatingTestLibraries.rst
@@ -1394,11 +1394,13 @@ case-insensitive.
    +-------------+---------------+------------+----------------------------------------------------------------+--------------------------------------+
    | Enum_       |               |            | The specified type must be an enumeration (a subclass of       | .. sourcecode:: python               |
    |             |               |            | Enum_) and arguments themselves must match its members.        |                                      |
-   |             |               |            |                                                                |    class Color(Enum):                |
-   |             |               |            |                                                                |        RED = 1                       |
+   |             |               |            | Starting from RF 3.2.2, matching members is case-, underscore- |    class Color(Enum):                |
+   |             |               |            | and whitespace-insensitive.                                        |        RED = 1                       |
    |             |               |            |                                                                |        GREEN = 2                     |
+   |             |               |            |                                                                |        DARKGREEN = 3                 |
    |             |               |            |                                                                |                                      |
-   |             |               |            |                                                                | | `GREEN`                            |
+   |             |               |            |                                                                | | `GREEN` (Color.GREEN)              |
+   |             |               |            |                                                                | | `Dark Green` (Color.DARKGREEN)     |
    +-------------+---------------+------------+----------------------------------------------------------------+--------------------------------------+
    | NoneType_   |               |            | String `NONE` (case-insensitively) is converted to `None`      | | `None`                             |
    |             |               |            | object, other values are passed as-is. Mainly relevant when    |                                      |

--- a/src/robot/running/arguments/typeconverters.py
+++ b/src/robot/running/arguments/typeconverters.py
@@ -263,9 +263,9 @@ class EnumConverter(TypeConverter):
             return getattr(self._enum, value)
         except AttributeError:
             members = self._get_members(self._enum)
-            normalized_value = normalize(value)
+            normalized_value = normalize(value, ignore='_')
             for member in members:
-                if normalize(member) == normalized_value:
+                if normalize(member, ignore='_') == normalized_value:
                     return getattr(self._enum, member)
             raise ValueError("%s does not have member '%s'. Available: %s"
                              % (self.type_name, value, seq2str(members)))

--- a/src/robot/running/arguments/typeconverters.py
+++ b/src/robot/running/arguments/typeconverters.py
@@ -30,7 +30,7 @@ from numbers import Integral, Real
 
 from robot.libraries.DateTime import convert_date, convert_time
 from robot.utils import (FALSE_STRINGS, IRONPYTHON, TRUE_STRINGS, PY_VERSION,
-                         PY2, seq2str, type_name, unicode)
+                         PY2, normalize, seq2str, type_name, unicode)
 
 
 class TypeConverter(object):
@@ -263,6 +263,10 @@ class EnumConverter(TypeConverter):
             return getattr(self._enum, value)
         except AttributeError:
             members = self._get_members(self._enum)
+            normalized_value = normalize(value)
+            for member in members:
+                if normalize(member) == normalized_value:
+                    return getattr(self._enum, member)
             raise ValueError("%s does not have member '%s'. Available: %s"
                              % (self.type_name, value, seq2str(members)))
 


### PR DESCRIPTION
I have implemented the enhancement proposed in issue #3611. The changes are backwards compatible as the member is first matched without normalization.