### PR TITLE
Libdoc html in-browser switch to list one shortcut per line

### DIFF
--- a/src/robot/htmldata/libdoc/libdoc.css
+++ b/src/robot/htmldata/libdoc/libdoc.css
@@ -39,25 +39,37 @@ a:hover {
     font-weight: bold;
     letter-spacing: 0.1em;
 }
-.shortcuts-style-select {
-    border: 0;
-    padding: 0;
-}
-.shortcuts-style-select label {
+label.switch {
     background-color: white;
-    border: 1px solid #c30;
-    border-radius: 2px;
-    color: #c30;
     cursor: pointer;
+    position: relative;
 }
-.shortcuts-style-select input[type="radio"] {
+input.switch {
     display: none;
 }
-.shortcuts-style-select input[type="radio"]:checked ~ span {
-    background: #c30 !important;
-    border: 1px solid #c30;
-    border-radius: 2px;
-    color: white;
+.slider {
+    background-color: grey;
+    display: inline-block;
+    height: 20px;
+    position: relative;
+    top: 5px;
+    width: 40px;
+}
+.slider:before {
+    background-color: white;
+    content: "";
+    height: 14px;
+    left: 3px;
+    position: absolute;
+    top: 3px;
+    width: 14px;
+}
+input.switch:checked + .slider::before {
+    background-color: white;
+    left: 22px;
+}
+input.switch:checked + .slider {
+    background-color: #c30;
 }
 .shortcuts .one-per-line {
     display: none;

--- a/src/robot/htmldata/libdoc/libdoc.css
+++ b/src/robot/htmldata/libdoc/libdoc.css
@@ -39,6 +39,29 @@ a:hover {
     font-weight: bold;
     letter-spacing: 0.1em;
 }
+.shortcuts-style-select {
+    border: 0;
+    padding: 0;
+}
+.shortcuts-style-select label {
+    background-color: white;
+    border: 1px solid #c30;
+    border-radius: 2px;
+    color: #c30;
+    cursor: pointer;
+}
+.shortcuts-style-select input[type="radio"] {
+    display: none;
+}
+.shortcuts-style-select input[type="radio"]:checked ~ span {
+    background: #c30 !important;
+    border: 1px solid #c30;
+    border-radius: 2px;
+    color: white;
+}
+.shortcuts .one-per-line {
+    display: none;
+}
 .normal-first-letter::first-letter {
     font-weight: normal !important;
     letter-spacing: 0 !important;

--- a/src/robot/htmldata/libdoc/libdoc.html
+++ b/src/robot/htmldata/libdoc/libdoc.html
@@ -319,14 +319,32 @@
 
 <script type="text/x-jquery-tmpl" id="shortcuts-template">
     <h2 id="Shortcuts">Shortcuts</h2>
+    {{if keywords.length > 3}}
+    <fieldset class="shortcuts-style-select">
+        <span>List style:</span>
+        <label title="Shortcut list uses minimum height."><input type="radio" name="shortcut-liststyle" checked="checked" value="All in one line" onclick="$('.shortcuts .all-in-one').show();$('.shortcuts .one-per-line').hide();"><span>All in one line</span></label>
+        <label title="One per line may be easier to spot."><input type="radio" name="shortcut-liststyle" value="One per line" onclick="$('.shortcuts .all-in-one').hide();$('.shortcuts .one-per-line').show();"><span>One per line</span></label>
+    </fieldset>
+    {{/if}}
     <div class='shortcuts'>
-        {{each keywords}}
-        <a href="#${encodeURIComponent($value.name)}"
-           class="{{if $value.matched === false}}no-{{/if}}match"
-           title="${$value.shortdoc}">${$value.name}</a>
-        {{if $index < keywords.length-1}}&middot;{{/if}}
-        {{/each}}
+        <div class='all-in-one'>
+            {{each keywords}}
+            <a href="#${encodeURIComponent($value.name)}"
+            class="{{if $value.matched === false}}no-{{/if}}match"
+            title="${$value.shortdoc}">${$value.name}</a>
+            {{if $index < keywords.length-1}}&middot;{{/if}}
+            {{/each}}
+        </div>
+        <div class='one-per-line'>
+            {{each keywords}}
+            <a href="#${encodeURIComponent($value.name)}"
+            class="{{if $value.matched === false}}no-{{/if}}match"
+            title="${$value.shortdoc}">${$value.name}</a>
+            {{if $index < keywords.length-1}}<br>{{/if}}
+            {{/each}}
+        </div>
     </div>
+
 </script>
 
 <script type="text/x-jquery-tmpl" id="tags-template">

--- a/src/robot/htmldata/libdoc/libdoc.html
+++ b/src/robot/htmldata/libdoc/libdoc.html
@@ -320,11 +320,11 @@
 <script type="text/x-jquery-tmpl" id="shortcuts-template">
     <h2 id="Shortcuts">Shortcuts</h2>
     {{if keywords.length > 3}}
-    <fieldset class="shortcuts-style-select">
-        <span>List style:</span>
-        <label title="Shortcut list uses minimum height."><input type="radio" name="shortcut-liststyle" checked="checked" value="All in one line" onclick="$('.shortcuts .all-in-one').show();$('.shortcuts .one-per-line').hide();"><span>All in one line</span></label>
-        <label title="One per line may be easier to spot."><input type="radio" name="shortcut-liststyle" value="One per line" onclick="$('.shortcuts .all-in-one').hide();$('.shortcuts .one-per-line').show();"><span>One per line</span></label>
-    </fieldset>
+        <span>Expanded shortcut list</span>
+        <label class="switch" title="Switch between compact list or expanded list">
+            <input type="checkbox" class="switch" onclick="$('.shortcuts .all-in-one').toggle();$('.shortcuts .one-per-line').toggle();">
+            <span class="slider"></span>
+        </label>
     {{/if}}
     <div class='shortcuts'>
         <div class='all-in-one'>
@@ -344,7 +344,6 @@
             {{/each}}
         </div>
     </div>
-
 </script>
 
 <script type="text/x-jquery-tmpl" id="tags-template">


### PR DESCRIPTION
Hi,
when reading the library documentation in a web browser, I would like to have a list of the "shortcuts" (keywords) one per line, because for me it seems easier to read.

With the attached pull request, the HTML page created by libdoc looks like this:

![RF_libdoc_after_](https://user-images.githubusercontent.com/69890168/90648039-57aa1900-e239-11ea-84ef-b3a011c4d3f2.png)

A click on "One per line" switches the list to one keyword per line:
![RF_libdoc_after_one-per-line_](https://user-images.githubusercontent.com/69890168/90648053-5d076380-e239-11ea-8682-8bc4c75a013f.png)

The new optional "One per line" shortcuts list style takes more vertical place. However, it may be easier to spot a specific keyword than in the compact list. It is possible to switch back to the original style in the browser.

Tested for the libraries from Robot Framework source and for SeleniumLibrary in Google Chrome 84, Mozilla Firefox 79 and Internet Explorer 11.

Best Regards,
Rudolf