### PR TITLE
Fix tests on Jython 2.7.2 (Java 8) on Linux/Ubuntu

### DIFF
--- a/.github/workflows/acceptance_tests_jython.yml
+++ b/.github/workflows/acceptance_tests_jython.yml
@@ -1,8 +1,12 @@
 name: Acceptance tests (Jython)
 
 on:
+  push:
   schedule:
     - cron: '0 */12 * * *'
+
+env:
+  JAVA_TOOL_OPTIONS:
 
 jobs:
   test_using_jython:

--- a/.github/workflows/acceptance_tests_jython.yml
+++ b/.github/workflows/acceptance_tests_jython.yml
@@ -1,7 +1,6 @@
 name: Acceptance tests (Jython)
 
 on:
-  push:
   schedule:
     - cron: '0 */12 * * *'
 

--- a/.github/workflows/acceptance_tests_jython.yml
+++ b/.github/workflows/acceptance_tests_jython.yml
@@ -5,9 +5,6 @@ on:
   schedule:
     - cron: '0 */12 * * *'
 
-env:
-  JAVA_TOOL_OPTIONS:
-
 jobs:
   test_using_jython:
     strategy:
@@ -26,7 +23,7 @@ jobs:
           - os: ubuntu-latest
             jython_dir: $GITHUB_WORKSPACE/jython
             jython_cmd: $GITHUB_WORKSPACE/jython/bin/jython
-            set_jython_env: export JYTHON_HOME=$GITHUB_WORKSPACE/jython; export CLASSPATH=$JAVA_HOME/lib/tools.jar;
+            set_jython_env: export JYTHON_HOME=$GITHUB_WORKSPACE/jython; export CLASSPATH=$JAVA_HOME/lib/tools.jar; unset JAVA_TOOL_OPTIONS
             set_display: export DISPLAY=:99; Xvfb :99 -screen 0 1024x768x24 -ac -noreset & sleep 3
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Recently, Github Actions started defining "JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8" variable on Linux hosts, but this variable prevents acceptance tests from proper execution.

The error is:
```
Traceback (most recent call last):
  File "atest/run.py", line 126, in <module>
    rc = atests(*sys.argv[1:])
  File "atest/run.py", line 58, in atests
    interpreter = InterpreterFactory(interpreter)
  File "/home/runner/work/robotframework/robotframework/atest/interpreter.py", line 21, in InterpreterFactory
    return Interpreter(path, name, version)
  File "/home/runner/work/robotframework/robotframework/atest/interpreter.py", line 30, in __init__
    name, version = self._get_name_and_version()
  File "/home/runner/work/robotframework/robotframework/atest/interpreter.py", line 49, in _get_name_and_version
    version = re.match(r'\d+\.\d+\.\d+', version).group()
AttributeError: 'NoneType' object has no attribute 'group'
```

If JAVA_TOOL_OPTIONS is not set, tests run fine. It looks to be an issue in Jython itself. Found in [2nd point of comment](https://github.com/robotframework/robotframework/issues/3501#issuecomment-677719760).

This happens when `Jython -V` invoked by atest/interpreter.py, if JAVA_TOOL_OPTIONS is unset, it returns only version on a one line, otherwise, it returns 2 lines where the first line is `Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8` and second line is Jython version.

Related issue on GHA side: https://github.com/actions/virtual-environments/issues/1437