### PR TITLE
Split keyword argument lines

### DIFF
--- a/src/robot/htmldata/libdoc/libdoc.html
+++ b/src/robot/htmldata/libdoc/libdoc.html
@@ -367,7 +367,7 @@
         </td>
         <td class="args">
             {{each args}}
-            <span>${$value}</span>{{if $index < args.length-1}}, {{/if}}
+            <span>${$value}</span>{{if $index < args.length-1}},<br/>{{/if}}
             {{/each}}
         </td>
         {{if libdoc.contains_tags}}


### PR DESCRIPTION
We should put this behind a command line flag or such to let users choose if splitting is preferred.