### PR TITLE
Also suppress errno.EBADF for broken pipe error

### DIFF
--- a/src/robot/output/console/highlighting.py
+++ b/src/robot/output/console/highlighting.py
@@ -70,7 +70,7 @@ class HighlightingStream(object):
         try:
             yield
         except IOError as err:
-            if err.errno not in (errno.EPIPE, errno.EINVAL):
+            if err.errno not in (errno.EPIPE, errno.EINVAL, errno.EBADF):
                 raise
 
     def flush(self):


### PR DESCRIPTION
This fixes the stack trace I have below when running robotframework with pytest in a windows console (although I'm not sure why it happens in the first place... pytest probably does some mocking that robotframework doesn't like).

```
  File "c:\bin\miniconda\envs\py_38_tests\lib\site-packages\robot\run.py", line 492, in run_cli
    return RobotFramework().execute_cli(arguments, exit=exit)
  File "c:\bin\miniconda\envs\py_38_tests\lib\site-packages\robot\utils\application.py", line 46, in execute_cli
    rc = self._execute(arguments, options)
  File "c:\bin\miniconda\envs\py_38_tests\lib\site-packages\robot\utils\application.py", line 91, in _execute
    return self._report_error('Unexpected error: %s' % error,
  File "c:\bin\miniconda\envs\py_38_tests\lib\site-packages\robot\utils\application.py", line 106, in _report_error
    self._logger.error(message)
  File "c:\bin\miniconda\envs\py_38_tests\lib\site-packages\robot\output\loggerhelper.py", line 60, in error
    self.write(msg, 'ERROR')
  File "c:\bin\miniconda\envs\py_38_tests\lib\site-packages\robot\output\loggerhelper.py", line 63, in write
    self.message(Message(message, level, html))
  File "c:\bin\miniconda\envs\py_38_tests\lib\site-packages\robot\output\logger.py", line 145, in message
    logger.message(msg)
  File "c:\bin\miniconda\envs\py_38_tests\lib\site-packages\robot\output\console\verbose.py", line 67, in message
    self._writer.error(msg.message, msg.level, clear=self._running_test)
  File "c:\bin\miniconda\envs\py_38_tests\lib\site-packages\robot\output\console\verbose.py", line 145, in error
    self._stderr.error(message, level)
  File "c:\bin\miniconda\envs\py_38_tests\lib\site-packages\robot\output\console\highlighting.py", line 102, in error
    self.highlight(level, flush=False)
  File "c:\bin\miniconda\envs\py_38_tests\lib\site-packages\robot\output\console\highlighting.py", line 89, in highlight
    self.flush()
  File "c:\bin\miniconda\envs\py_38_tests\lib\site-packages\robot\output\console\highlighting.py", line 85, in flush
    self.stream.flush()
OSError: [WinError 6] The handle is invalid
```