### PR TITLE
Remove EOL Python 3.4 from officially supported versions in setup.py and README

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -117,11 +117,13 @@ a good place to start is http://python.org. There you can download a suitable
 installer and get more information about the installation process and Python
 in general.
 
-Robot Framework 3.2 supports Python 2.7 and Python 3.4 and newer, but the `plan
+Robot Framework 4.0 supports Python 2.7 and Python 3.5 and newer, but the `plan
 is to drop Python 2 support soon`__ and require Python 3.6 or newer. If you
-need to use older Python versions, Robot Framework 3.0 supports Python 2.6,
-Robot Framework 2.5-2.8 support Python 2.5, and Robot Framework 2.0-2.1
-support Python 2.3 and 2.4.
+need to use older Python versions,
+Robot Framework 3.2 supports Python 3.4,
+Robot Framework 3.0 supports Python 2.6,
+Robot Framework 2.5-2.8 support Python 2.5,
+and Robot Framework 2.0-2.1 support Python 2.3 and 2.4.
 
 After installing Python, you probably still want to configure PATH_ to make
 Python itself as well as the ``robot`` and ``rebot`` `runner scripts`_

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -118,12 +118,7 @@ installer and get more information about the installation process and Python
 in general.
 
 Robot Framework 4.0 supports Python 2.7 and Python 3.5 and newer, but the `plan
-is to drop Python 2 support soon`__ and require Python 3.6 or newer. If you
-need to use older Python versions,
-Robot Framework 3.2 supports Python 3.4,
-Robot Framework 3.0 supports Python 2.6,
-Robot Framework 2.5-2.8 support Python 2.5,
-and Robot Framework 2.0-2.1 support Python 2.3 and 2.4.
+is to drop Python 2 support soon`__ and require Python 3.6 or newer.
 
 After installing Python, you probably still want to configure PATH_ to make
 Python itself as well as the ``robot`` and ``rebot`` `runner scripts`_

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python or Java.
 
 Robot Framework is operating system and application independent. The core
 framework is implemented using `Python <http://python.org>`_, supports both
-Python 2 and Python 3, and runs also on `Jython <http://jython.org>`_ (JVM),
+Python 2.7 and Python 3.5+, and runs also on `Jython <http://jython.org>`_ (JVM),
 `IronPython <http://ironpython.net>`_ (.NET) and `PyPy <http://pypy.org>`_.
 The framework has a rich ecosystem around it consisting of various generic
 libraries and tools that are developed as separate projects. For more

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ Operating System :: OS Independent
 Programming Language :: Python :: 2
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7


### PR DESCRIPTION
Fixes #3577.