### PR TITLE
timezone aware timestamps

### DIFF
--- a/src/robot/conf/settings.py
+++ b/src/robot/conf/settings.py
@@ -69,7 +69,8 @@ class _BaseSettings(object):
                  'ConsoleColors'    : ('consolecolors', 'AUTO'),
                  'StdOut'           : ('stdout', None),
                  'StdErr'           : ('stderr', None),
-                 'XUnitSkipNonCritical' : ('xunitskipnoncritical', False)}
+                 'XUnitSkipNonCritical' : ('xunitskipnoncritical', False),
+                 'XOutputTimeInfo'  : ('xoutputtimeinfo', False)}
     _output_opts = ['Output', 'Log', 'Report', 'XUnit', 'DebugFile']
 
     def __init__(self, options=None, **extra_options):
@@ -137,6 +138,7 @@ class _BaseSettings(object):
             self._validate_expandkeywords(value)
         if name == 'Extension':
             return tuple(ext.lower().lstrip('.') for ext in value.split(':'))
+
         return value
 
     def _escape_as_data(self, value):
@@ -349,6 +351,10 @@ class _BaseSettings(object):
     @property
     def xunit_skip_noncritical(self):
         return self['XUnitSkipNonCritical']
+
+    @property
+    def xoutput_timeinfo(self):
+        return self['XOutputTimeInfo']
 
     @property
     def statistics_config(self):

--- a/src/robot/conf/settings.py
+++ b/src/robot/conf/settings.py
@@ -70,7 +70,8 @@ class _BaseSettings(object):
                  'StdOut'           : ('stdout', None),
                  'StdErr'           : ('stderr', None),
                  'XUnitSkipNonCritical' : ('xunitskipnoncritical', False),
-                 'XOutputTimeInfo'  : ('xoutputtimeinfo', False)}
+                 'XOutputTimeInfo'  : ('xoutputtimeinfo', False),
+                 'TimestampFormat'  : ('timestampformat', None)}
     _output_opts = ['Output', 'Log', 'Report', 'XUnit', 'DebugFile']
 
     def __init__(self, options=None, **extra_options):
@@ -355,6 +356,10 @@ class _BaseSettings(object):
     @property
     def xoutput_timeinfo(self):
         return self['XOutputTimeInfo']
+
+    @property
+    def timestamp_format(self):
+        return self['TimestampFormat']
 
     @property
     def statistics_config(self):

--- a/src/robot/conf/settings.py
+++ b/src/robot/conf/settings.py
@@ -71,7 +71,7 @@ class _BaseSettings(object):
                  'StdErr'           : ('stderr', None),
                  'XUnitSkipNonCritical' : ('xunitskipnoncritical', False),
                  'XOutputTimeInfo'  : ('xoutputtimeinfo', False),
-                 'TimestampFormat'  : ('timestampformat', None)}
+                 'TimeStampFormat'  : ('timestampformat', None)}
     _output_opts = ['Output', 'Log', 'Report', 'XUnit', 'DebugFile']
 
     def __init__(self, options=None, **extra_options):
@@ -139,6 +139,8 @@ class _BaseSettings(object):
             self._validate_expandkeywords(value)
         if name == 'Extension':
             return tuple(ext.lower().lstrip('.') for ext in value.split(':'))
+        if name == 'TimeStampFormat':
+            self._validate_timestampformat(value)
 
         return value
 
@@ -309,6 +311,10 @@ class _BaseSettings(object):
                 raise DataError("Invalid value for option '--expandkeywords'. "
                                 "Expected 'TAG:<pattern>', or "
                                 "'NAME:<pattern>' but got '%s'." % opt)            
+
+    def _validate_timestampformat(self, value):
+        if value != 'iso8601utc':
+            raise DataError("Invalid value for option '--timestampformat'. %s" % value)
 
     def __contains__(self, setting):
         return setting in self._cli_opts

--- a/src/robot/output/output.py
+++ b/src/robot/output/output.py
@@ -26,7 +26,7 @@ class Output(AbstractLogger):
     def __init__(self, settings):
         AbstractLogger.__init__(self)
         self._xmllogger = XmlLogger(settings.output, settings.log_level,
-                                    settings.rpa)
+                                    settings.rpa, includetimeinfo=settings.xoutput_timeinfo)
         self.listeners = Listeners(settings.listeners, settings.log_level)
         self.library_listeners = LibraryListeners(settings.log_level)
         self._register_loggers(DebugFile(settings.debug_file))

--- a/src/robot/output/xmllogger.py
+++ b/src/robot/output/xmllogger.py
@@ -22,11 +22,12 @@ from .loggerhelper import IsLogged
 
 class XmlLogger(ResultVisitor):
 
-    def __init__(self, path, log_level='TRACE', rpa=False, generator='Robot'):
+    def __init__(self, path, log_level='TRACE', rpa=False, generator='Robot', includetimeinfo=False):
         self._log_message_is_logged = IsLogged(log_level)
         self._error_message_is_logged = IsLogged('WARN')
         self._writer = self._get_writer(path, rpa, generator)
         self._errors = []
+        self._includetimeinfo = includetimeinfo
 
     def _get_writer(self, path, rpa, generator):
         if not path:
@@ -154,4 +155,12 @@ class XmlLogger(ResultVisitor):
             attrs['elapsedtime'] = str(item.elapsedtime)
         if extra_attrs:
             attrs.update(extra_attrs)
+        if self._includetimeinfo:
+            from time import localtime
+            lt = localtime()
+            z = lt.tm_gmtoff / 3600
+            dst = lt.tm_isdst
+            timeinfo = {'timezone': str(z), 'dst': str(dst)}
+            attrs.update(timeinfo)
+
         self._writer.element('status', item.message, attrs)

--- a/src/robot/run.py
+++ b/src/robot/run.py
@@ -356,6 +356,9 @@ Options
                           |  path/to/test/directory/
                           Examples:
                           --argumentfile argfile.txt --argumentfile STDIN
+ -z --xoutputtimeinfo     Include system timezone and daylight saving time in
+                          output.xml status elements so the timestamp are
+                          definitive.
  -h -? --help             Print usage instructions.
  --version                Print version information.
 

--- a/src/robot/run.py
+++ b/src/robot/run.py
@@ -359,6 +359,9 @@ Options
  -z --xoutputtimeinfo     Include system timezone and daylight saving time in
                           output.xml status elements so the timestamp are
                           definitive.
+    --timestampformat iso8601utc  Provide a format for the timestamp.
+                          iso8601utc:  Formatted as "%Y-%m-%dT%H:%M:%S.%fZ"
+                                       e.g. 2020-09-10T06:17:37.831Z
  -h -? --help             Print usage instructions.
  --version                Print version information.
 

--- a/src/robot/utils/application.py
+++ b/src/robot/utils/application.py
@@ -41,8 +41,9 @@ class Application(object):
 
     def execute_cli(self, cli_arguments, exit=True):
         with self._logger:
-            self._logger.info('%s %s' % (self._ap.name, self._ap.version))
             options, arguments = self._parse_arguments(cli_arguments)
+            self._set_timestamp_format(options)
+            self._logger.info('%s %s' % (self._ap.name, self._ap.version))
             rc = self._execute(arguments, options)
         if exit:
             self._exit(rc)
@@ -75,6 +76,7 @@ class Application(object):
 
     def execute(self, *arguments, **options):
         with self._logger:
+            self._set_timestamp_format(options)
             self._logger.info('%s %s' % (self._ap.name, self._ap.version))
             return self._execute(list(arguments), options)
 
@@ -110,6 +112,15 @@ class Application(object):
 
     def _exit(self, rc):
         sys.exit(rc)
+
+    def _set_timestamp_format(self, options):
+        if 'timestampformat' in options:
+            # Implement a single case to allow for a utc timestamp, but if a rework of robottime allow, this
+            # could change to allow for arbitrary timestamp formats
+            if options['timestampformat'] == 'iso8601utc':
+                from .robottime import default_to_iso8601, default_to_utc_timestamp
+                default_to_utc_timestamp()
+                default_to_iso8601()
 
 
 class DefaultLogger(object):

--- a/src/robot/utils/robottime.py
+++ b/src/robot/utils/robottime.py
@@ -21,6 +21,7 @@ from .normalizing import normalize
 from .misc import plural_or_not, roundup
 from .robottypes import is_number, is_string
 
+use_utc_timestamp = False
 
 _timer_re = re.compile(r'^([+-])?(\d+:)?(\d+):(\d+)(\.\d+)?$')
 
@@ -29,7 +30,7 @@ def _get_timetuple(epoch_secs=None):
     if epoch_secs is None:  # can also be 0 (at least in unit tests)
         epoch_secs = time.time()
     secs, millis = _float_secs_to_secs_and_millis(epoch_secs)
-    timetuple = time.localtime(secs)[:6]  # from year to secs
+    timetuple = time.localtime(secs)[:6] if not use_utc_timestamp else time.gmtime(secs)[:6]  # from year to secs
     return timetuple + (millis,)
 
 def _float_secs_to_secs_and_millis(secs):
@@ -211,7 +212,7 @@ def get_time(format='timestamp', time_=None):
     # 1) Return time in seconds since epoc
     if 'epoch' in format:
         return time_
-    timetuple = time.localtime(time_)
+    timetuple = time.localtime(time_) if not use_utc_timestamp else time.gmtime(time_)
     parts = []
     for i, match in enumerate('year month day hour min sec'.split()):
         if match in format:
@@ -306,7 +307,7 @@ def timestamp_to_secs(timestamp, seps=None):
 def secs_to_timestamp(secs, seps=None, millis=False):
     if not seps:
         seps = ('', ' ', ':', '.' if millis else None)
-    ttuple = time.localtime(secs)[:6]
+    ttuple = time.localtime(secs)[:6] if not use_utc_timestamp else time.gmtime(secs)[:6]
     if millis:
         millis = (secs - int(secs)) * 1000
         ttuple = ttuple + (roundup(millis),)

--- a/src/robot/utils/robottime.py
+++ b/src/robot/utils/robottime.py
@@ -31,6 +31,9 @@ gtimesep = None
 gmillissep = None
 gtz = ''
 
+def default_to_utc_timestamp():
+    global use_utc_timestamp
+    use_utc_timestamp = True
 
 def default_to_iso8601():
     global gdaysep


### PR DESCRIPTION
To at least partly address timezone in timestamps as discussed in 
https://github.com/robotframework/robotframework/issues/3061
and 
https://groups.google.com/forum/#!topic/robotframework-users/Wtg8EYwNVJ8
proposing the addition of two options as detailed in usage.

-z --xoutputtimeinfo     Include system timezone and daylight saving time in output.xml status elements so the timestamp are definitive.
--timestampformat iso8601utc  Provide a format for the timestamp. iso8601utc:  Formatted as "%Y-%m-%dT%H:%M:%S.%fZ" e.g. 2020-09-10T06:17:37.831Z

The resultant output with both options is
<status status="PASS" starttime="2020-09-10T07:37:25.717Z" endtime="2020-09-10T07:37:26.170Z" timezone="10.0" dst="0"></status>
The more important of the two is the timestamp format, and the intent is that eventually the robottime module could evolve to allow arbitrary timestamp formats including ones with +/- timezones as per iso8601, e.g. 2020-09-10T07:52:07+10:00, at which point the other status attributes could be considered redundant.

I have not considered or tested side effects for rebot, but when run against a single output.xml file rebot resulted in html files with utc times.
e.g.
Status:	All tests passed
Documentation: A suite of tests with tagged tests
Start Time:	20200910 07:54:24.615
End Time:	20200910 07:54:25.093
Elapsed Time:	00:00:00.478
Log File:	log.html
