### PR TITLE
Disable automatic type argument conversion (`none` => `None`) on some keywords.

### DIFF
--- a/atest/robot/standard_libraries/builtin/get_variable_value.robot
+++ b/atest/robot/standard_libraries/builtin/get_variable_value.robot
@@ -9,6 +9,9 @@ Get value when variable exists
 Get value when variable doesn't exist
     Check Test Case  ${TESTNAME}
 
+Get value when default value is none
+    Check Test Case  ${TESTNAME}
+
 Default value contains variables
     Check Test Case  ${TESTNAME}
 

--- a/atest/robot/standard_libraries/string/split_string.robot
+++ b/atest/robot/standard_libraries/string/split_string.robot
@@ -9,6 +9,9 @@ Split String
 Split String With Longer Separator
     Check Test Case    ${TESTNAME}
 
+Split String With none As Separator
+    Check Test Case    ${TESTNAME}
+
 Split String With Whitespaces and Separator Is None
     Check Test Case    ${TESTNAME}
 
@@ -34,6 +37,9 @@ Split String From Right
     Check Test Case    ${TESTNAME}
 
 Split String From Right With Longer Separator
+    Check Test Case    ${TESTNAME}
+
+Split String From Right With none As Separator
     Check Test Case    ${TESTNAME}
 
 Split String From Right With Whitespaces and Separator Is None

--- a/atest/robot/standard_libraries/string/string.robot
+++ b/atest/robot/standard_libraries/string/string.robot
@@ -69,3 +69,7 @@ Strip String With Invalid Mode
 
 Strip String With Given Characters
     Check Test Case    ${TESTNAME}
+
+Strip String With Given Characters none
+    Check Test Case    ${TESTNAME}
+

--- a/atest/robot/standard_libraries/xml/element_attribute.robot
+++ b/atest/robot/standard_libraries/xml/element_attribute.robot
@@ -16,6 +16,9 @@ Getting non-existing attribute returns None
 Default value is used when attribute does not exist
     Check Test Case    ${TESTNAME}
 
+Default value is none when attribute does not exist
+    Check Test Case    ${TESTNAME}
+
 Get element attributes
     Check Test Case    ${TESTNAME}
 

--- a/atest/robot/standard_libraries/xml/set_element_information.robot
+++ b/atest/robot/standard_libraries/xml/set_element_information.robot
@@ -27,6 +27,9 @@ Set Element Text Returns Root Element
 Set Elements Text
     Check Test Case    ${TESTNAME}
 
+Set Element Text none
+    Check Test Case    ${TESTNAME}
+
 Set Element Attribute
     Check Test Case    ${TESTNAME}
 

--- a/atest/testdata/standard_libraries/builtin/get_variable_value.robot
+++ b/atest/testdata/standard_libraries/builtin/get_variable_value.robot
@@ -17,6 +17,10 @@ Get value when variable doesn't exist
     ${y} =    Get Variable Value    ${nonex}    default value
     Should be equal    ${y}    default value
 
+Get value when default value is none
+    ${x} =    Get Variable Value    ${nonex}    none
+    Should be equal    ${x}    none
+
 Default value contains variables
     ${x} =    Get Variable Value    ${nonex}    ${VAR}
     Should be equal    ${x}    var table

--- a/atest/testdata/standard_libraries/operating_system/env_vars.robot
+++ b/atest/testdata/standard_libraries/operating_system/env_vars.robot
@@ -16,6 +16,8 @@ Get Environment Variable
     Should Contain    ${var}    ${:}
     ${var} =    Get Environment Variable    non_existing    default value
     Should Be Equal    ${var}    default value
+    ${var} =    Get Environment Variable    non_existing    none
+    Should Be Equal    ${var}    none
     ${var} =    Get Environment Variable    non_existing_2
 
 Set Environment Variable

--- a/atest/testdata/standard_libraries/string/convert_to.robot
+++ b/atest/testdata/standard_libraries/string/convert_to.robot
@@ -64,6 +64,7 @@ Convert To Title Case with excludes
     they're bill's friends from the UK
     ...                   They're Bill's Friends From the UK
     ...                                         exclude=${EXCLUDES}
+    this is none          This Is none          exclude=none
 
 Convert To Title Case with regexp excludes
     [Template]    Test title case

--- a/atest/testdata/standard_libraries/string/split_string.robot
+++ b/atest/testdata/standard_libraries/string/split_string.robot
@@ -14,6 +14,10 @@ Split String With Longer Separator
     ${result} =    Split String    1abc2abc3    abc
     Result Should Contain Items In Given Order    ${result}    1    2    3
 
+Split String With none As Separator
+    ${result} =    Split String    1none2none3    none
+    Result Should Contain Items In Given Order    ${result}    1    2    3
+
 Split String With Whitespaces and Separator Is None
     ${result} =    Split String    ${WHITE SPACES}
     Result Should Contain Items In Given Order    ${result}    hello    world    again
@@ -48,6 +52,10 @@ Split String From Right
 
 Split String From Right With Longer Separator
     ${result} =    Split String From Right    1abc2abc3    abc
+    Result Should Contain Items In Given Order    ${result}    1    2    3
+
+Split String From Right With none As Separator
+    ${result} =    Split String From Right    1none2none3    none
     Result Should Contain Items In Given Order    ${result}    1    2    3
 
 Split String From Right With Whitespaces and Separator Is None

--- a/atest/testdata/standard_libraries/string/string.robot
+++ b/atest/testdata/standard_libraries/string/string.robot
@@ -110,3 +110,7 @@ Strip String With Invalid Mode
 Strip String With Given Characters
     ${result} =    Strip String    aabaHelloeee    characters=abe
     Should be equal    ${result}    Hello
+
+Strip String With Given Characters none
+    ${result} =    Strip String    none123noneee    characters=none
+    Should be equal    ${result}    123

--- a/atest/testdata/standard_libraries/xml/element_attribute.robot
+++ b/atest/testdata/standard_libraries/xml/element_attribute.robot
@@ -21,6 +21,10 @@ Default value is used when attribute does not exist
     ${attr}=     Get Element Attribute    <tag a="1"/>    a    default=value
     Should Be Equal    ${attr}    1
 
+Default value is none when attribute does not exist
+    ${attr}=     Get Element Attribute    <tag a="1"/>    b    default=none
+    Should Be Equal    ${attr}    none
+
 Get element attributes
     ${attrs}=   Get Element Attributes    <tag a="1" b="2"/>
     Should Be True    ${attrs} == {'a': '1', 'b': '2'}

--- a/atest/testdata/standard_libraries/xml/set_element_information.robot
+++ b/atest/testdata/standard_libraries/xml/set_element_information.robot
@@ -32,6 +32,12 @@ Set Element Text
     Set Element Text    ${XML}    new    xpath=child
     Element Text Should Be    ${XML}    new    xpath=child
 
+Set Element Text none
+     Set Element Text    ${XML}    none    xpath=child
+     Element Text Should Be    ${XML}    none    xpath=child
+     Set Elements Text    ${XML}    none    xpath=child
+     Element Text Should Be    ${XML}    none    xpath=child
+
 Set Element Text And Tail
     ${child} =    Get Element    ${XML}    child
     Set Element Text    ${XML}    new text    new tail    xpath=child

--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -21,6 +21,7 @@ import re
 import time
 
 from robot.api import logger
+from robot.api.deco import keyword
 from robot.errors import (ContinueForLoop, DataError, ExecutionFailed,
                           ExecutionFailures, ExecutionPassed, ExitForLoop,
                           PassExecution, ReturnFromKeyword, VariableError)
@@ -1299,6 +1300,7 @@ class _Variables(_BuiltInBase):
         """
         return self._variables.as_dict(decoration=is_falsy(no_decoration))
 
+    @keyword(types=None)
     @run_keyword_variant(resolve=0)
     def get_variable_value(self, name, default=None):
         """Returns variable value or ``default`` if the variable does not exist.

--- a/src/robot/libraries/OperatingSystem.py
+++ b/src/robot/libraries/OperatingSystem.py
@@ -24,6 +24,7 @@ import time
 
 from robot.version import get_version
 from robot.api import logger
+from robot.api.deco import keyword
 from robot.utils import (abspath, ConnectionCache, console_decode, del_env_var,
                          get_env_var, get_env_vars, get_time, is_truthy,
                          is_unicode, normpath, parse_time, plural_or_not,
@@ -931,6 +932,7 @@ class OperatingSystem(object):
 
     # Environment Variables
 
+    @keyword(types=None)
     def get_environment_variable(self, name, default=None):
         """Returns the value of an environment variable with the given name.
 

--- a/src/robot/libraries/String.py
+++ b/src/robot/libraries/String.py
@@ -23,6 +23,7 @@ from string import ascii_lowercase, ascii_uppercase, digits
 
 
 from robot.api import logger
+from robot.api.deco import keyword
 from robot.utils import (is_bytes, is_string, is_truthy, is_unicode, lower,
                          unic, FileReader, PY3)
 from robot.version import get_version
@@ -84,6 +85,7 @@ class String(object):
         """
         return string.upper()
 
+    @keyword(types=None)
     def convert_to_title_case(self, string, exclude=None):
         """Converts string to title case.
 
@@ -504,6 +506,7 @@ class String(object):
             string = self.replace_string_using_regexp(string, pattern, '')
         return string
 
+    @keyword(types=None)
     def split_string(self, string, separator=None, max_split=-1):
         """Splits the ``string`` using ``separator`` as a delimiter string.
 
@@ -529,6 +532,7 @@ class String(object):
         max_split = self._convert_to_integer(max_split, 'max_split')
         return string.split(separator, max_split)
 
+    @keyword(types=None)
     def split_string_from_right(self, string, separator=None, max_split=-1):
         """Splits the ``string`` using ``separator`` starting from right.
 
@@ -621,6 +625,7 @@ class String(object):
         end = self._convert_to_index(end, 'end')
         return string[start:end]
 
+    @keyword(types=None)
     def strip_string(self, string, mode='both', characters=None):
         """Remove leading and/or trailing whitespaces from the given string.
 

--- a/src/robot/libraries/XML.py
+++ b/src/robot/libraries/XML.py
@@ -23,6 +23,7 @@ except ImportError:
     lxml_etree = None
 
 from robot.api import logger
+from robot.api.deco import keyword
 from robot.libraries.BuiltIn import BuiltIn
 from robot.utils import (asserts, ET, ETSource, is_bytes, is_falsy, is_string,
                          is_truthy, plural_or_not as s, PY2)
@@ -759,6 +760,7 @@ class XML(object):
         text = self.get_element_text(source, xpath, normalize_whitespace)
         should_match(text, pattern, message, values=False)
 
+    @keyword(types=None)
     def get_element_attribute(self, source, name, xpath='.', default=None):
         """Returns the named attribute of the specified element.
 
@@ -968,6 +970,7 @@ class XML(object):
         for elem in self.get_elements(source, xpath):
             self.set_element_tag(elem, tag)
 
+    @keyword(types=None)
     def set_element_text(self, source, text=None, tail=None, xpath='.'):
         """Sets text and/or tail text of the specified element.
 
@@ -999,6 +1002,7 @@ class XML(object):
             element.tail = tail
         return source
 
+    @keyword(types=None)
     def set_elements_text(self, source, text=None, tail=None, xpath='.'):
         """Sets text and/or tail text of the specified elements.
 


### PR DESCRIPTION
This is a PR for #3649. Opted for using the `@keyword(types=None)` decorator. Added one acceptance test for all the applicable cases.