### PR TITLE
failure exceptiontype in output.xml

### DIFF
--- a/src/robot/output/loggerhelper.py
+++ b/src/robot/output/loggerhelper.py
@@ -49,30 +49,31 @@ class AbstractLogger(object):
     def warn(self, msg):
         self.write(msg, 'WARN')
 
-    def fail(self, msg):
+    def fail(self, msg, error_type=None):
         html = False
         if msg.startswith("*HTML*"):
             html = True
             msg = msg[6:].lstrip()
-        self.write(msg, 'FAIL', html)
+        self.write(msg, 'FAIL', html, error_type)
 
     def error(self, msg):
         self.write(msg, 'ERROR')
 
-    def write(self, message, level, html=False):
-        self.message(Message(message, level, html))
+    def write(self, message, level, html=False, error_type=None):
+        self.message(Message(message, level, html, error_type=error_type))
 
     def message(self, msg):
         raise NotImplementedError(self.__class__)
 
 
 class Message(BaseMessage):
-    __slots__ = ['_message']
+    __slots__ = ['_message', 'error_type']
 
-    def __init__(self, message, level='INFO', html=False, timestamp=None):
+    def __init__(self, message, level='INFO', html=False, timestamp=None, error_type=None):
         message = self._normalize_message(message)
         level, html = self._get_level_and_html(level, html)
         timestamp = timestamp or get_timestamp()
+        self.error_type=error_type
         BaseMessage.__init__(self, message, level, html, timestamp)
 
     def _normalize_message(self, msg):

--- a/src/robot/output/xmllogger.py
+++ b/src/robot/output/xmllogger.py
@@ -58,6 +58,8 @@ class XmlLogger(ResultVisitor):
 
     def _write_message(self, msg):
         attrs = {'timestamp': msg.timestamp or 'N/A', 'level': msg.level}
+        if msg.error_type:
+            attrs['exceptiontype'] = msg.error_type.__name__
         if msg.html:
             attrs['html'] = 'yes'
         self._writer.element('msg', msg.message, attrs)

--- a/src/robot/running/context.py
+++ b/src/robot/running/context.py
@@ -194,5 +194,5 @@ class _ExecutionContext(object):
     def warn(self, message):
         self.output.warn(message)
 
-    def fail(self, message):
-        self.output.fail(message)
+    def fail(self, message, error_type=None):
+        self.output.fail(message, error_type)

--- a/src/robot/running/statusreporter.py
+++ b/src/robot/running/statusreporter.py
@@ -69,7 +69,7 @@ class StatusReporter(object):
         failure = HandlerExecutionFailed(ErrorDetails(exc_info))
         if failure.timeout:
             context.timeout_occurred = True
-        context.fail(failure.full_message)
+        context.fail(failure.full_message, exc_type)
         if failure.traceback:
             context.debug(failure.traceback)
         return failure


### PR DESCRIPTION
Based on discussions on #devel channel.

I got requirement that perform auto analysis on failures. I have did this but I felt if robot provide few info in error message this will help more in my task with high accuracy
Example: Let us assume test case consist keyword Should Be True  "Demo" != "Demo1" and it got failed, we will get error message like "Demo" != "Demo1"
In above error message =! is my key and I update testcase analysis comment that its application issue since validation got failed.
Note: Accuracy may not be 100% but we have started and will improve this.
Here I need help from robotframework that, Let us have custom robotframework exceptions as prefix in error message
Example:
 1) Robotframework: If any Should * keyword got failed error message should be like ValidationException: <actual error>
 2) Selenium: If any Wait * keyword got failed error message should be ElementException: <actual selenium throwed exception & error>
So above approach gives confident on which type of error we got based on exception type and we can take a call on this.
Note: This is draft idea and im not sure is this possible or not, is it valid?, how it helps robotframework, how other libraries owner react to it if possible.
Since we are working on CI error message like showing error line number I have proposed this.