### PR TITLE
Exclude tests that require lxml or Pillow from CI runs on Win + Python 3.9

### DIFF
--- a/.github/workflows/acceptance_tests_cpython.yml
+++ b/.github/workflows/acceptance_tests_cpython.yml
@@ -27,6 +27,10 @@ jobs:
             set_display: export DISPLAY=:99; Xvfb :99 -screen 0 1024x768x24 -ac -noreset & sleep 3
           - os: windows-latest
             set_codepage: chcp 850
+          - os: windows-latest
+            python-version: '3.9.0-alpha - 3.9'
+            set_codepage: chcp 850
+            atest_args: --exclude require-lxml --exclude require-screenshot
         exclude:
           - os: windows-latest
             python-version: 'pypy2'
@@ -91,14 +95,6 @@ jobs:
           sudo apt-get -y -q install xvfb scrot zip curl libxml2-dev libxslt1-dev
         if: contains(matrix.os, 'ubuntu')
 
-      # See unofficial pre-compiled libraries at https://www.lfd.uci.edu/~gohlke/pythonlibs
-      # And https://github.com/robotframework/robotframework/issues/3629
-      - name: Install Pillow and lxml on Python 3.9 (on Win)
-        run: |
-          python -m pip install https://download.lfd.uci.edu/pythonlibs/w3jqiv8s/Pillow-7.2.0-cp39-cp39-win_amd64.whl
-          python -m pip install https://download.lfd.uci.edu/pythonlibs/w3jqiv8s/lxml-4.5.2-cp39-cp39-win_amd64.whl
-        if: contains(matrix.python-version, '3.9') && contains(matrix.os, 'Windows')
-
       - name: Disable NTP on macOS (https://github.com/actions/virtual-environments/issues/820)
         run: |
           sudo systemsetup -setusingnetworktime off
@@ -111,7 +107,7 @@ jobs:
           ${{ env.ATEST_PYTHON }} -m pip install -r atest/requirements-run.txt
           ${{ matrix.set_codepage }}
           ${{ matrix.set_display }}
-          ${{ env.ATEST_PYTHON }} atest/run.py ${{ env.BASE_PYTHON }} --exclude no-ci atest/robot
+          ${{ env.ATEST_PYTHON }} atest/run.py ${{ env.BASE_PYTHON }} --exclude no-ci ${{ matrix.atest_args }} atest/robot
 
       - name: Delete output.xml (on Win)
         run: |

--- a/atest/requirements.txt
+++ b/atest/requirements.txt
@@ -2,9 +2,6 @@
 # See atest/README.rst for more information.
 
 enum34; python_version < '3.0'
-pillow < 7; platform_system == 'Windows' and python_version == '2.7'
-pillow < 6; platform_system == 'Windows' and python_version == '3.4'
-pillow >= 7.1.0; platform_system == 'Windows' and python_version >= '3.5'
 
 # https://github.com/IronLanguages/ironpython2/issues/113
 docutils >= 0.9; platform_python_implementation != 'IronPython'
@@ -18,3 +15,7 @@ pyyaml == 5.2; platform_python_implementation == 'Jython'
 # headers. Alternatively it can be installed using a package manager like
 # `sudo apt-get install python-lxml`.
 lxml; platform_python_implementation == 'CPython' or platform_python_implementation == 'PyPy'
+
+pillow < 7; platform_system == 'Windows' and python_version == '2.7'
+pillow < 6; platform_system == 'Windows' and python_version == '3.4'
+pillow >= 7.1.0; platform_system == 'Windows' and python_version >= '3.5'


### PR DESCRIPTION
Also, make sure that Pillow and lxml libraries are at the end of
atest/requirements.txt, so install errors don't impact other 3rd
party libraries.