### PR TITLE
refactored LibDocLib.py so that it can be libdoced...

### DIFF
--- a/atest/robot/libdoc/LibDocLib.py
+++ b/atest/robot/libdoc/LibDocLib.py
@@ -16,11 +16,18 @@ ROOT = join(dirname(abspath(__file__)), '..', '..', '..')
 
 class LibDocLib(object):
 
-    def __init__(self, interpreter):
-        self.libdoc = interpreter.libdoc
-        self.encoding = SYSTEM_ENCODING \
-            if not interpreter.is_ironpython else CONSOLE_ENCODING
+    def __init__(self, interpreter=None):
+        self.interpreter = interpreter
         self.schema = XMLSchema(join(ROOT, 'doc', 'schema', 'libdoc.02.xsd'))
+
+    @property
+    def libdoc(self):
+        return self.interpreter.libdoc
+
+    @property
+    def encoding(self):
+        return SYSTEM_ENCODING \
+                if not self.interpreter.is_ironpython else CONSOLE_ENCODING
 
     def run_libdoc(self, args):
         cmd = self.libdoc + self._split_args(args)


### PR DESCRIPTION
The LibDocLib.py had a init function that requires arguments.
When using libdoc to document that library the init fails.
That is why it can not be used with LSP and no "Go To Definition" is possible in the atests.

That is now fixed.