### PR TITLE
Topic/robot repr (fixes #3697)

### DIFF
--- a/atest/robot/libdoc/console_viewer.robot
+++ b/atest/robot/libdoc/console_viewer.robot
@@ -17,6 +17,7 @@ List all keywords
     ...   Non Ascii Unicode Defaults
     ...   Non Ascii Unicode Doc
     ...   Non String Defaults
+    ...   Robot Espacers
     ...   Set Name Using Robot Name Attribute
     ...   Takes \${embedded} \${args}
 

--- a/atest/robot/libdoc/default_escaping.robot
+++ b/atest/robot/libdoc/default_escaping.robot
@@ -1,0 +1,48 @@
+*** Settings ***
+Resource          libdoc_resource.robot
+Library           ${TESTDATADIR}/default_escaping.py
+Resource          ${TESTDATADIR}/default_escaping.resource
+Suite Setup       Run Libdoc And Parse Model From JSON    ${TESTDATADIR}/default_escaping.py
+
+*** Comments ***
+This test checks if the libdoc.html presented strings are the ones that can be
+pasted directly to robot code and reproduce the same default value.
+The first line of each test is that value.
+The called keyword checks equality.
+
+*** Test Cases ***
+Verify All
+    Verify All         first \${scalar} \nthen\t \@{list} and \\\\\&{dict.key}[2] so \ \ \\ \ \ \ me env \%{username} and a \\\${backslash} \ \ \
+    Check Libdoc Default    0    first \\\${scalar} \\nthen\\t \\\@{list} and \\\\\\\\\\\&{dict.key}[2] so \\ \\ \\\\ \\ \\ \\ me env \\\%{username} and a \\\\\\\${backslash} \\ \\ \\
+
+Verify Backslash
+    Verify Backslash    c:\\windows\\system
+    Check Libdoc Default    1    c:\\\\windows\\\\system
+
+Verify Line Break
+    Verify Line Break    Hello\nWorld!\r\nEnd...\\n
+    Check Libdoc Default    2    Hello\\nWorld!\\r\\nEnd...\\\\n
+
+Verify Line Tab
+    Verify Line Tab    Hello\tWorld!\t\t End\\t...
+    Check Libdoc Default    3    Hello\\tWorld!\\t\\t End\\\\t...
+
+Verify Spaces
+    Verify Spaces    \ \ \ \ Hello\tW \ \ orld!\t \ \t En d\\t... \
+    Check Libdoc Default    4    \\ \\ \\ \\ Hello\\tW \\ \\ orld!\\t \\ \\t En d\\\\t... \\
+
+Verify Variables
+    Verify Variables    first \${scalar} then \@{list} and \&{dict.key}[2] some env \%{username} and a \\\${backslash} \ \ \
+    Check Libdoc Default    5    first \\\${scalar} then \\\@{list} and \\\&{dict.key}[2] some env \\\%{username} and a \\\\\\\${backslash} \\ \\ \\
+
+Verify No Escaping on Resource Files
+    Run Libdoc And Parse Model From JSON    ${TESTDATADIR}/default_escaping.resource
+    Check Scalar in Default    some\${text} and ${scalar} \ ${{'Hello'[1:3]}}\ with\n\t space
+    Check Libdoc Default    0    some\\\${text} and \${scalar} \\ \${{'Hello'[1:3]}}\\ with\\n\\t space
+
+*** Keywords ***
+Check Libdoc Default
+    [Arguments]    ${keyword_index}    ${expected}
+    Should Be Equal    ${expected}
+    ...                ${MODEL}[keywords][${keyword_index}][args][0][default]
+    Log    ${MODEL}[keywords][${keyword_index}][args][0][default]

--- a/atest/robot/libdoc/html_output.robot
+++ b/atest/robot/libdoc/html_output.robot
@@ -27,7 +27,7 @@ Inits
 Keyword Names
     ${MODEL}[keywords][0][name]     Get Hello
     ${MODEL}[keywords][1][name]     Keyword
-    ${MODEL}[keywords][13][name]    Set Name Using Robot Name Attribute
+    ${MODEL}[keywords][14][name]    Set Name Using Robot Name Attribute
 
 Keyword Arguments
     [Template]    Verify Argument Models
@@ -36,12 +36,13 @@ Keyword Arguments
     ${MODEL}[keywords][6][args]     arg=hyv\\xe4
     ${MODEL}[keywords][10][args]    arg=hyvä
     ${MODEL}[keywords][12][args]    a=1    b=True    c=(1, 2, None)
-    ${MODEL}[keywords][13][args]    a    b    *args    **kwargs
+    ${MODEL}[keywords][13][args]    arg=\\ robot \\ escapers\\n\\t\\r \\ \\
+    ${MODEL}[keywords][14][args]    a    b    *args    **kwargs
 
 Embedded Arguments
     [Template]    NONE
-    Should Be Equal    ${MODEL}[keywords][14][name]    Takes \${embedded} \${args}
-    Should Be Empty    ${MODEL}[keywords][14][args]
+    Should Be Equal    ${MODEL}[keywords][15][name]    Takes \${embedded} \${args}
+    Should Be Empty    ${MODEL}[keywords][15][args]
 
 Keyword Documentation
     ${MODEL}[keywords][1][doc]

--- a/atest/robot/libdoc/html_output_from_json.robot
+++ b/atest/robot/libdoc/html_output_from_json.robot
@@ -33,8 +33,11 @@ Keyword Arguments
     ${JSON-MODEL}[keywords][12][args]    ${MODEL}[keywords][12][args]
     ${JSON-MODEL}[keywords][13][args]    ${MODEL}[keywords][13][args]
 
-Embedded Arguments
+Embedded Arguments names
     ${JSON-MODEL}[keywords][14][name]    ${MODEL}[keywords][14][name]
+
+Embedded Arguments arguments
+    [Template]    List of Dict Should Be Equal
     ${JSON-MODEL}[keywords][14][args]    ${MODEL}[keywords][14][args]
 
 Keyword Documentation

--- a/atest/robot/libdoc/html_output_from_libspec.robot
+++ b/atest/robot/libdoc/html_output_from_libspec.robot
@@ -33,8 +33,11 @@ Keyword Arguments
     ${XML-MODEL}[keywords][12][args]    ${MODEL}[keywords][12][args]
     ${XML-MODEL}[keywords][13][args]    ${MODEL}[keywords][13][args]
 
-Embedded Arguments
+Embedded Arguments names
     ${XML-MODEL}[keywords][14][name]    ${MODEL}[keywords][14][name]
+
+Embedded Arguments arguments
+    [Template]    List of Dict Should Be Equal
     ${XML-MODEL}[keywords][14][args]    ${MODEL}[keywords][14][args]
 
 Keyword Documentation

--- a/atest/robot/libdoc/json_output.robot
+++ b/atest/robot/libdoc/json_output.robot
@@ -27,7 +27,7 @@ Inits
 Keyword Names
     ${MODEL}[keywords][0][name]     Get Hello
     ${MODEL}[keywords][1][name]     Keyword
-    ${MODEL}[keywords][13][name]    Set Name Using Robot Name Attribute
+    ${MODEL}[keywords][14][name]    Set Name Using Robot Name Attribute
 
 Keyword Arguments
     [Template]    Verify Argument Models
@@ -36,12 +36,13 @@ Keyword Arguments
     ${MODEL}[keywords][6][args]     arg=hyv\\xe4
     ${MODEL}[keywords][10][args]    arg=hyvä
     ${MODEL}[keywords][12][args]    a=1    b=True    c=(1, 2, None)
-    ${MODEL}[keywords][13][args]    a    b    *args    **kwargs
+    ${MODEL}[keywords][13][args]    arg=\\ robot \\ escapers\\n\\t\\r \\ \\
+    ${MODEL}[keywords][14][args]    a    b    *args    **kwargs
 
 Embedded Arguments
     [Template]    NONE
-    Should Be Equal    ${MODEL}[keywords][14][name]    Takes \${embedded} \${args}
-    Should Be Empty    ${MODEL}[keywords][14][args]
+    Should Be Equal    ${MODEL}[keywords][15][name]    Takes \${embedded} \${args}
+    Should Be Empty    ${MODEL}[keywords][15][args]
 
 Keyword Documentation
     ${MODEL}[keywords][1][doc]

--- a/atest/robot/libdoc/module_library.robot
+++ b/atest/robot/libdoc/module_library.robot
@@ -37,13 +37,14 @@ Has No Inits
 Keyword Names
     Keyword Name Should Be           0     Get Hello
     Keyword Name Should Be           1     Keyword
-    Keyword Name Should Be           13    Set Name Using Robot Name Attribute
+    Keyword Name Should Be           14    Set Name Using Robot Name Attribute
 
 Keyword Arguments
     Keyword Arguments Should Be      0
     Keyword Arguments Should Be      1     a1=d    *a2
     Keyword Arguments Should Be      12    a=1    b=True    c=(1, 2, None)
-    Keyword Arguments Should Be      13    a    b    *args    **kwargs
+    Keyword Arguments Should Be      13    arg=\\ robot \\ escapers\\n\\t\\r \\ \\
+    Keyword Arguments Should Be      14    a    b    *args    **kwargs
 
 Non-ASCII Unicode Defaults
     Keyword Arguments Should Be      10    arg=hyvä
@@ -55,8 +56,8 @@ Non-ASCII String Defaults
     Keyword Arguments Should Be      7     arg=${{'hyvä' if $PY3_or_IPY else 'hyv\\xc3\\xa4'}}
 
 Embedded Arguments
-    Keyword Name Should Be           14    Takes \${embedded} \${args}
-    Keyword Arguments Should Be      14
+    Keyword Name Should Be           15    Takes \${embedded} \${args}
+    Keyword Arguments Should Be      15
 
 Keyword Documentation
     Keyword Doc Should Be            1     A keyword.\n\nSee `get hello` for details.
@@ -97,6 +98,6 @@ Keyword source info
     Keyword Lineno Should Be         0     19
 
 Keyword source info with decorated function
-    Keyword Name Should Be           14    Takes \${embedded} \${args}
-    Keyword Should Not Have Source   14
-    Keyword Lineno Should Be         14    81
+    Keyword Name Should Be           15    Takes \${embedded} \${args}
+    Keyword Should Not Have Source   15
+    Keyword Lineno Should Be         15    81

--- a/atest/testdata/libdoc/default_escaping.py
+++ b/atest/testdata/libdoc/default_escaping.py
@@ -1,0 +1,32 @@
+# coding: utf-8
+
+"""Library to document and test correct default value escaping."""
+from robot.libraries.BuiltIn import BuiltIn
+
+b = BuiltIn()
+
+
+def verify_backslash(current='c:\\windows\\system', expected='c:\\windows\\system'):
+    b.should_be_equal(current, expected)
+
+
+def verify_line_break(current='Hello\nWorld!\r\nEnd...\\n', expected='Hello\nWorld!\r\nEnd...\\n'):
+    b.should_be_equal(current, expected)
+
+
+def verify_line_tab(current='Hello\tWorld!\t\t End\\t...', expected='Hello\tWorld!\t\t End\\t...'):
+    b.should_be_equal(current, expected)
+
+
+def verify_spaces(current='    Hello\tW   orld!\t  \t En d\\t... ', expected='    Hello\tW   orld!\t  \t En d\\t... '):
+    b.should_be_equal(current, expected)
+
+
+def verify_variables(current='first ${scalar} then @{list} and &{dict.key}[2] some env %{username} and a \\${backslash}   ',
+                     expected='first ${scalar} then @{list} and &{dict.key}[2] some env %{username} and a \\${backslash}   '):
+    b.should_be_equal(current, expected)
+
+
+def verify_all(current='first ${scalar} \nthen\t @{list} and \\\\&{dict.key}[2] so   \\    me env %{username} and a \\${backslash}   ',
+               expected='first ${scalar} \nthen\t @{list} and \\\\&{dict.key}[2] so   \\    me env %{username} and a \\${backslash}   '):
+    b.should_be_equal(current, expected)

--- a/atest/testdata/libdoc/default_escaping.resource
+++ b/atest/testdata/libdoc/default_escaping.resource
@@ -1,0 +1,12 @@
+*** Variables ***
+${scalar}=    Some Test
+
+
+*** Keywords ***
+Check Scalar in Default
+    [Arguments]
+    ...     ${current}=some\${text} and ${scalar} \ ${{'Hello'[1:3]}}\ with\n\t space
+    ...    ${expected}=some\${text} and ${scalar} \ ${{'Hello'[1:3]}}\ with\n\t space
+    Log    current: '${current}'
+    Log    expected: '${expected}'
+    Should Be Equal    ${current}    ${expected}

--- a/atest/testdata/libdoc/module.py
+++ b/atest/testdata/libdoc/module.py
@@ -98,3 +98,6 @@ def keyword_with_tags_3():
 
     Tags: tag1, tag2
     """
+
+def robot_espacers(arg=" robot  escapers\n\t\r  "):
+    pass

--- a/src/robot/libdocpkg/robotbuilder.py
+++ b/src/robot/libdocpkg/robotbuilder.py
@@ -106,7 +106,8 @@ class KeywordDocBuilder(object):
 
     def build_keyword(self, kw):
         doc, tags = self._get_doc_and_tags(kw)
-        self._escape_strings_in_defaults(kw)
+        if not self._resource:
+            self._escape_strings_in_defaults(kw)
         return KeywordDoc(name=kw.name,
                           args=kw.arguments,
                           doc=doc,


### PR DESCRIPTION
Escape robot special chars in argument default value representations. To support better default values in libdoc.