### PR TITLE
Fixed problem with variable name like ${var_name} for `Variable Should Exist` and `Variable Should Not Exist`

### DIFF
--- a/atest/testdata/standard_libraries/builtin/variable_should_exist.robot
+++ b/atest/testdata/standard_libraries/builtin/variable_should_exist.robot
@@ -71,7 +71,7 @@ Variable Should Not Exist With Given Error Message
     Variable Should Not Exist    ${scalar}    This is the error message
 
 Variable Should Not Exist With Error Message Containing Variables
-    [Documentation]    FAIL Error with vars: ${scalar} & ${42}
+    [Documentation]    FAIL Error with vars: \${scalar} & \${42}
     Variable Should Not Exist    ${scalar}    Error with vars: ${scalar} & ${42}
 
 Variable Should Not Exist With Built In Variables

--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -1359,12 +1359,10 @@ class _Variables(_BuiltInBase):
         See also `Variable Should Not Exist` and `Keyword Should Exist`.
         """
         name = self._get_var_name(name)
-        msg = self._variables.replace_string(msg) if msg \
-            else "Variable '%s' does not exist." % name
         try:
             self._variables[name]
         except DataError:
-            raise AssertionError(msg)
+            raise AssertionError(msg or "Variable '%s' does not exist." % name)
 
     @run_keyword_variant(resolve=0)
     def variable_should_not_exist(self, name, msg=None):
@@ -1379,14 +1377,12 @@ class _Variables(_BuiltInBase):
         See also `Variable Should Exist` and `Keyword Should Exist`.
         """
         name = self._get_var_name(name)
-        msg = self._variables.replace_string(msg) if msg \
-            else "Variable '%s' exists." % name
         try:
             self._variables[name]
         except DataError:
             pass
         else:
-            raise AssertionError(msg)
+            raise AssertionError(msg or "Variable '%s' exists." % name)
 
     def replace_variables(self, text):
         """Replaces variables in the given text with their current values.


### PR DESCRIPTION
If you pass variable name like `${var_name}` to msg in keywords `Variable Should Exist` and `Variable Should Not Exist` it will raise error like `Variable '${var_name}' not found.

```
*** Test Cases ***
Example
    Variable should not exist   ${var}   msg=Var ${var} is exist!!!
```
Before fix
![image](https://user-images.githubusercontent.com/56407674/99958190-fc3c7980-2d99-11eb-941a-a8210391e3e0.png)
```
*** Variables ***
${var}=  42
*** Test Cases ***
Example
    Variable should not exist   ${var}   msg=Var ${var} is exist!!!
```
![image](https://user-images.githubusercontent.com/56407674/99959914-eed4be80-2d9c-11eb-871e-147ccac7af3e.png)

___
After fix
![image](https://user-images.githubusercontent.com/56407674/99958223-0a8a9580-2d9a-11eb-8807-d78c2092668b.png)

```
*** Variables ***
${var}=  42
*** Test Cases ***
Example
    Variable should not exist   ${var}   msg=Var ${var} is exist!!!
```
![image](https://user-images.githubusercontent.com/56407674/99958700-e8ddde00-2d9a-11eb-8e44-8a027306f692.png)

@pekkaklarck Can you explain why ```self._variables.replace_string(msg)``` was used? Mb my problem is not serious than problem which was solved by this call.