### PR TITLE
differentiate test and suite statuses from other statuses

### DIFF
--- a/doc/schema/robot.02.xsd
+++ b/doc/schema/robot.02.xsd
@@ -38,7 +38,7 @@
             <xs:element name="test" type="Test" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="doc" type="xs:string" minOccurs="0" />
             <xs:element name="meta" type="Metadata" minOccurs="0" maxOccurs="unbounded" />
-            <xs:element name="status" type="SuiteAndTestStatus" />
+            <xs:element name="status" type="Status" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string" />
         <xs:attribute name="source" type="xs:string" />
@@ -60,7 +60,7 @@
             <xs:element name="doc" type="xs:string" minOccurs="0" />
             <xs:element name="tag" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="timeout" type="Timeout" minOccurs="0" />
-            <xs:element name="status" type="SuiteAndTestStatus" />
+            <xs:element name="status" type="Status" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string" />
         <xs:attribute name="id" type="xs:string" />
@@ -80,7 +80,7 @@
             <xs:element name="msg" type="Message" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="tag" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="timeout" type="Timeout" minOccurs="0" />
-            <xs:element name="status" type="Status" />
+            <xs:element name="status" type="BodyItemStatus" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string" />
         <xs:attribute name="library" type="xs:string" />
@@ -105,7 +105,7 @@
             <xs:element name="iter" type="ForIteration" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="msg" type="Message" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="doc" type="xs:string" minOccurs="0" />
-            <xs:element name="status" type="Status" />
+            <xs:element name="status" type="BodyItemStatus" />
         </xs:choice>
         <xs:attribute name="flavor" type="ForFlavor" />
     </xs:complexType>
@@ -126,7 +126,7 @@
             <xs:element name="if" type="If" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="msg" type="Message" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="doc" type="xs:string" minOccurs="0" />
-            <xs:element name="status" type="Status" />
+            <xs:element name="status" type="BodyItemStatus" />
         </xs:choice>
     </xs:complexType>
     <xs:complexType name="ForIterationVariable">
@@ -142,7 +142,7 @@
             <xs:element name="branch" type="IfBranch" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="msg" type="Message" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="doc" type="xs:string" minOccurs="0" />
-            <xs:element name="status" type="Status" />
+            <xs:element name="status" type="BodyItemStatus" />
         </xs:choice>
     </xs:complexType>
     <xs:complexType name="IfBranch">
@@ -152,7 +152,7 @@
             <xs:element name="if" type="If" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="msg" type="Message" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="doc" type="xs:string" minOccurs="0" />
-            <xs:element name="status" type="Status" />
+            <xs:element name="status" type="BodyItemStatus" />
         </xs:choice>
         <xs:attribute name="type" type="IfType" use="required" />
         <xs:attribute name="condition" type="xs:string" />
@@ -195,10 +195,17 @@
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>
-    <xs:complexType name="SuiteAndTestStatus">
+    <xs:simpleType name="StatusValue">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="PASS" />
+            <xs:enumeration value="FAIL" />
+            <xs:enumeration value="SKIP" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="BodyItemStatus">
         <xs:simpleContent>
             <xs:extension base="xs:string">
-                <xs:attribute name="status" type="SuiteAndTestStatusValue" use="required" />
+                <xs:attribute name="status" type="BodyItemStatusValue" use="required" />
                 <xs:attribute name="starttime" type="xs:string" />
                 <xs:attribute name="endtime" type="xs:string" />
                 <!-- Not set if both `starttime` and `endtime` are defined. -->
@@ -206,20 +213,12 @@
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>
-    <xs:simpleType name="StatusValue">
+    <xs:simpleType name="BodyItemStatusValue">
         <xs:restriction base="xs:string">
             <xs:enumeration value="PASS" />
             <xs:enumeration value="FAIL" />
             <xs:enumeration value="SKIP" />
-            <!-- Only used with keywords, FORs and IFs, not with tests and suites. -->
             <xs:enumeration value="NOT RUN" />
-        </xs:restriction>
-    </xs:simpleType>
-    <xs:simpleType name="SuiteAndTestStatusValue">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="PASS" />
-            <xs:enumeration value="FAIL" />
-            <xs:enumeration value="SKIP" />
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="Timeout">

--- a/doc/schema/robot.02.xsd
+++ b/doc/schema/robot.02.xsd
@@ -38,7 +38,7 @@
             <xs:element name="test" type="Test" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="doc" type="xs:string" minOccurs="0" />
             <xs:element name="meta" type="Metadata" minOccurs="0" maxOccurs="unbounded" />
-            <xs:element name="status" type="Status" />
+            <xs:element name="status" type="SuiteAndTestStatus" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string" />
         <xs:attribute name="source" type="xs:string" />
@@ -60,13 +60,15 @@
             <xs:element name="doc" type="xs:string" minOccurs="0" />
             <xs:element name="tag" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="timeout" type="Timeout" minOccurs="0" />
-            <xs:element name="status" type="Status" />
+            <xs:element name="status" type="SuiteAndTestStatus" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string" />
         <xs:attribute name="id" type="xs:string" />
     </xs:complexType>
     <xs:complexType name="Keyword">
         <xs:choice maxOccurs="unbounded">
+            <!-- These keywords can be regular keywords or test setup and teardown.
+                 If the later, they must have the `type` attribute set accordingly. -->
             <xs:element name="kw" type="Keyword" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="for" type="For" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="if" type="If" minOccurs="0" maxOccurs="unbounded" />
@@ -193,6 +195,17 @@
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>
+    <xs:complexType name="SuiteAndTestStatus">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="status" type="SuiteAndTestStatusValue" use="required" />
+                <xs:attribute name="starttime" type="xs:string" />
+                <xs:attribute name="endtime" type="xs:string" />
+                <!-- Not set if both `starttime` and `endtime` are defined. -->
+                <xs:attribute name="elapsedtime" type="xs:string" />
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
     <xs:simpleType name="StatusValue">
         <xs:restriction base="xs:string">
             <xs:enumeration value="PASS" />
@@ -200,6 +213,13 @@
             <xs:enumeration value="SKIP" />
             <!-- Only used with keywords, FORs and IFs, not with tests and suites. -->
             <xs:enumeration value="NOT RUN" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="SuiteAndTestStatusValue">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="PASS" />
+            <xs:enumeration value="FAIL" />
+            <xs:enumeration value="SKIP" />
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="Timeout">

--- a/doc/schema/robot.02.xsd
+++ b/doc/schema/robot.02.xsd
@@ -65,11 +65,11 @@
         <xs:attribute name="name" type="xs:string" />
         <xs:attribute name="id" type="xs:string" />
     </xs:complexType>
+    <!-- Keywords can be regular keywords or setup and teardown keywords.
+         If the later, they must have the `type` attribute set accordingly. -->
     <xs:complexType name="Keyword">
         <xs:choice maxOccurs="unbounded">
-            <!-- These keywords can be regular keywords or test setup and teardown.
-                 If the later, they must have the `type` attribute set accordingly. -->
-            <xs:element name="kw" type="Keyword" minOccurs="0" maxOccurs="unbounded" />
+           <xs:element name="kw" type="Keyword" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="for" type="For" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="if" type="If" minOccurs="0" maxOccurs="unbounded" />
             <!-- Assigned variables. -->


### PR DESCRIPTION
Differentiate test and suite statuses from other statuses, as "NOT RUN" is only available for keywords, FORs and IFs.
Related to #3726. 
