### PR TITLE
Don't convert value if it is already a valid type.

### DIFF
--- a/atest/robot/keywords/type_conversion/unions.robot
+++ b/atest/robot/keywords/type_conversion/unions.robot
@@ -28,3 +28,6 @@ Optional argument
 
 Optional argument with default
      Check Test Case    ${TESTNAME}
+
+Avoid unnecessary conversion
+     Check Test Case    ${TESTNAME}

--- a/atest/testdata/keywords/type_conversion/keyword_decorator.robot
+++ b/atest/testdata/keywords/type_conversion/keyword_decorator.robot
@@ -513,7 +513,7 @@ Multiple types using Union
     NONE          None
     ${1}          1
     ${1.2}        1.2
-    ${None}       None
+    ${None}       ${None}
 
 Argument not matching Union tupes
     [Tags]        require-py3
@@ -525,10 +525,10 @@ Multiple types using tuple
     [Template]    Multiple types using tuple
     1             1
     1.2           1.2
-    NONE          None
+    NONE          NONE
     ${1}          1
     ${1.2}        1.2
-    ${None}       None
+    ${None}       ${None}
 
 Argument not matching tuple tupes
     [Template]    Conversion Should Fail

--- a/atest/testdata/keywords/type_conversion/unions.py
+++ b/atest/testdata/keywords/type_conversion/unions.py
@@ -53,3 +53,7 @@ def optional_argument(argument: Optional[int], expected):
 
 def optional_argument_with_default(argument: Optional[float] = None, expected=None):
     assert argument == expected
+
+
+def union_with_string_first(argument: Union[str, None], expected):
+    assert argument == expected

--- a/atest/testdata/keywords/type_conversion/unions.robot
+++ b/atest/testdata/keywords/type_conversion/unions.robot
@@ -6,9 +6,9 @@ Force Tags        require-py3
 *** Test Cases ***
 Union
     [Template]    Union of int float and string
-    1          ${1}
-    2.1        ${2.1}
-    ${21.0}    ${21}
+    1          1
+    2.1        2.1
+    ${21.0}    ${21.0}
     2hello     2hello
     ${-110}    ${-110}
 
@@ -17,7 +17,7 @@ Union with None
     1          ${1}
     ${2}       ${2}
     ${None}    ${None}
-    NONE       ${None}
+    NONE       NONE
 
 Union with None and string
     [Template]    Union with None and str
@@ -44,9 +44,9 @@ Union with custom type
 
 Multiple types using tuple
     [Template]    Tuple of int float and string
-    1          ${1}
-    2.1        ${2.1}
-    ${21.0}    ${21}
+    1          1
+    2.1        2.1
+    ${21.0}    ${21.0}
     2hello     2hello
     ${-110}    ${-110}
 
@@ -66,3 +66,7 @@ Optional argument with default
     [Template]    Optional argument with default
     1       ${1}
     None    ${None}
+
+Avoid unnecessary conversion
+    Union With String First    ${NONE}    ${NONE}
+    Union With String First    None       None

--- a/src/robot/running/arguments/typeconverters.py
+++ b/src/robot/running/arguments/typeconverters.py
@@ -451,7 +451,9 @@ class CombinedConverter(TypeConverter):
         return True
 
     def _no_conversion_needed(self, value):
-        return False
+        NoneType = type(None)
+        types = tuple(NoneType if it is None else it for it in self.args)
+        return isinstance(value, types)
 
     def _convert(self, value, explicit_type=True):
         for typ in self.args:


### PR DESCRIPTION
#3867
#3738

If a value is already a valid type from a type union then there is no need to convert it.