### PR TITLE
Search functionality in log files

### DIFF
--- a/src/robot/htmldata/rebot/log.css
+++ b/src/robot/htmldata/rebot/log.css
@@ -181,3 +181,64 @@
 #total-stats tr:hover, #tag-stats tr:hover {
     cursor: default;
 }
+
+.highlighted {
+    background: orange;
+}
+
+#search, #open-search {
+    position: fixed;
+    bottom: 5px;
+    right: 5px;
+    z-index: 1000;
+    background: white;
+    max-height: 50%;
+    overflow: auto;
+}
+
+#search {
+    width: 30em;
+    display: none;
+}
+
+#results {
+    display: none;
+}
+
+#results a:link {
+    color: #000;
+    font-style: italic;
+}
+
+#results a:visited  {
+    color: #000;
+    font-style: italic;
+}
+
+#open-search {
+    border: 2px solid #ccc;
+    border-radius: 4px;
+    width: 40px;
+    height: 40px;
+    background-color: white;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEwAACxMBAJqcGAAAAY5JREFUSImt1LtrFGEUBfCfURsFHwEr29UNkS3MFklrQK0EIYUk/5IQ0FSmCCKW1mpAommToCKoK+lsLUKeSFbXFLuT3B13Hjt64INvOPeec+fOnUs2mpjHBrbRwQE+YQFTObm5qGMZf0qct7gxjPgM9kqKJ+cAs2XFf4fEX3iOe7iKsxjFHTxFO8R2ikzqqcq/oVFQUANfUm8ynhUce97qVVoGo/gaclcGBTVDQDuvigw09Lfrr+maD+TSkOIJngWNx2lyI5C3KxrcDRof0+R2IC9XNLgSNPbTZDKa7YricFr/v3EqIUZ0xxPO4FxFg0vhnoz7scFmICcqGjTDvRWJEayG57mKBg/C/U2anHDSu5+oDSlex6GTlTE2KOhVMPmACyXFL+qOZZL7Xf/3OMY17KZMrheI13px6e26nmVyX3eDxnYt4lav0qTiaTzp8VkrPNdkNyOpkyM4lEkNL0uK/CjgXw8ySHATD7GGLd0/fgfv8QiTOI93BSb/jCKT/4Isk1ZOTiWTF0H8M8aPANvFyARlADGFAAAAAElFTkSuQmCC);
+    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI4IiBoZWlnaHQ9IjgiIHZpZXdCb3g9IjAgMCA4IDgiPgogIDxwYXRoIGQ9Ik0zLjUgMGMtMS45MyAwLTMuNSAxLjU3LTMuNSAzLjVzMS41NyAzLjUgMy41IDMuNWMuNTkgMCAxLjE3LS4xNCAxLjY2LS40MWExIDEgMCAwIDAgLjEzLjEzbDEgMWExLjAyIDEuMDIgMCAxIDAgMS40NC0xLjQ0bC0xLTFhMSAxIDAgMCAwLS4xNi0uMTNjLjI3LS40OS40NC0xLjA2LjQ0LTEuNjYgMC0xLjkzLTEuNTctMy41LTMuNS0zLjV6bTAgMWMxLjM5IDAgMi41IDEuMTEgMi41IDIuNSAwIC42Ni0uMjQgMS4yNy0uNjYgMS43Mi0uMDEuMDEtLjAyLjAyLS4wMy4wM2ExIDEgMCAwIDAtLjEzLjEzYy0uNDQuNC0xLjA0LjYzLTEuNjkuNjMtMS4zOSAwLTIuNS0xLjExLTIuNS0yLjVzMS4xMS0yLjUgMi41LTIuNXoiCiAgLz4KPC9zdmc+), none;
+    background-size: 24px 24px;
+}
+
+#open-search:hover {
+    background-color: #ccc;
+}
+
+#search-title {
+    font-size: 1.1em;
+    font-weight: bold;
+    letter-spacing: 1px;
+}
+
+#search-string {
+    box-sizing: border-box;
+    width: 100%;
+}

--- a/src/robot/htmldata/rebot/log.html
+++ b/src/robot/htmldata/rebot/log.html
@@ -65,53 +65,39 @@ $(document).ready(function() {
 function doSearch() {
     let string = $('#search-string').val();
     $("#results-table tr").remove();
-    let results = [];
+    let resultsArray = [];
     if (string !== "") {
         $('.keyword').each(function () {
             const result = {};
             let key = $(this)[0].id;
             let elem = $(this).find('.element-header-left')
-            let el = elem[0];
-            if (el && el.title.toLowerCase().match(string.toLowerCase())) {
+            if (elem[0] && elem[0].title.toLowerCase().match(string.toLowerCase())) {
                 elem.addClass("highlighted")
-                let parentKeywords = buildParentKeywords(findAncestor(el, "keyword"));
-                parentKeywords.splice(parentKeywords.length - 1, 0,
-                    $(this).find('.parent-name')[0].innerText.replaceAll(" ", ""));
-                let fullName = buildFullName(el, "test");
-                if (!fullName) {
-                    fullName = buildFullName(el, "suite");
-                }
-                result[key] = fullName
-                    + " | "
-                    + parentKeywords.slice(0, -1).join(' | ')
-                    + parentKeywords.slice(-1)[0];
-                results.push(result);
+                result[key] = buildFullName(elem);
+                resultsArray.push(result);
             } else {
                 elem.removeClass("highlighted")
             }
         });
     }
-    let rows = "";
-    let url = document.URL.split("#")[0] + "#";
-    if (results.length === 0) {
-        rows += "<tr><td>No results found.</tr></td>";
-    }
-    $.each(results, function () {
-        rows += "<tr><td><a href="
-            + url + Object.keys(this)[0] + ">"
-            + escape(Object.values(this).toString())
-            + "</a></td></tr>";
-    });
-
-    $(rows).appendTo("#results-table tbody");
+    $(createResults(resultsArray)).appendTo("#results-table tbody");
     $("#results").show();
 }
 
-function escape(string) {
-    return string.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+function buildFullName(elem) {
+    let longname = getLongname(elem[0], "test");
+    if (!longname) {
+        longname = getLongname(elem[0], "suite");
+    }
+    let parentKeywords = getParentKeywords(findAncestor(elem[0], "keyword"));
+    addKeywordLibraryName(parentKeywords, elem);
+    return longname
+        + " | "
+        + parentKeywords.slice(0, -1).join(' | ')
+        + parentKeywords.slice(-1)[0];
 }
 
-function buildParentKeywords(ancestor) {
+function getParentKeywords(ancestor) {
     let name = [];
     while (ancestor) {
         name.push(ancestor.querySelector(".element-header-left").title);
@@ -120,18 +106,41 @@ function buildParentKeywords(ancestor) {
     return name.reverse();
 }
 
-function buildFullName(ancestor, type) {
-    let fullName = "";
-    ancestor = findAncestor(ancestor, type);
+function addKeywordLibraryName(parentKeywords, elem) {
+    return parentKeywords.splice(parentKeywords.length - 1, 0,
+        elem.find('.parent-name')[0].innerText.replaceAll(" ", ""));
+}
+
+function getLongname(ancestor, cls) {
+    ancestor = findAncestor(ancestor, cls);
     if (ancestor) {
-        fullName = ancestor.querySelector(".metadata td").innerText;
+        return ancestor.querySelector(".metadata td").innerText;
     }
-    return fullName;
+    return "";
 }
 
 function findAncestor(el, cls) {
     while ((el = el.parentElement) && !el.classList.contains(cls));
     return el;
+}
+
+function createResults(resultsArray) {
+    let rows = "";
+    let url = document.URL.split("#")[0] + "#";
+    if (resultsArray.length === 0) {
+        rows += "<tr><td>No results found.</tr></td>";
+    }
+    $.each(resultsArray, function () {
+        rows += "<tr><td><a href="
+            + url + Object.keys(this)[0] + ">"
+            + escape(Object.values(this).toString())
+            + "</a></td></tr>";
+    });
+    return rows;
+}
+
+function escape(string) {
+    return string.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
 function openSearch() {

--- a/src/robot/htmldata/rebot/log.html
+++ b/src/robot/htmldata/rebot/log.html
@@ -58,7 +58,113 @@ $(document).ready(function() {
         expandSuite(topsuite);
     }
     setTimeout(function () { loadAndExpandElementIds(window.output['expand_keywords']); }, 100);
+    $.tmpl('searchButton').appendTo($('body'));
+    $(document).bind('keydown', handleKeyDown);
 });
+
+function doSearch() {
+    let string = $('#search-string').val();
+    $("#results-table tr").remove();
+    let results = [];
+    if (string !== "") {
+        $('.keyword').each(function () {
+            const result = {};
+            let key = $(this)[0].id;
+            let elem = $(this).find('.element-header-left')
+            let el = elem[0];
+            if (el && el.title.toLowerCase().match(string.toLowerCase())) {
+                elem.addClass("highlighted")
+                let parentKeywords = buildParentKeywords(findAncestor(el, "keyword"));
+                parentKeywords.splice(parentKeywords.length - 1, 0,
+                    $(this).find('.parent-name')[0].innerText.replaceAll(" ", ""));
+                let fullName = buildFullName(el, "test");
+                if (!fullName) {
+                    fullName = buildFullName(el, "suite");
+                }
+                result[key] = fullName
+                    + " | "
+                    + parentKeywords.slice(0, -1).join(' | ')
+                    + parentKeywords.slice(-1)[0];
+                results.push(result);
+            } else {
+                elem.removeClass("highlighted")
+            }
+        });
+    }
+    let rows = "";
+    let url = document.URL.split("#")[0] + "#";
+    if (results.length === 0) {
+        rows += "<tr><td>No results found.</tr></td>";
+    }
+    $.each(results, function () {
+        rows += "<tr><td><a href="
+            + url + Object.keys(this)[0] + ">"
+            + escape(Object.values(this).toString())
+            + "</a></td></tr>";
+    });
+
+    $(rows).appendTo("#results-table tbody");
+    $("#results").show();
+}
+
+function escape(string) {
+    return string.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function buildParentKeywords(ancestor) {
+    let name = [];
+    while (ancestor) {
+        name.push(ancestor.querySelector(".element-header-left").title);
+        ancestor = findAncestor(ancestor, "keyword");
+    }
+    return name.reverse();
+}
+
+function buildFullName(ancestor, type) {
+    let fullName = "";
+    ancestor = findAncestor(ancestor, type);
+    if (ancestor) {
+        fullName = ancestor.querySelector(".metadata td").innerText;
+    }
+    return fullName;
+}
+
+function findAncestor(el, cls) {
+    while ((el = el.parentElement) && !el.classList.contains(cls));
+    return el;
+}
+
+function openSearch() {
+    $('#search').show();
+    $('#open-search').hide();
+    $('#search-string').focus().select();
+}
+
+function closeSearch() {
+    $('#search').hide();
+    $('#open-search').show();
+}
+
+function resetSearch() {
+    $('.keyword').each(function () {
+        let elem = $(this).find('.element-header-left');
+        elem.removeClass("highlighted");
+    });
+    $('#search-string').val('');
+    $("#results-table tr").remove();
+    $("#results").hide();
+}
+
+function handleKeyDown(event) {
+    event = event || window.event;
+    var keyCode = event.keyCode || event.which;
+    if (keyCode === 27)  // esc
+        setTimeout(closeSearch, 0);
+    if (keyCode === 83 && $('#search').is(':hidden'))  // s
+        setTimeout(openSearch, 0);
+    if (keyCode === 13 && $('#search').is(':visible'))  // enter
+        setTimeout(doSearch, 0);
+}
 
 function addLogLevelSelector(minLevel, defaultLevel) {
     var controller = LogLevelController(minLevel, defaultLevel);
@@ -384,6 +490,34 @@ function addExecutionLog(main) {
       {{if showTrace()}}<option value="0">TRACE</option>{{/if}}
     </select>
   </div>
+</script>
+
+<script type="text/x-jquery-tmpl" id="searchButton">
+      <form id="search" action="javascript:void(0)">
+        <fieldset>
+            <legend id="search-title">Search keywords</legend>
+            <input type="text" id="search-string">
+            <p></p>
+            <div id="search-buttons">
+                <input type="button" value="Search" onclick="doSearch()"
+                       title="Search (shortcut: <Enter>)">
+                 <input type="button" value="Reset" onclick="resetSearch()"
+                       title="Reset search">
+                <input type="button" value="Close" onclick="closeSearch()"
+                       title="Close search (shortcut: <Esc>)">
+            </div>
+            <p></p><p></p>
+            <fieldset id="results">
+            <legend> Results </legend>
+            <table id="results-table">
+              <tbody>
+              </tbody>
+            </table>
+            </fieldset>
+            <p></p>
+        </fieldset>
+    </form>
+    <div id="open-search" onclick="openSearch()" title="Search keywords (shortcut: s)"></div>
 </script>
 
 </body>


### PR DESCRIPTION
I created a prototype search in log.html for #3799.
The interface was inspired from the old search function in libdoc and it looks like this:

![Capture0](https://user-images.githubusercontent.com/4466614/114353570-dd3a5a80-9b75-11eb-93a3-5c47ab3c6e38.PNG)

![Capture](https://user-images.githubusercontent.com/4466614/114353595-e1ff0e80-9b75-11eb-90b6-6e982d930b2c.PNG)

In the search dialog, all the results are links to the keywords in the log file and inside the log the results are highlighted in orange.

A limitation I've encountered is that not all keywords are available from the start in DOM and are not accessible to search through them. A proposal I have is to add a checkbox to `Expand all keywords and search`, but maybe there is a better way to do it that I cannot see at the moment.

@pekkaklarck any comments and suggestions from you are welcomed :)