### PR TITLE
Fixed Typo in User Guide

### DIFF
--- a/doc/userguide/src/ExtendingRobotFramework/CreatingTestLibraries.rst
+++ b/doc/userguide/src/ExtendingRobotFramework/CreatingTestLibraries.rst
@@ -2237,7 +2237,7 @@ Programmatic logging APIs
 
 Programmatic APIs provide somewhat cleaner way to log information than
 using the standard output and error streams. Currently these
-interfaces are available only to Python bases test libraries.
+interfaces are available only to Python based test libraries.
 
 Public logging API
 ''''''''''''''''''


### PR DESCRIPTION
While reading the user guide I found a typo. Maybe you want to fix this, although I can understand that maybe more important issues will be preferred. Thank you for your work! 😄 