### PR TITLE
Fix keyword documentation shortcuts menu overflow and overscroll

### DIFF
--- a/src/robot/htmldata/libdoc/libdoc.css
+++ b/src/robot/htmldata/libdoc/libdoc.css
@@ -404,7 +404,7 @@ input.hamburger-menu:checked ~ span.hamburger-menu-3
         display: block;
         position: fixed;
         height: 100vh;
-        width: 100vw;
+        width: 100%;
     }
 
     .keywords-overview {
@@ -414,6 +414,7 @@ input.hamburger-menu:checked ~ span.hamburger-menu-3
 
     .shortcuts {
         max-width: 100vw;
+        overscroll-behavior: none;
     }
 }
 


### PR DESCRIPTION
Fixes #4012 

Note: [overscroll-behavior](https://caniuse.com/css-overscroll-behavior) CSS property isn't yet supported on Safari. However, the keyword documentation pages seemed to work as they do now.