### PR TITLE
rename continue-on-failure-recursive tag to robot:recursive-continue-on-failure

### DIFF
--- a/atest/testdata/running/continue_on_failure_tag.robot
+++ b/atest/testdata/running/continue_on_failure_tag.robot
@@ -162,7 +162,7 @@ Recursive continue in test with tag and two nested UK without tag
     ...    3) kw2a\n\n
     ...    4) kw2b\n\n
     ...    5) This should be executed
-    [Tags]   robot:continue-on-failure-recursive
+    [Tags]   robot:recursive-continue-on-failure
     Failure in user keyword without tag     run_kw=Failure in user keyword without tag
     Fail   This should be executed
 
@@ -173,7 +173,7 @@ Recursive continue in test with Set Tags and two nested UK without tag
     ...    3) kw2a\n\n
     ...    4) kw2b\n\n
     ...    5) This should be executed
-    Set Tags   robot:continue-on-failure-recursive
+    Set Tags   robot:recursive-continue-on-failure
     Failure in user keyword without tag     run_kw=Failure in user keyword without tag
     Fail   This should be executed
 
@@ -184,7 +184,7 @@ Recursive continue in test with tag and two nested UK with and without tag
     ...    3) kw2a\n\n
     ...    4) kw2b\n\n
     ...    5) This should be executed
-    [Tags]   robot:continue-on-failure-recursive
+    [Tags]   robot:recursive-continue-on-failure
     Failure in user keyword with tag     run_kw=Failure in user keyword without tag
     Fail   This should be executed
 
@@ -220,7 +220,7 @@ Failure in user keyword without tag
 
 Failure in user keyword with recursive tag
     [Arguments]    ${run_kw}=No Operation
-    [Tags]   robot:continue-on-failure-recursive
+    [Tags]   robot:recursive-continue-on-failure
     Fail   kw1a
     Fail   kw1b
     Log    This should be executed

--- a/atest/testdata/running/continue_on_failure_tag.robot
+++ b/atest/testdata/running/continue_on_failure_tag.robot
@@ -15,7 +15,7 @@ Continue in test with Set Tags
     [Documentation]    FAIL ${HEADER}\n\n
     ...    1) 1\n\n
     ...    2) 2
-    Set Tags   robot:continue-on-failure
+    Set Tags   ROBOT:CONTINUE-ON-FAILURE            # case shouldn't matter
     Fail   1
     Fail   2
     Log    This should be executed
@@ -31,7 +31,7 @@ Continue in test with tag and UK without tag
     [Documentation]    FAIL ${HEADER}\n\n
     ...    1) kw2a\n\n
     ...    2) This should be executed
-    [Tags]   robot:continue-on-failure
+    [Tags]   robot:CONTINUE-on-failure              # case shouldn't matter
     Failure in user keyword without tag
     Fail   This should be executed
 
@@ -41,7 +41,7 @@ Continue in test with tag and nested UK with and without tag
     ...    2) kw1b\n\n
     ...    3) kw2a\n\n
     ...    4) This should be executed
-    [Tags]   robot:continue-on-failure
+    [Tags]   robot: continue-on-failure             # spaces should be collapsed
     Failure in user keyword with tag     run_kw=Failure in user keyword without tag
     Fail   This should be executed
 
@@ -173,7 +173,7 @@ Recursive continue in test with Set Tags and two nested UK without tag
     ...    3) kw2a\n\n
     ...    4) kw2b\n\n
     ...    5) This should be executed
-    Set Tags   robot:recursive-continue-on-failure
+    Set Tags   robot: recursive-continue-on-failure     # spaces should be collapsed
     Failure in user keyword without tag     run_kw=Failure in user keyword without tag
     Fail   This should be executed
 
@@ -184,7 +184,7 @@ Recursive continue in test with tag and two nested UK with and without tag
     ...    3) kw2a\n\n
     ...    4) kw2b\n\n
     ...    5) This should be executed
-    [Tags]   robot:recursive-continue-on-failure
+    [Tags]   ROBOT:RECURSIVE-CONTINUE-ON-FAILURE        # case shouldn't matter
     Failure in user keyword with tag     run_kw=Failure in user keyword without tag
     Fail   This should be executed
 

--- a/doc/userguide/src/ExecutingTestCases/TestExecution.rst
+++ b/doc/userguide/src/ExecutingTestCases/TestExecution.rst
@@ -418,14 +418,14 @@ executed from within a user keyword with the reserved tag set).
 
 To support use cases where the behaviour should propagate from
 test cases into user keywords (and/or from user keywords into other
-user keywords), the reserved tag `robot:continue-on-failure-recursive`
+user keywords), the reserved tag `robot:recursive-continue-on-failure`
 can be used. The below examples executes all the keywords listed.
 
 .. sourcecode:: robotframework
 
    *** Test Cases ***
    Test
-       [Tags]    robot:continue-on-failure-recursive
+       [Tags]    robot:recursive-continue-on-failure
        Should be Equal   1   2
        User Keyword 1
        Log   log from test case
@@ -441,7 +441,7 @@ can be used. The below examples executes all the keywords listed.
        Log   log from keyword 2
 
 
-The `robot:continue-on-failure` and `robot:continue-on-failure-recursive`
+The `robot:continue-on-failure` and `robot:recursive-continue-on-failure`
 tags are new in Robot Framework 4.1.
 
 Execution continues on teardowns automatically

--- a/src/robot/running/context.py
+++ b/src/robot/running/context.py
@@ -133,7 +133,7 @@ class _ExecutionContext(object):
             return False
         if 'robot:continue-on-failure' in parents[-1].tags:
             return True
-        return any('robot:continue-on-failure-recursive' in p.tags for p in parents)
+        return any('robot:recursive-continue-on-failure' in p.tags for p in parents)
 
     def end_suite(self, suite):
         for name in ['${PREV_TEST_NAME}',


### PR DESCRIPTION
minor modifications to #3925, renaming the recursive tag as `robot:recursive-continue-on-failure` and modified tests to also use upper-case or whitespace in those reserved tags.


I did not mix case for the tagstatistic tests as it seems, I had to do below to make it pass 
``` 
     def _suppress_reserved(self, tag):
         # don't suppress reserved tags if the user explicitly included them
-        return tag.startswith('robot:') and not self._included.match(tag)
+        return tag.lower().startswith('robot:') and not self._included.match(tag)
```

full diff required to make the test pass when I use ROBOT: prefix.. this doesn't look correct..don't have time this week to look at this..

```
diff --git a/atest/robot/tags/tag_stat_include_and_exclude.robot b/atest/robot/tags/tag_stat_include_and_exclude.robot
index a13b5ba9e..76e697992 100644
--- a/atest/robot/tags/tag_stat_include_and_exclude.robot
+++ b/atest/robot/tags/tag_stat_include_and_exclude.robot
@@ -5,7 +5,7 @@ Resource          atest_resource.robot
 *** Variables ***
 ${DATA SOURCE}    tags/include_and_exclude.robot
 ${F}              force
-${INTERNAL}       robot:just-an-example
+${INTERNAL}       ROBOT:just-an-example
 ${I1}             incl1
 ${I2}             incl 2
 ${I3}             incl_3
@@ -34,12 +34,12 @@ Include With Patterns
     --TagStatInc *cl3 --TagStatInc i*2    ${E3}    ${I2}    ${I3}
 
 Include to show internal tags
-    --tagstatinclude incl1 --tagstatinclude robot:*    ${I1}    ${INTERNAL}
-    --tagstatinclude robot:*    ${INTERNAL}
+    --tagstatinclude incl1 --tagstatinclude ROBOT:*    ${I1}    ${INTERNAL}
+    --tagstatinclude ROBOT:*    ${INTERNAL}
     --tagstatinclude *    @{ALL}    ${INTERNAL}
 
 Include and exclude internal
-    --tagstatinclude incl1 --tagstatinclude robot:* --tagstatexclude robot:*    ${I1}
+    --tagstatinclude incl1 --tagstatinclude ROBOT:* --tagstatexclude ROBOT:*    ${I1}
 
 One Exclude
     --tagstatexclude excl1    ${E2}    ${E3}    ${F}    @{INCL}
diff --git a/atest/testdata/tags/include_and_exclude.robot b/atest/testdata/tags/include_and_exclude.robot
index 20c624b07..48368e129 100644
--- a/atest/testdata/tags/include_and_exclude.robot
+++ b/atest/testdata/tags/include_and_exclude.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Force Tags      force    robot:just-an-example
+Force Tags      force    ROBOT:just-an-example
 
 *** Test Cases ***
 Incl-1
diff --git a/src/robot/model/tagstatistics.py b/src/robot/model/tagstatistics.py
index bdecaa8ff..a737e3a5c 100644
--- a/src/robot/model/tagstatistics.py
+++ b/src/robot/model/tagstatistics.py
@@ -73,7 +73,7 @@ class TagStatisticsBuilder(object):
 
     def _suppress_reserved(self, tag):
         # don't suppress reserved tags if the user explicitly included them
-        return tag.startswith('robot:') and not self._included.match(tag)
+        return tag.lower().startswith('robot:') and not self._included.match(tag)
 
 
 class TagStatInfo(object):
```