### PR TITLE
fix indentation issue in ListenerInterface documentation

### DIFF
--- a/doc/userguide/src/ExtendingRobotFramework/ListenerInterface.rst
+++ b/doc/userguide/src/ExtendingRobotFramework/ListenerInterface.rst
@@ -576,10 +576,10 @@ probably more useful than this example.
            else:
                self.outfile.write('FAIL: %s\n' % attrs['message'])
 
-        def end_suite(self, name, attrs):
+       def end_suite(self, name, attrs):
             self.outfile.write('%s\n%s\n' % (attrs['status'], attrs['message']))
 
-        def close(self):
+       def close(self):
             self.outfile.close()
 
 The following example implements the same functionality as the previous one,


### PR DESCRIPTION
Hey, hope it's alright to open a PR for this type of thing. I was browsing through the listener documentation and copied an example. I then noticed that this example had a slight indentation issue (lines 579 and line 582). This PR fixes that slight indentation issue