### PR TITLE
ISSUE-3410 Added `--maxassignlength` option

### DIFF
--- a/doc/userguide/src/Appendices/CommandLineOptions.rst
+++ b/doc/userguide/src/Appendices/CommandLineOptions.rst
@@ -50,6 +50,8 @@ Command line options for test execution
   --reporttitle <title>   `Sets a title`_ for the generated test report.
   --reportbackground <colors>  `Sets background colors`_ of the generated report.
   --maxerrorlines <lines>  Sets the number of `error lines`_ shown in reports when tests fail.
+  --maxassignlength <characters>  Sets the number of `characters`_ shown in reports when
+                           variable is assigned.
   -L, --loglevel <level>  `Sets the threshold level`_ for logging. Optionally
                           the default `visible log level`_ can be given
                           separated with a colon (:).

--- a/src/robot/conf/settings.py
+++ b/src/robot/conf/settings.py
@@ -129,6 +129,8 @@ class _BaseSettings(object):
             return self._process_randomize_value(value)
         if name == 'MaxErrorLines':
             return self._process_max_error_lines(value)
+        if name == 'MaxAssignLength':
+            return self._process_max_assign_length(value)
         if name == 'RemoveKeywords':
             self._validate_remove_keywords(value)
         if name == 'FlattenKeywords':
@@ -180,6 +182,15 @@ class _BaseSettings(object):
         value = self._convert_to_integer('maxerrorlines', value)
         if value < 10:
             raise DataError("Option '--maxerrorlines' expected an integer "
+                            "value greater that 10 but got '%s'." % value)
+        return value
+
+    def _process_max_assign_length(self, value):
+        value = self._convert_to_integer('maxassignlength', value)
+        if value == -1:
+            return None
+        if value < 10:
+            raise DataError("Option '--maxassignlength' expected an integer "
                             "value greater that 10 but got '%s'." % value)
         return value
 
@@ -408,6 +419,7 @@ class RobotSettings(_BaseSettings):
                        'Output'             : ('output', 'output.xml'),
                        'LogLevel'           : ('loglevel', 'INFO'),
                        'MaxErrorLines'      : ('maxerrorlines', 40),
+                       'MaxAssignLength'    : ('maxassignlength', 200),
                        'DryRun'             : ('dryrun', False),
                        'ExitOnFailure'      : ('exitonfailure', False),
                        'ExitOnError'        : ('exitonerror', False),
@@ -540,6 +552,10 @@ class RobotSettings(_BaseSettings):
     @property
     def max_error_lines(self):
         return self['MaxErrorLines']
+
+    @property
+    def max_assign_length(self):
+        return self['MaxAssignLength']
 
     @property
     def pre_run_modifiers(self):

--- a/src/robot/run.py
+++ b/src/robot/run.py
@@ -205,6 +205,10 @@ Options
     --maxerrorlines lines  Maximum number of error message lines to show in
                           report when tests fail. Default is 40, minimum is 10
                           and `NONE` can be used to show the full message.
+    --maxassignlength characters  Maximum number of characters to show in
+                          report when variable is assigned. Default is 200,
+                          minimum is 10 and -1 can be used to remove assigned
+                          value.
  -L --loglevel level      Threshold level for logging. Available levels: TRACE,
                           DEBUG, INFO (default), WARN, NONE (no logging). Use
                           syntax `LOGLEVEL:DEFAULT` to define the default
@@ -446,6 +450,7 @@ class RobotFramework(Application):
         with pyloggingconf.robot_handler_enabled(settings.log_level):
             old_max_error_lines = text.MAX_ERROR_LINES
             text.MAX_ERROR_LINES = settings.max_error_lines
+            text.MAX_ASSIGN_LENGTH = settings.max_assign_length
             try:
                 result = suite.run(settings)
             finally:

--- a/src/robot/utils/text.py
+++ b/src/robot/utils/text.py
@@ -26,7 +26,7 @@ from .unic import unic
 
 
 MAX_ERROR_LINES = 40
-_MAX_ASSIGN_LENGTH = 200
+MAX_ASSIGN_LENGTH = 200
 _MAX_ERROR_LINE_LENGTH = 78
 _ERROR_CUT_EXPLN = '    [ Message content over the limit has been removed. ]'
 _TAGS_RE = re.compile(r'\s*tags:(.*)', re.IGNORECASE)
@@ -83,6 +83,8 @@ def _count_virtual_line_length(line):
 def format_assign_message(variable, value, cut_long=True):
     formatter = {'$': unic, '@': seq2str2, '&': _dict_to_str}[variable[0]]
     value = formatter(value)
+    if MAX_ASSIGN_LENGTH is None:
+        return '%s = ...' % variable
     if cut_long:
         value = cut_assign_value(value)
     return '%s = %s' % (variable, value)
@@ -97,8 +99,8 @@ def _dict_to_str(d):
 def cut_assign_value(value):
     if not is_unicode(value):
         value = unic(value)
-    if len(value) > _MAX_ASSIGN_LENGTH:
-        value = value[:_MAX_ASSIGN_LENGTH] + '...'
+    if len(value) > MAX_ASSIGN_LENGTH:
+        value = value[:MAX_ASSIGN_LENGTH] + '...'
     return value
 
 


### PR DESCRIPTION
Here I try to implement #ISSUE-3410
Now it seems like
![image](https://user-images.githubusercontent.com/56407674/128151471-020e5e2e-9ea0-44e1-a5f6-2fbb73652393.png)

@pekkaklarck If this approach is Ok I will add test for this feature. 
