### PR TITLE
Access to --include and --exclude Tags from Automatic Variables (#3255)

### DIFF
--- a/atest/robot/variables/automatic_variables.robot
+++ b/atest/robot/variables/automatic_variables.robot
@@ -14,10 +14,10 @@ Test Documentation
     Should Be Equal    ${tc.doc}    My doc.\nIn 2 lines! And with variable value!!
 
 Test Tags
-    Check Test Tags    ${TEST NAME}    Force 1    Hello, world!    id-42    variable value
+    Check Test Tags    ${TEST NAME}    Force 1    Hello, world!    id-42    include this test    variable value
 
 Modifying \${TEST TAGS} does not affect actual tags test has
-    Check Test Tags    ${TEST NAME}    Force 1    mytag
+    Check Test Tags    ${TEST NAME}    Force 1    mytag    include this test
 
 Suite Name
     Check Test Case    ${TEST NAME}

--- a/atest/robot/variables/automatic_variables.robot
+++ b/atest/robot/variables/automatic_variables.robot
@@ -1,5 +1,5 @@
 *** Setting ***
-Suite Setup       Run Tests    ${EMPTY}    variables/automatic_variables/
+Suite Setup       Run Tests    --exclude exclude_this_test --include include_this_test   variables/automatic_variables/
 Resource          atest_resource.robot
 
 *** Test Case ***

--- a/atest/testdata/variables/automatic_variables/auto1.robot
+++ b/atest/testdata/variables/automatic_variables/auto1.robot
@@ -17,7 +17,7 @@ ${VARIABLE}          variable value
 ${EXP_SUITE_NAME}    Automatic Variables.Auto1
 ${EXP_SUITE_DOC}     This is suite documentation. With ${VARIABLE}.
 ${EXP_SUITE_META}    {'MeTa1': 'Value', 'meta2': '${VARIABLE}'}
-${EXP_SUITE_STATS}   16 tests, 16 passed, 2 failed
+${EXP_SUITE_STATS}   18 tests, 16 passed, 2 failed
 @{LAST_TEST}         Previous Test Variables Should Have Correct Values When That Test Fails    PASS
 
 *** Test Case ***

--- a/atest/testdata/variables/automatic_variables/auto1.robot
+++ b/atest/testdata/variables/automatic_variables/auto1.robot
@@ -6,7 +6,7 @@ Suite Setup       Check Variables In Suite Setup    ${EXP_SUITE_NAME}
 ...               ${EXP_SUITE_DOC}    ${EXP_SUITE_META}
 Suite Teardown    Check Variables In Suite Teardown    ${EXP_SUITE_NAME}
 ...               FAIL    ${EXP_SUITE_STATS}    @{LAST_TEST}
-Force Tags        Force 1
+Force Tags        Force 1    include this test
 Resource          resource.robot
 Library           Collections
 Library           HelperLib.py    ${SUITE SOURCE}    ${SUITE NAME}
@@ -17,7 +17,7 @@ ${VARIABLE}          variable value
 ${EXP_SUITE_NAME}    Automatic Variables.Auto1
 ${EXP_SUITE_DOC}     This is suite documentation. With ${VARIABLE}.
 ${EXP_SUITE_META}    {'MeTa1': 'Value', 'meta2': '${VARIABLE}'}
-${EXP_SUITE_STATS}   16 tests, 14 passed, 2 failed
+${EXP_SUITE_STATS}   16 tests, 16 passed, 2 failed
 @{LAST_TEST}         Previous Test Variables Should Have Correct Values When That Test Fails    PASS
 
 *** Test Case ***
@@ -38,15 +38,21 @@ Test Documentation
 
 Test Tags
     [Tags]    id-${42}    Hello, world!    ${VARIABLE}
-    [Setup]    Check Test Tags    Force 1    Hello, world!    id-42    ${VARIABLE}
-    Check Test Tags    Force 1    Hello, world!    id-42    ${VARIABLE}
-    [Teardown]    Check Test Tags    Force 1    Hello, world!    id-42    ${VARIABLE}
+    [Setup]    Check Test Tags    Force 1    Hello, world!    id-42    include this test    ${VARIABLE}
+    Check Test Tags    Force 1    Hello, world!    id-42    include this test    ${VARIABLE}
+    [Teardown]    Check Test Tags    Force 1    Hello, world!    id-42    include this test    ${VARIABLE}
 
 Modifying ${TEST TAGS} does not affect actual tags test has
     [Documentation]    The variable is changed but not "real" tags
     [Tags]    mytag
     Append To List    ${TEST TAGS}    not really added
-    Check Test Tags    Force 1    mytag    not really added
+    Check Test Tags    Force 1    include this test    mytag    not really added
+
+Include-tags Available As Automatic Variables
+    Should Contain    ${INCLUDE_TAGS}    include this test
+
+Exclude-tags Available As Automatic Variables
+    Should Contain    ${EXCLUDE_TAGS}    exclude this test
 
 Suite Name
     Should Be Equal    ${SUITE_NAME}    ${EXP_SUITE_NAME}
@@ -106,3 +112,7 @@ Previous Test Variables Should Have Correct Values When That Test Fails
     [Setup]    Check Previous Test variables    Test Status When Setup Fails    FAIL    Setup failed:\nExpected failure in setup
     Check Previous Test variables    Test Status When Setup Fails    FAIL    Setup failed:\nExpected failure in setup
     [Teardown]    Check Previous Test variables    Test Status When Setup Fails    FAIL    Setup failed:\nExpected failure in setup
+
+This Test Should Be Excluded
+    [Tags]    exclude this test
+    Fail    Should not be executed

--- a/atest/testdata/variables/automatic_variables/auto2.robot
+++ b/atest/testdata/variables/automatic_variables/auto2.robot
@@ -4,6 +4,7 @@ Suite Setup       Check Variables In Suite Setup    Automatic Variables.Auto2
 Suite Teardown    Check Variables In Suite Teardown    Automatic Variables.Auto2    FAIL
 ...               1 test, 0 passed, 1 failed
 ...               @{LAST_TEST}
+Force Tags        include_this_tag
 Resource          resource.robot
 
 *** Variable ***

--- a/atest/testdata/variables/automatic_variables/auto2.robot
+++ b/atest/testdata/variables/automatic_variables/auto2.robot
@@ -4,7 +4,7 @@ Suite Setup       Check Variables In Suite Setup    Automatic Variables.Auto2
 Suite Teardown    Check Variables In Suite Teardown    Automatic Variables.Auto2    FAIL
 ...               1 test, 0 passed, 1 failed
 ...               @{LAST_TEST}
-Force Tags        include_this_tag
+Force Tags        include this test
 Resource          resource.robot
 
 *** Variable ***

--- a/doc/userguide/src/CreatingTestData/Variables.rst
+++ b/doc/userguide/src/CreatingTestData/Variables.rst
@@ -988,6 +988,12 @@ can be changed dynamically using keywords from the `BuiltIn`_ library.
    |                        | alphabetical order. Can be modified dynamically using |            |
    |                        | :name:`Set Tags` and :name:`Remove Tags` keywords.    |            |
    +------------------------+-------------------------------------------------------+------------+
+   | @{INCLUDE_TAGS}        | A list of tags that were provided to by the           | Everywhere |
+   |                        | --include command line option.                        |            |
+   +------------------------+-------------------------------------------------------+------------+
+   | @{EXCLUDE_TAGS}        | A list of tags that were provided to by the           | Everywhere |
+   |                        | --exclude command line option.                        |            |
+   +------------------------+-------------------------------------------------------+------------+
    | ${TEST DOCUMENTATION}  | The documentation of the current test case. Can be set| Test case  |
    |                        | dynamically using using :name:`Set Test Documentation`|            |
    |                        | keyword.                                              |            |

--- a/src/robot/variables/scopes.py
+++ b/src/robot/variables/scopes.py
@@ -201,7 +201,9 @@ class GlobalVariables(Variables):
                             ('${LOG_LEVEL}', settings.log_level),
                             ('${PREV_TEST_NAME}', ''),
                             ('${PREV_TEST_STATUS}', ''),
-                            ('${PREV_TEST_MESSAGE}', '')]:
+                            ('${PREV_TEST_MESSAGE}', ''),
+                            ('@{INCLUDE_TAGS}', settings.suite_config['include_tags']),
+                            ('@{EXCLUDE_TAGS}', settings.suite_config['exclude_tags'])]:
             self[name] = value
 
 


### PR DESCRIPTION
This PR adds two new automatic/built-in variables: @{INCLUDE_TAGS} and @{EXCLUDE_TAGS} containing the tags set by the respective command line options.

As requested in feature request #3255
