### PR TITLE
#4047 Variable in normal syntax is not replaced with its value in some cases;

### DIFF
--- a/atest/testdata/running/if/complex_if.robot
+++ b/atest/testdata/running/if/complex_if.robot
@@ -45,14 +45,19 @@ Setting after if
 
 For loop inside if
     ${value}    Set Variable    0
+    ${outter}    Set Variable   'focus pokus'
     IF    'kaunis maailma'
         FOR    ${var}    IN    1    2    3
             ${value}=    Set Variable    ${var}
         END
     ELSE IF    'ei tanne'
+        FOR    ${outter}    IN    1    2    3
+            Log    ${outter}
+        END
         ${value}=    Set Variable    123
     END
     Should be equal    ${value}    3
+    Should be equal    ${outter}    'focus pokus'
 
 For loop inside for loop
     ${checker}    Set Variable    wrong

--- a/src/robot/running/bodyrunner.py
+++ b/src/robot/running/bodyrunner.py
@@ -112,7 +112,7 @@ class IfRunner(object):
             if error and self._run:
                 raise DataError(error)
             runner = BodyRunner(self._context, run_branch, self._templated)
-            if not recursive_dry_run:
+            if run_branch and not recursive_dry_run:
                 runner.run(branch.body)
         return run_branch
 


### PR DESCRIPTION
Improved test ``For loop inside if`` in  ``atest/testdata/running/if/complex_if.robot`` is failed before fix
![image](https://user-images.githubusercontent.com/56407674/128629164-331cce40-3422-4723-a309-412b9fc0c8a1.png)
After fix it is OK:
![image](https://user-images.githubusercontent.com/56407674/128629185-c0410eed-3dc9-4d04-8596-be584f0bd9af.png)


 