### PR TITLE
Process: Return created process object

### DIFF
--- a/atest/robot/standard_libraries/process/process_library.robot
+++ b/atest/robot/standard_libraries/process/process_library.robot
@@ -23,5 +23,8 @@ Running a process in a shell
 Input things to process
     Check Test Case    ${TESTNAME}
 
+Assign process object to variable
+    Check Test Case    ${TESTNAME}
+
 Get process id
     Check Test Case    ${TESTNAME}

--- a/atest/testdata/standard_libraries/process/process_library.robot
+++ b/atest/testdata/standard_libraries/process/process_library.robot
@@ -41,6 +41,12 @@ Input things to process
     ${result}=    Wait For Process
     Should Match    ${result.stdout}    *inp 42*
 
+Assign process object to variable
+    ${process} =    Start Process  python  -c  print('Hello, world!')
+    ${result} =    Run Process  python  -c  import sys; print(sys.stdin.read().upper().strip())  stdin=${process.stdout}
+    Wait For Process    ${process}
+    Should Be Equal As Strings    ${result.stdout}  HELLO, WORLD!
+
 Get process id
     ${handle}=    Some process
     ${pid}=    Get Process Id    ${handle}

--- a/atest/testdata/standard_libraries/process/terminate_process.robot
+++ b/atest/testdata/standard_libraries/process/terminate_process.robot
@@ -96,10 +96,12 @@ Terminate all processes
     END
 
 Terminating all empties cache
+    [Documentation]    FAIL Non-existing index or alias '1'.
     Some process
+    Some process
+    Switch process    ${2}
     Terminate All Processes    kill=True
-    ${handle} =    Some Process
-    Should Be Equal    ${handle}    ${1}
+    Switch process    ${1}
 
 *** Keywords ***
 Terminate should stop countdown

--- a/src/robot/libraries/Process.py
+++ b/src/robot/libraries/Process.py
@@ -375,19 +375,32 @@ class Process(object):
         for more information about the arguments, and `Run Process` keyword
         for related examples.
 
-        Makes the started process new `active process`. Returns an identifier
-        that can be used as a handle to activate the started process if needed.
+        Makes the started process new `active process`. Returns the created 
+        process object [https://docs.python.org/3/library/subprocess.html#popen-constructor]
+        which can be assigned to a variable if needed.
+
+        Note: Returning an actual process object introduced in RF 5.0, previous versions
+        would only return a generic handler.
 
         Processes are started so that they create a new process group. This
         allows sending signals to and terminating also possible child
         processes. This is not supported on Jython.
+
+        Examples:
+        | Start Process | ${command} | alias=example |
+        | ${result} = | Wait For Process | example |
+        | ${process} = | Start Process | python | -c | print('Hello, world!') |
+        | ${result} = | Run Process | python | -c | import sys; print(sys.stdin.read().upper().strip()) | stdin=${process.stdout} |
+        | Wait For Process | ${process} |
+        | Should Be Equal | ${result.stdout} | HELLO, WORLD! |
         """
         conf = ProcessConfiguration(**configuration)
         command = conf.get_command(command, list(arguments))
         self._log_start(command, conf)
         process = subprocess.Popen(command, **conf.popen_config)
         self._results[process] = ExecutionResult(process, **conf.result_config)
-        return self._processes.register(process, alias=conf.alias)
+        self._processes.register(process, alias=conf.alias)
+        return self._processes.current
 
     def _log_start(self, command, config):
         if is_list_like(command):

--- a/src/robot/libraries/Process.py
+++ b/src/robot/libraries/Process.py
@@ -380,7 +380,7 @@ class Process(object):
         which can be assigned to a variable if needed.
 
         Note: Returning an actual process object introduced in RF 5.0, previous versions
-        would only return a generic handler.
+        would only return a generic process handle.
 
         Processes are started so that they create a new process group. This
         allows sending signals to and terminating also possible child

--- a/src/robot/utils/connectioncache.py
+++ b/src/robot/utils/connectioncache.py
@@ -138,12 +138,12 @@ class ConnectionCache(object):
         return self.current is not self._no_current
 
     def resolve_alias_or_index(self, alias_or_index):
-        for resolver in self._resolve_alias, self._resolve_index:
+        for resolver in self._resolve_alias, self._resolve_index, self._is_connection:
             try:
                 return resolver(alias_or_index)
             except ValueError:
                 pass
-        raise ValueError("Non-existing index or alias '%s'." % alias_or_index)
+        raise ValueError(f"Non-existing index or alias '{alias_or_index}'.")
 
     def _resolve_alias(self, alias):
         if is_string(alias) and alias in self._aliases:
@@ -158,6 +158,9 @@ class ConnectionCache(object):
         if not 0 < index <= len(self._connections):
             raise ValueError
         return index
+
+    def _is_connection(self, conn):
+        return self._connections.index(conn) + 1
 
 
 @py3to2


### PR DESCRIPTION
Modifies create_process method as it returns a process object.
Iterable for process objects  goes through connection indexes
so we can directly call get_connection for generated index from
register method.

Fixes #4104