### PR TITLE
No _start/_end_keyword when in FOR loop

### DIFF
--- a/src/robot/output/listeners.py
+++ b/src/robot/output/listeners.py
@@ -46,11 +46,11 @@ class Listeners(object):
         self._is_logged.set_level(level)
 
     def start_keyword(self, kw):
-        if kw.type != kw.IF_ELSE_ROOT:
+        if kw.type != kw.IF_ELSE_ROOT and kw.type != kw.FOR:
             self._start_keyword(kw)
 
     def end_keyword(self, kw):
-        if kw.type != kw.IF_ELSE_ROOT:
+        if kw.type != kw.IF_ELSE_ROOT and kw.type != kw.FOR:
             self._end_keyword(kw)
 
     def log_message(self, msg):


### PR DESCRIPTION
This PR aims to fix missing html output when using start_keyword or end_keyword listener and failure is in FOR loop.

Given following test suite:

    *** Test Cases ***
    List
        ${list}    Create List    foo    bar
        FOR    ${element}    IN    @{list}
            Log    ${element}
            Fail    Error
        END


    *** Keywords ***
    Log Error Situation
        Log    Error Situation
        
and following listener.py

    from robot.libraries.BuiltIn import BuiltIn

    ROBOT_LISTENER_API_VERSION = 2


    def end_keyword(name, attributes):
        if attributes['status'] == 'FAIL':
            BuiltIn().run_keyword('Log Error Situation')

When executing `robot --listener .\listener.py .` We get this output

    > robot --listener .\listener.py .
    ==============================================================================
    Rf-For
    ==============================================================================
    Rf-For.Test
    ==============================================================================
    List                                                                  | FAIL |
    Error
    ------------------------------------------------------------------------------
    Rf-For.Test                                                           | FAIL |
    1 test, 0 passed, 1 failed
    ==============================================================================
    Rf-For                                                                | FAIL |
    1 test, 0 passed, 1 failed
    ==============================================================================
    Output:  C:\Users\hpaavola\Development\sandbox\rf-for\output.xml
    [ ERROR ] Reading XML source 'C:\Users\hpaavola\Development\sandbox\rf-for\output.xml' failed: Incompatible child element 'kw' for 'for'.

    Try --help for usage information.
    
Using Robot Framework 4.1.1 After this fix, the output is as expected; html files are created and listener is working as expected.