### PR TITLE
Add len and type log formatter options to log keyword

### DIFF
--- a/atest/robot/standard_libraries/builtin/log.robot
+++ b/atest/robot/standard_libraries/builtin/log.robot
@@ -105,6 +105,22 @@ formatter=repr pretty prints
     Stdout Should Contain    ${small dict}
     Stdout Should Contain    ${small list}
 
+formatter=len
+    ${tc} =    Check Test Case    ${TEST NAME}
+    Check Log Message    ${tc.kws[0].msgs[0]}    20
+    Check Log Message    ${tc.kws[1].msgs[0]}    13
+    Check Log Message    ${tc.kws[2].msgs[0]}    42    DEBUG
+    Check Log Message    ${tc.kws[4].msgs[0]}    21
+    Check Log Message    ${tc.kws[6].msgs[0]}    5
+
+formatter=type
+    ${tc} =    Check Test Case    ${TEST NAME}
+    Check Log Message    ${tc.kws[0].msgs[0]}    <class 'str'>
+    Check Log Message    ${tc.kws[1].msgs[0]}    <class 'str'>
+    Check Log Message    ${tc.kws[2].msgs[0]}    42    DEBUG
+    Check Log Message    ${tc.kws[4].msgs[0]}    <class 'bytes'>
+    Check Log Message    ${tc.kws[6].msgs[0]}    <class 'str'>
+
 formatter=invalid
     Check Test Case    ${TEST NAME}
 

--- a/atest/testdata/standard_libraries/builtin/log.robot
+++ b/atest/testdata/standard_libraries/builtin/log.robot
@@ -102,8 +102,28 @@ formatter=repr pretty prints
     ${non ascii} =    Evaluate    ['hyv\\xe4', b'hyv\\xe4', {'\\u2603': b'\\x00\\xff'}]
     Log    ${non ascii}    formatter=repr
 
+formatter=len
+    [Setup]    Set Log Level    DEBUG
+    Log    Nothing special here    formatter=len
+    Log    Hyvää yötä \u2603!    formatter=LEN
+    Log    ${42}    DEBUG    ${FALSE}    ${FALSE}    ${TRUE}
+    ${bytes} =    Evaluate    b'\\x00abc\\xff (formatter=len)'
+    Log    ${bytes}    formatter=len    console=True
+    ${nfd} =    Evaluate    'hyva\u0308'
+    Log    ${nfd}    formatter=len
+
+formatter=type
+    [Setup]    Set Log Level    DEBUG
+    Log    Nothing special here    formatter=type
+    Log    Hyvää yötä \u2603!    formatter=TYPE
+    Log    ${42}    DEBUG    ${FALSE}    ${FALSE}    ${TRUE}
+    ${bytes} =    Evaluate    b'\\x00abc\\xff (formatter=type)'
+    Log    ${bytes}    formatter=type    console=True
+    ${nfd} =    Evaluate    'hyva\u0308'
+    Log    ${nfd}    formatter=type
+
 formatter=invalid
-    [Documentation]    FAIL ValueError: Invalid formatter 'invalid'. Available 'str', 'repr' and 'ascii'.
+    [Documentation]    FAIL ValueError: Invalid formatter 'invalid'. Available 'str', 'repr', 'ascii', 'len', and 'type'.
     Log    x    formatter=invalid
 
 Log callable

--- a/atest/testdata/standard_libraries/builtin/should_be_equal.robot
+++ b/atest/testdata/standard_libraries/builtin/should_be_equal.robot
@@ -253,7 +253,7 @@ formatter=repr/ascii with multiline and non-ASCII characters
     Å\nÄ\n\Ö\n    Å\nA\u0308\n\Ö\n    formatter=ascii
 
 Invalid formatter
-    [Documentation]    FAIL ValueError: Invalid formatter 'invalid'. Available 'str', 'repr' and 'ascii'.
+    [Documentation]    FAIL ValueError: Invalid formatter 'invalid'. Available 'str', 'repr', 'ascii', 'len', and 'type'.
     1    1    formatter=invalid
 
 Tuple and list with same items fail

--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -2847,10 +2847,10 @@ class _Misc(_BuiltInBase):
 
         The ``formatter`` argument controls how to format the string
         representation of the message. Possible values are ``str`` (default),
-        ``repr`` and ``ascii``, and they work similarly to Python built-in
-        functions with same names. When using ``repr``, bigger lists,
-        dictionaries and other containers are also pretty-printed so that
-        there is one item per row. For more details see `String
+        ``repr``, ``ascii``, ``len``, and ``type``. They work similarly to
+        Python built-in functions with same names. When using ``repr``, bigger
+        lists, dictionaries and other containers are also pretty-printed so
+        that there is one item per row. For more details see `String
         representations`.
 
         The old way to control string representation was using the ``repr``
@@ -2884,10 +2884,12 @@ class _Misc(_BuiltInBase):
         try:
             return {'str': unic,
                     'repr': prepr,
-                    'ascii': ascii}[formatter.lower()]
+                    'ascii': ascii,
+                    'len': len,
+                    'type': type}[formatter.lower()]
         except KeyError:
             raise ValueError("Invalid formatter '%s'. Available "
-                             "'str', 'repr' and 'ascii'." % formatter)
+                             "'str', 'repr', 'ascii', 'len', and 'type'." % formatter)
 
     @run_keyword_variant(resolve=0)
     def log_many(self, *messages):


### PR DESCRIPTION
Resolves #4095

- Adds the len (suggested) and type formatter options to _get_formatters used by Log.
- Acceptance tests added for each.
- Doc and error message modifications.

Made an attempt at the additional suggestion in #4095 to support any builtin but couldn't get it down. After looking at the [list of builtins](https://docs.python.org/3/library/functions.html) as well I am not confident that I am not opening some can of worms in the process there. :sweat_smile: