### PR TITLE
Resolves  #4074 Add timestamp attribute testsuite element in xunit output

### DIFF
--- a/atest/robot/output/xunit.robot
+++ b/atest/robot/output/xunit.robot
@@ -1,15 +1,21 @@
 *** Settings ***
 Documentation       Tests for xunit-compatible xml-output.
 Resource            atest_resource.robot
+Resource            rebot_resource.robot
 Variables           unicode_vars.py
-Suite Setup         Run Tests    -x xunit.xml -l log.html --skiponfailure täg    ${TESTDATA}
+Suite Setup         Run Keywords
+...    Create Output With Robot    ${OUT ONE}    ${EMPTY}    ${PASS AND FAIL}
+...    AND
+...    Create Output With Robot    ${OUT TWO}    ${EMPTY}    ${TESTDATA}
+...    AND
+...    Run Tests    -x xunit.xml -l log.html --skiponfailure täg    ${TESTDATA}
 
 *** Variables ***
 ${TESTDATA}         misc/non_ascii.robot
 ${PASS AND FAIL}    misc/pass_and_fail.robot
 ${INVALID}          %{TEMPDIR}${/}ïnvälïd-xünït.xml
-${MERGE ONE}        %{TEMPDIR}${/}merge1.xml
-${MERGE TWO}        %{TEMPDIR}${/}merge2.xml
+${OUT ONE}          %{TEMPDIR}${/}out1.xml
+${OUT TWO}          %{TEMPDIR}${/}out2.xml
 
 *** Test Cases ***
 XUnit File Is Created
@@ -78,17 +84,11 @@ Skipping non-critical tests is deprecated
     Stderr Should Contain   Command line option --xunitskipnoncritical has been deprecated and has no effect.
 
 Merge outputs
-    Run Tests Without Processing Output    --output ${MERGE ONE}    ${PASS AND FAIL}
-    Run Tests Without Processing Output    --output ${MERGE TWO}    ${TESTDATA}
-    Execute On Existing Execution Environment
-    ...    ${INTERPRETER.rebot}    --xUnit xunit.xml -l log.html    ${MERGE TWO} ${MERGE ONE}    ${COMMON DEFAULTS}
+    Run Rebot    -x xunit.xml -l log.html    ${OUT ONE} ${OUT TWO}
     Verify XUnit Timestamp    ${EMPTY}
 
 Rebot with start and end time
-    Run Tests    -l log.html    ${PASS AND FAIL}
-    Execute On Existing Execution Environment
-    ...    ${INTERPRETER.rebot}    -x xunit.xml -l log.html --starttime 20211215-12:11:10.456 --endtime 20211215-12:13:14.789
-    ...    ${OUTFILE}    ${COMMON DEFAULTS}
+    Run Rebot    -x xunit.xml -l log.html --starttime 20211215-12:11:10.456 --endtime 20211215-12:13:14.789    ${OUT ONE}
     Verify XUnit Timestamp    2021-12-15T12:11:10.456000
 
 *** Keywords ***
@@ -116,11 +116,3 @@ Verify XUnit Timestamp
     File Should Exist    ${OUTDIR}/xunit.xml
     ${suite} =    Get XUnit Node
     Element Attribute Should Match    ${suite}    timestamp    ${pattern}
-
-Execute On Existing Execution Environment
-    [Arguments]    ${executor}    ${options}    ${sources}    ${default options}=
-    @{arguments} =    Get Execution Arguments    ${options}    ${sources}    ${default options}
-    ${result} =    Run Process    @{executor}    @{arguments}
-    ...    stdout=${STDOUTFILE}    stderr=${STDERRFILE}    output_encoding=SYSTEM
-    ...    timeout=5min    on_timeout=terminate
-    [Return]    ${result}

--- a/src/robot/reporting/xunitwriter.py
+++ b/src/robot/reporting/xunitwriter.py
@@ -49,7 +49,8 @@ class XUnitFileWriter(ResultVisitor):
                  'errors': '0',
                  'failures': failures,
                  'skipped': skipped,
-                 'time': self._time_as_seconds(suite.elapsedtime)}
+                 'time': self._time_as_seconds(suite.elapsedtime),
+                 'timestamp' : self._starttime_to_isoformat(suite.starttime)}
         self._writer.start('testsuite', attrs)
 
     def _get_stats(self, statistics):
@@ -90,3 +91,8 @@ class XUnitFileWriter(ResultVisitor):
 
     def end_result(self, result):
         self._writer.close()
+
+    def _starttime_to_isoformat(self, stime):
+        if not stime:
+            return None
+        return f'{stime[:4]}-{stime[4:6]}-{stime[6:8]}T{stime[9:22]}000'


### PR DESCRIPTION
Resolves issue #4074 by adding the timestamp attribute to testsuite element in xunit output. The timestamp is generated from the testsuite ```starttime``` which seems to be procedure in other tools as well. Furthermore, strong assumption is done that RF starttime format is always ```YYYYMMDD hh:mm:ss.mil```. Starttime with empty string ```''``` or ```None``` yields xunit timestamp attribute to empty value as well: ```timestamp=""```.

Valid RF starttime yields e.g. ```2021-11-10T21:34:30.006000```  