### PR TITLE
 Resolves #2982 xUnit outputs: Add separate <testsuite> entries for each suite

### DIFF
--- a/atest/robot/output/xunit.robot
+++ b/atest/robot/output/xunit.robot
@@ -8,9 +8,8 @@ Suite Setup         Run Tests    -x xunit.xml -l log.html --skiponfailure täg  
 ${TESTDATA}         misc/non_ascii.robot
 ${PASS AND FAIL}    misc/pass_and_fail.robot
 ${INVALID}          %{TEMPDIR}${/}ïnvälïd-xünït.xml
-${OUT ONE}          %{TEMPDIR}${/}out1.xml
-${OUT TWO}          %{TEMPDIR}${/}out2.xml
-
+${NESTED}           misc/suites
+ 
 *** Test Cases ***
 XUnit File Is Created
     Stderr should be empty
@@ -72,6 +71,26 @@ Invalid XUnit File
 Skipping non-critical tests is deprecated
     Run tests    --xUnit xunit.xml --xUnitSkipNonCritical     ${PASS AND FAIL}
     Stderr Should Contain   Command line option --xunitskipnoncritical has been deprecated and has no effect.
+
+XUnit File From Nested Suites
+    Run Tests    -x xunit.xml -l log.html    ${TESTDATA} ${NESTED}
+    Stderr Should Be Empty
+    Stdout Should Contain    XUnit:
+    File Should Exist    ${OUTDIR}/xunit.xml
+    File Should Exist    ${OUTDIR}/log.html
+    ${root} =    Parse XML    ${OUTDIR}/xunit.xml
+    Should Be Equal    ${root.tag}    testsuite
+    ${suites} =    Get Elements    ${root}    testsuite
+    Length Should Be    ${suites}    2
+    ${tests} =    Get Elements    ${suites}[0]    testcase
+    Length Should Be    ${tests}    8
+    Element Attribute Should be    ${tests}[7]    name    Ñöñ-ÄŚÇÏÏ Tëśt äņd Këywörd Nämës, Спасибо
+    ${failures} =    Get Elements    ${suites}[0]    testcase/failure
+    Length Should Be    ${failures}    4
+    Element Attribute Should be    ${failures}[0]    message    ${MESSAGES}
+    ${nested suite} =    Get Element    ${OUTDIR}/xunit.xml    xpath=testsuite[2]
+    Element Attribute Should Be       ${nested suite}    tests       11
+    Element Attribute Should Be       ${nested suite}    failures    1
 
 *** Keywords ***
 Get XUnit Node

--- a/atest/robot/rebot/xunit.robot
+++ b/atest/robot/rebot/xunit.robot
@@ -22,21 +22,40 @@ XUnit Option Given
     Stdout Should Contain    XUnit:
     File Should Exist    ${OUTDIR}/xunit.xml
     File Should Exist    ${OUTDIR}/log.html
-    Suite Stats Should Be    19    5
     ${root} =    Parse XML    ${OUTDIR}/xunit.xml
     Should Be Equal    ${root.tag}    testsuite
-    ${tests} =    Get Elements    ${root}    testcase
-    Length Should Be    ${tests}    19
+    ${suites} =    Get Elements    ${root}    testsuite
+    Length Should Be    ${suites}    2
+    ${tests} =    Get Elements    ${suites}[0]    testcase
+    Length Should Be    ${tests}    8
     Element Attribute Should be    ${tests}[7]    name    Ñöñ-ÄŚÇÏÏ Tëśt äņd Këywörd Nämës, Спасибо
-    ${failures} =    Get Elements    ${root}    testcase/failure
-    Length Should Be    ${failures}    5
+    ${failures} =    Get Elements    ${suites}[0]    testcase/failure
+    Length Should Be    ${failures}    4
     Element Attribute Should be    ${failures}[0]    message    ${MESSAGES}
 
+Suite Stats
+    [Template]    Suite Stats Should Be
+    19    5
+    8     4    xpath=testsuite[1]
+    11    1    xpath=testsuite[2]
+    1     1    xpath=testsuite[2]/testsuite[1]
+    2     0    xpath=testsuite[2]/testsuite[2]
+    1     0    xpath=testsuite[2]/testsuite[2]/testsuite[1]
+    1     0    xpath=testsuite[2]/testsuite[2]/testsuite[2]
+    3     0    xpath=testsuite[2]/testsuite[3]
+    1     0    xpath=testsuite[2]/testsuite[3]/testsuite[1]
+    2     0    xpath=testsuite[2]/testsuite[3]/testsuite[2]
+    3     0    xpath=testsuite[2]/testsuite[4]
+    1     0    xpath=testsuite[2]/testsuite[5]
+    1     0    xpath=testsuite[2]/testsuite[6]
+
 Times in xUnit output
-    Previous Test Should Have Passed    XUnit Option Given
+    Previous Test Should Have Passed    Suite Stats
     ${suite} =    Parse XML    ${OUTDIR}/xunit.xml
     Element Attribute Should Match    ${suite}    time    ?.???
-    Element Attribute Should Match    ${suite}    time    ?.???    xpath=.//testcase[1]
+    Element Attribute Should Match    ${suite}    time    ?.???    xpath=testsuite[1]
+    Element Attribute Should Match    ${suite}    time    ?.???    xpath=testsuite[1]/testcase[1]
+    Element Attribute Should Match    ${suite}    time    ?.???    xpath=testsuite[2]/testsuite[1]/testcase[1]
 
 XUnit skip non-criticals is deprecated
     Run Rebot    --xUnit xunit.xml --xUnitSkipNonCritical     ${INPUT FILE}
@@ -69,8 +88,10 @@ Remove Temps
     Remove File    ${INPUT FILE}
 
 Suite Stats Should Be
-    [Arguments]    ${tests}    ${failures}    ${skipped}=0    ${time}=?.???    ${timestamp}=20??-??-??T??:??:??.???000
-    ${suite} =    Get Element    ${OUTDIR}/xunit.xml
+    [Arguments]    ${tests}    ${failures}    ${skipped}=0
+    ...    ${time}=?.???    ${timestamp}=20??-??-??T??:??:??.???000
+    ...    ${xpath}=.
+    ${suite} =    Get Element    ${OUTDIR}/xunit.xml    xpath=${xpath}
     Element Attribute Should Be       ${suite}    tests       ${tests}
     Element Attribute Should Be       ${suite}    failures    ${failures}
     Element Attribute Should Be       ${suite}    skipped     ${skipped}

--- a/src/robot/reporting/xunitwriter.py
+++ b/src/robot/reporting/xunitwriter.py
@@ -37,12 +37,8 @@ class XUnitFileWriter(ResultVisitor):
 
     def __init__(self, xml_writer):
         self._writer = xml_writer
-        self._root_suite = None
 
     def start_suite(self, suite):
-        if self._root_suite:
-            return
-        self._root_suite = suite
         tests, failures, skipped = self._get_stats(suite.statistics)
         attrs = {'name': suite.name,
                  'tests': tests,
@@ -61,8 +57,7 @@ class XUnitFileWriter(ResultVisitor):
         )
 
     def end_suite(self, suite):
-        if suite is self._root_suite:
-            self._writer.end('testsuite')
+        self._writer.end('testsuite')
 
     def visit_test(self, test):
         self._writer.start('testcase',


### PR DESCRIPTION
Introduces xunit output with separate <testsuite> element for each of suite. Allows nested suites targeting to design topics mentioned in #2982. 