### PR TITLE
fixes #4195: wrong node was expanded in case of ELSE-IF or TRY-EXCEPT branches

### DIFF
--- a/src/robot/model/body.py
+++ b/src/robot/model/body.py
@@ -56,10 +56,22 @@ class BodyItem(ModelObject):
             return 'k1'
         setup = getattr(self.parent, 'setup', None)
         body = getattr(self.parent, 'body', ())
-        teardown = getattr(self.parent, 'teardown', None)
-        steps = [step for step in [setup] + list(body) + [teardown]
+        flatbodylist = self.flatten(list(body))
+        teardown = getattr(self.parent, 'teardown', None)        
+        steps = [step for step in [setup] + flatbodylist + [teardown]
                  if step and step.type != step.MESSAGE]
         return '%s-k%d' % (self.parent.id, steps.index(self) + 1)
+    
+    @classmethod
+    def flatten(cls, steps):
+        result = []
+        for step in steps:
+            if step.type in (cls.IF_ELSE_ROOT, cls.TRY_EXCEPT_ROOT):
+                result.extend(step.body)
+            else:
+                result.append(step)
+        return result
+        
 
 
 class BaseBody(ItemList):

--- a/src/robot/reporting/jsmodelbuilders.py
+++ b/src/robot/reporting/jsmodelbuilders.py
@@ -73,20 +73,11 @@ class _Builder:
     def _build_keywords(self, steps, split=False):
         splitting = self._context.start_splitting_if_needed(split)
         # tuple([<listcomp>>]) is faster than tuple(<genex>) with short lists.
-        model = tuple([self._build_keyword(step) for step in self._flatten(steps)])
+        model = tuple([self._build_keyword(step) for step in BodyItem.flatten(steps)])
         return model if not splitting else self._context.end_splitting(model)
 
     def _build_keyword(self, step):
         raise NotImplementedError
-
-    def _flatten(self, steps):
-        result = []
-        for step in steps:
-            if step.type in (BodyItem.IF_ELSE_ROOT, BodyItem.TRY_EXCEPT_ROOT):
-                result.extend(step.body)
-            else:
-                result.append(step)
-        return result
 
 
 class SuiteBuilder(_Builder):


### PR DESCRIPTION
Just root-if node was counted when generating id. All sub-nodes of IF-root was ignored. I moved the flatten method from _Builder to BodyItem in order to apply flatten here, too. Now for computation of keyword position the correct amount of body-steps is used.

This should also solve similar problems with TRY-EXCEPT branches.