### PR TITLE
alternative way to parse EXCEPT AS fixes #4208

### DIFF
--- a/src/robot/parsing/lexer/statementlexers.py
+++ b/src/robot/parsing/lexer/statementlexers.py
@@ -226,12 +226,14 @@ class ExceptHeaderLexer(StatementLexer):
     def lex(self):
         self.statement[0].type = Token.EXCEPT
         as_seen = False
+        variable_seen = False
         for token in self.statement[1:]:
-            if token.value == 'AS':
+            if not as_seen and token.value == 'AS':
                 token.type = Token.AS
-                as_seen = True
-            elif as_seen:
+                as_seen = True                
+            elif as_seen and not variable_seen:                
                 token.type = Token.VARIABLE
+                variable_seen = True
             else:
                 token.type = Token.ARGUMENT
 

--- a/src/robot/parsing/model/statements.py
+++ b/src/robot/parsing/model/statements.py
@@ -946,12 +946,16 @@ class ExceptHeader(Statement):
 
     def validate(self):
         as_token = self.get_token(Token.AS)
-        if as_token:
-            if as_token is not self.tokens[-2]:
-                self.errors += ("EXCEPT's AS marker must be second to last.",)
-            var = self.tokens[-1].value
-            if not is_scalar_assign(var):
-                self.errors += (f"EXCEPT's AS variable '{var}' is invalid.",)
+        if as_token:                
+            var = self.get_token(Token.VARIABLE)
+            
+            if var is None:
+                self.errors += ("EXCEPT's AS expects a variable.",)
+            elif not is_scalar_assign(var.value):
+                self.errors += (f"EXCEPT's AS variable '{var.value}' is invalid.",)
+            
+            if var and next((v for v in self.tokens[self.tokens.index(var) + 1:] if v.type not in Token.NON_DATA_TOKENS), None):
+                self.errors += (f"EXCEPT's AS can only have one variable.",)
 
 
 @Statement.register


### PR DESCRIPTION
This is an alternative way to parse EXCEPT AS that does not validate the AS with indexes.

The ExceptHeaderLexer only lexes on "AS" token and one Variable token, and the rest are arguments.
This makes validating the ExceptHeader somewhat easier, because we only need to check for the AS and the Variable, and if there are other token after the variable.

If this is OK for you, I can provide/correct the testcases for that.