### PR TITLE
fix  #4214: just expand passed keywords 

### DIFF
--- a/src/robot/reporting/jsbuildingcontext.py
+++ b/src/robot/reporting/jsbuildingcontext.py
@@ -73,7 +73,8 @@ class JsBuildingContext:
 
     def check_expansion(self, kw):
         if self._expand_matcher is not None:
-            self._expand_matcher.match(kw)
+            if kw.passed:
+                self._expand_matcher.match(kw)
 
     @property
     def expand_keywords(self):


### PR DESCRIPTION
- do not expand skipped/NotRun to avoid browser crash on large logs
- failed kws expanded per default, thus no need to handle failed kws in --expandkeyword logic