### PR TITLE
Add SETTINGS dictionary to automatic variables to expose command line options (Issue #4229)

### DIFF
--- a/atest/robot/standard_libraries/builtin/log_variables.robot
+++ b/atest/robot/standard_libraries/builtin/log_variables.robot
@@ -22,6 +22,7 @@ Log Variables In Suite Setup
     Check Variable Message    \${LOG_LEVEL} = INFO
     Check Variable Message    \${None} = None
     Check Variable Message    \${null} = None
+    Check Variable Message    \&{OPTIONS} = { exclude=[] | include=[] | skip=[] }
     Check Variable Message    \${OUTPUT_DIR} = *    pattern=yes
     Check Variable Message    \${OUTPUT_FILE} = *    pattern=yes
     Check Variable Message    \${PREV_TEST_MESSAGE} =
@@ -29,7 +30,6 @@ Log Variables In Suite Setup
     Check Variable Message    \${PREV_TEST_STATUS} =
     Check Variable Message    \${REPORT_FILE} = NONE
     Check Variable Message    \${SCALAR} = Hi tellus
-    Check Variable Message    \&{SETTINGS} = { EXCLUDE_TAGS=[] | INCLUDE_TAGS=[] }
     Check Variable Message    \${SPACE} =
     Check Variable Message    \${SUITE_DOCUMENTATION} =
     Check Variable Message    \&{SUITE_METADATA} = { }
@@ -63,6 +63,7 @@ Log Variables In Test
     Check Variable Message    \${LOG_LEVEL} = TRACE
     Check Variable Message    \${None} = None
     Check Variable Message    \${null} = None
+    Check Variable Message    \&{OPTIONS} = { exclude=[] | include=[] | skip=[] }
     Check Variable Message    \${OUTPUT_DIR} = *    pattern=yes
     Check Variable Message    \${OUTPUT_FILE} = *    pattern=yes
     Check Variable Message    \${PREV_TEST_MESSAGE} =
@@ -70,7 +71,6 @@ Log Variables In Test
     Check Variable Message    \${PREV_TEST_STATUS} = PASS
     Check Variable Message    \${REPORT_FILE} = NONE
     Check Variable Message    \${SCALAR} = Hi tellus
-    Check Variable Message    \&{SETTINGS} = { EXCLUDE_TAGS=[] | INCLUDE_TAGS=[] }
     Check Variable Message    \${SPACE} =
     Check Variable Message    \${SUITE_DOCUMENTATION} =
     Check Variable Message    \&{SUITE_METADATA} = { }
@@ -108,6 +108,7 @@ Log Variables After Setting New Variables
     Check Variable Message    \${LOG_LEVEL} = TRACE    DEBUG
     Check Variable Message    \${None} = None    DEBUG
     Check Variable Message    \${null} = None    DEBUG
+    Check Variable Message    \&{OPTIONS} = { exclude=[] | include=[] | skip=[] }    DEBUG
     Check Variable Message    \${OUTPUT_DIR} = *    DEBUG    pattern=yes
     Check Variable Message    \${OUTPUT_FILE} = *    DEBUG    pattern=yes
     Check Variable Message    \${PREV_TEST_MESSAGE} =    DEBUG
@@ -115,7 +116,6 @@ Log Variables After Setting New Variables
     Check Variable Message    \${PREV_TEST_STATUS} = PASS    DEBUG
     Check Variable Message    \${REPORT_FILE} = NONE    DEBUG
     Check Variable Message    \${SCALAR} = Hi tellus    DEBUG
-    Check Variable Message    \&{SETTINGS} = { EXCLUDE_TAGS=[] | INCLUDE_TAGS=[] }    DEBUG
     Check Variable Message    \${SPACE} =    DEBUG
     Check Variable Message    \${SUITE_DOCUMENTATION} =    DEBUG
     Check Variable Message    \&{SUITE_METADATA} = { }    DEBUG
@@ -152,6 +152,7 @@ Log Variables In User Keyword
     Check Variable Message    \${LOG_LEVEL} = TRACE
     Check Variable Message    \${None} = None
     Check Variable Message    \${null} = None
+    Check Variable Message    \&{OPTIONS} = { exclude=[] | include=[] | skip=[] }
     Check Variable Message    \${OUTPUT_DIR} = *    pattern=yes
     Check Variable Message    \${OUTPUT_FILE} = *    pattern=yes
     Check Variable Message    \${PREV_TEST_MESSAGE} =
@@ -159,7 +160,6 @@ Log Variables In User Keyword
     Check Variable Message    \${PREV_TEST_STATUS} = PASS
     Check Variable Message    \${REPORT_FILE} = NONE
     Check Variable Message    \${SCALAR} = Hi tellus
-    Check Variable Message    \&{SETTINGS} = { EXCLUDE_TAGS=[] | INCLUDE_TAGS=[] }
     Check Variable Message    \${SPACE} =
     Check Variable Message    \${SUITE_DOCUMENTATION} =
     Check Variable Message    \&{SUITE_METADATA} = { }

--- a/atest/robot/standard_libraries/builtin/log_variables.robot
+++ b/atest/robot/standard_libraries/builtin/log_variables.robot
@@ -29,6 +29,7 @@ Log Variables In Suite Setup
     Check Variable Message    \${PREV_TEST_STATUS} =
     Check Variable Message    \${REPORT_FILE} = NONE
     Check Variable Message    \${SCALAR} = Hi tellus
+    Check Variable Message    \&{SETTINGS} = { EXCLUDE_TAGS=[] | INCLUDE_TAGS=[] }
     Check Variable Message    \${SPACE} =
     Check Variable Message    \${SUITE_DOCUMENTATION} =
     Check Variable Message    \&{SUITE_METADATA} = { }
@@ -41,7 +42,7 @@ Log Variables In Suite Setup
     Check Variable Message    \${SUITE_SOURCE} = *    pattern=yes
     Check Variable Message    \${TEMPDIR} = *    pattern=yes
     Check Variable Message    \${True} = *    pattern=yes
-    Should Be Equal As Integers    ${kw.message_count}    34    Wrong total message count
+    Should Be Equal As Integers    ${kw.message_count}    35    Wrong total message count
 
 Log Variables In Test
     ${test} =    Check Test Case    Log Variables
@@ -69,6 +70,7 @@ Log Variables In Test
     Check Variable Message    \${PREV_TEST_STATUS} = PASS
     Check Variable Message    \${REPORT_FILE} = NONE
     Check Variable Message    \${SCALAR} = Hi tellus
+    Check Variable Message    \&{SETTINGS} = { EXCLUDE_TAGS=[] | INCLUDE_TAGS=[] }
     Check Variable Message    \${SPACE} =
     Check Variable Message    \${SUITE_DOCUMENTATION} =
     Check Variable Message    \&{SUITE_METADATA} = { }
@@ -83,7 +85,7 @@ Log Variables In Test
     Check Variable Message    \${TEST_NAME} = Log Variables
     Check Variable Message    \@{TEST_TAGS} = [ ]
     Check Variable Message    \${True} = *    pattern=yes
-    Should Be Equal As Integers    ${kw.message_count}    38    Wrong total message count
+    Should Be Equal As Integers    ${kw.message_count}    39    Wrong total message count
 
 Log Variables After Setting New Variables
     ${test} =    Check Test Case    Log Variables
@@ -113,6 +115,7 @@ Log Variables After Setting New Variables
     Check Variable Message    \${PREV_TEST_STATUS} = PASS    DEBUG
     Check Variable Message    \${REPORT_FILE} = NONE    DEBUG
     Check Variable Message    \${SCALAR} = Hi tellus    DEBUG
+    Check Variable Message    \&{SETTINGS} = { EXCLUDE_TAGS=[] | INCLUDE_TAGS=[] }    DEBUG
     Check Variable Message    \${SPACE} =    DEBUG
     Check Variable Message    \${SUITE_DOCUMENTATION} =    DEBUG
     Check Variable Message    \&{SUITE_METADATA} = { }    DEBUG
@@ -128,7 +131,7 @@ Log Variables After Setting New Variables
     Check Variable Message    \@{TEST_TAGS} = [ ]    DEBUG
     Check Variable Message    \${True} = *    DEBUG    pattern=yes
     Check Variable Message    \${var} = Hello    DEBUG
-    Should Be Equal As Integers    ${kw.message_count}    41    Wrong total message count
+    Should Be Equal As Integers    ${kw.message_count}    42    Wrong total message count
 
 Log Variables In User Keyword
     ${test} =    Check Test Case    Log Variables
@@ -156,6 +159,7 @@ Log Variables In User Keyword
     Check Variable Message    \${PREV_TEST_STATUS} = PASS
     Check Variable Message    \${REPORT_FILE} = NONE
     Check Variable Message    \${SCALAR} = Hi tellus
+    Check Variable Message    \&{SETTINGS} = { EXCLUDE_TAGS=[] | INCLUDE_TAGS=[] }
     Check Variable Message    \${SPACE} =
     Check Variable Message    \${SUITE_DOCUMENTATION} =
     Check Variable Message    \&{SUITE_METADATA} = { }
@@ -171,7 +175,7 @@ Log Variables In User Keyword
     Check Variable Message    \@{TEST_TAGS} = [ ]
     Check Variable Message    \${True} = *    pattern=yes
     Check Variable Message    \${ukvar} = Value of an uk variable
-    Should Be Equal As Integers    ${kw.message_count}    39    Wrong total message count
+    Should Be Equal As Integers    ${kw.message_count}    40    Wrong total message count
 
 List and dict variables failing during iteration
     Check Test Case    ${TEST NAME}

--- a/atest/robot/standard_libraries/builtin/log_variables.robot
+++ b/atest/robot/standard_libraries/builtin/log_variables.robot
@@ -22,7 +22,7 @@ Log Variables In Suite Setup
     Check Variable Message    \${LOG_LEVEL} = INFO
     Check Variable Message    \${None} = None
     Check Variable Message    \${null} = None
-    Check Variable Message    \&{OPTIONS} = { exclude=[] | include=[] | skip=[] }
+    Check Variable Message    \&{OPTIONS} = { exclude=[] | include=[] | skip=[] | skiponfailure=[] }
     Check Variable Message    \${OUTPUT_DIR} = *    pattern=yes
     Check Variable Message    \${OUTPUT_FILE} = *    pattern=yes
     Check Variable Message    \${PREV_TEST_MESSAGE} =
@@ -63,7 +63,7 @@ Log Variables In Test
     Check Variable Message    \${LOG_LEVEL} = TRACE
     Check Variable Message    \${None} = None
     Check Variable Message    \${null} = None
-    Check Variable Message    \&{OPTIONS} = { exclude=[] | include=[] | skip=[] }
+    Check Variable Message    \&{OPTIONS} = { exclude=[] | include=[] | skip=[] | skiponfailure=[] }
     Check Variable Message    \${OUTPUT_DIR} = *    pattern=yes
     Check Variable Message    \${OUTPUT_FILE} = *    pattern=yes
     Check Variable Message    \${PREV_TEST_MESSAGE} =
@@ -108,7 +108,7 @@ Log Variables After Setting New Variables
     Check Variable Message    \${LOG_LEVEL} = TRACE    DEBUG
     Check Variable Message    \${None} = None    DEBUG
     Check Variable Message    \${null} = None    DEBUG
-    Check Variable Message    \&{OPTIONS} = { exclude=[] | include=[] | skip=[] }    DEBUG
+    Check Variable Message    \&{OPTIONS} = { exclude=[] | include=[] | skip=[] | skiponfailure=[] }    DEBUG
     Check Variable Message    \${OUTPUT_DIR} = *    DEBUG    pattern=yes
     Check Variable Message    \${OUTPUT_FILE} = *    DEBUG    pattern=yes
     Check Variable Message    \${PREV_TEST_MESSAGE} =    DEBUG
@@ -152,7 +152,7 @@ Log Variables In User Keyword
     Check Variable Message    \${LOG_LEVEL} = TRACE
     Check Variable Message    \${None} = None
     Check Variable Message    \${null} = None
-    Check Variable Message    \&{OPTIONS} = { exclude=[] | include=[] | skip=[] }
+    Check Variable Message    \&{OPTIONS} = { exclude=[] | include=[] | skip=[] | skiponfailure=[] }
     Check Variable Message    \${OUTPUT_DIR} = *    pattern=yes
     Check Variable Message    \${OUTPUT_FILE} = *    pattern=yes
     Check Variable Message    \${PREV_TEST_MESSAGE} =

--- a/atest/robot/variables/automatic_variables.robot
+++ b/atest/robot/variables/automatic_variables.robot
@@ -1,5 +1,7 @@
 *** Setting ***
-Suite Setup       Run Tests    --exclude exclude_this_test --include include_this_test   variables/automatic_variables/
+Suite Setup       Run Tests    
+...               --exclude exclude_this_test --include include_this_test --skip skip_me --skiponfailure me_too
+...               variables/automatic_variables/
 Resource          atest_resource.robot
 
 *** Test Case ***

--- a/atest/robot/variables/automatic_variables.robot
+++ b/atest/robot/variables/automatic_variables.robot
@@ -1,5 +1,5 @@
 *** Setting ***
-Suite Setup       Run Tests    ${EMPTY}    variables/automatic_variables/
+Suite Setup       Run Tests    --exclude exclude_this_test --include include_this_test   variables/automatic_variables/
 Resource          atest_resource.robot
 
 *** Test Case ***
@@ -14,10 +14,10 @@ Test Documentation
     Should Be Equal    ${tc.doc}    My doc.\nIn 2 lines! And with variable value!!
 
 Test Tags
-    Check Test Tags    ${TEST NAME}    Force 1    Hello, world!    id-42    variable value
+    Check Test Tags    ${TEST NAME}    Force 1    Hello, world!    id-42    include this test    variable value
 
 Modifying \${TEST TAGS} does not affect actual tags test has
-    Check Test Tags    ${TEST NAME}    Force 1    mytag
+    Check Test Tags    ${TEST NAME}    Force 1    mytag    include this test
 
 Suite Name
     Check Test Case    ${TEST NAME}

--- a/atest/testdata/variables/automatic_variables/auto1.robot
+++ b/atest/testdata/variables/automatic_variables/auto1.robot
@@ -6,7 +6,7 @@ Suite Setup       Check Variables In Suite Setup    ${EXP_SUITE_NAME}
 ...               ${EXP_SUITE_DOC}    ${EXP_SUITE_META}
 Suite Teardown    Check Variables In Suite Teardown    ${EXP_SUITE_NAME}
 ...               FAIL    ${EXP_SUITE_STATS}    @{LAST_TEST}
-Force Tags        Force 1
+Force Tags        Force 1    include this test
 Resource          resource.robot
 Library           Collections
 Library           HelperLib.py    ${SUITE SOURCE}    ${SUITE NAME}
@@ -17,7 +17,7 @@ ${VARIABLE}          variable value
 ${EXP_SUITE_NAME}    Automatic Variables.Auto1
 ${EXP_SUITE_DOC}     This is suite documentation. With ${VARIABLE}.
 ${EXP_SUITE_META}    {'MeTa1': 'Value', 'meta2': '${VARIABLE}'}
-${EXP_SUITE_STATS}   16 tests, 14 passed, 2 failed
+${EXP_SUITE_STATS}   18 tests, 16 passed, 2 failed
 @{LAST_TEST}         Previous Test Variables Should Have Correct Values When That Test Fails    PASS
 
 *** Test Case ***
@@ -38,15 +38,21 @@ Test Documentation
 
 Test Tags
     [Tags]    id-${42}    Hello, world!    ${VARIABLE}
-    [Setup]    Check Test Tags    Force 1    Hello, world!    id-42    ${VARIABLE}
-    Check Test Tags    Force 1    Hello, world!    id-42    ${VARIABLE}
-    [Teardown]    Check Test Tags    Force 1    Hello, world!    id-42    ${VARIABLE}
+    [Setup]    Check Test Tags    Force 1    Hello, world!    id-42    include this test    ${VARIABLE}
+    Check Test Tags    Force 1    Hello, world!    id-42    include this test    ${VARIABLE}
+    [Teardown]    Check Test Tags    Force 1    Hello, world!    id-42    include this test    ${VARIABLE}
 
 Modifying ${TEST TAGS} does not affect actual tags test has
     [Documentation]    The variable is changed but not "real" tags
     [Tags]    mytag
     Append To List    ${TEST TAGS}    not really added
-    Check Test Tags    Force 1    mytag    not really added
+    Check Test Tags    Force 1    include this test    mytag    not really added
+
+Include-tags Available As Automatic Variables
+    Should Contain    ${SETTINGS.INCLUDE_TAGS}    include this test
+
+Exclude-tags Available As Automatic Variables
+    Should Contain    ${SETTINGS.EXCLUDE_TAGS}    exclude this test
 
 Suite Name
     Should Be Equal    ${SUITE_NAME}    ${EXP_SUITE_NAME}
@@ -106,3 +112,7 @@ Previous Test Variables Should Have Correct Values When That Test Fails
     [Setup]    Check Previous Test variables    Test Status When Setup Fails    FAIL    Setup failed:\nExpected failure in setup
     Check Previous Test variables    Test Status When Setup Fails    FAIL    Setup failed:\nExpected failure in setup
     [Teardown]    Check Previous Test variables    Test Status When Setup Fails    FAIL    Setup failed:\nExpected failure in setup
+
+This Test Should Be Excluded
+    [Tags]    exclude this test
+    Fail    Should not be executed

--- a/atest/testdata/variables/automatic_variables/auto1.robot
+++ b/atest/testdata/variables/automatic_variables/auto1.robot
@@ -17,7 +17,7 @@ ${VARIABLE}          variable value
 ${EXP_SUITE_NAME}    Automatic Variables.Auto1
 ${EXP_SUITE_DOC}     This is suite documentation. With ${VARIABLE}.
 ${EXP_SUITE_META}    {'MeTa1': 'Value', 'meta2': '${VARIABLE}'}
-${EXP_SUITE_STATS}   18 tests, 16 passed, 2 failed
+${EXP_SUITE_STATS}   19 tests, 17 passed, 2 failed
 @{LAST_TEST}         Previous Test Variables Should Have Correct Values When That Test Fails    PASS
 
 *** Test Case ***
@@ -49,10 +49,14 @@ Modifying ${TEST TAGS} does not affect actual tags test has
     Check Test Tags    Force 1    include this test    mytag    not really added
 
 Include-tags Available As Automatic Variables
-    Should Contain    ${SETTINGS.INCLUDE_TAGS}    include this test
+    Should Contain    ${OPTIONS.include}    include this test
 
 Exclude-tags Available As Automatic Variables
-    Should Contain    ${SETTINGS.EXCLUDE_TAGS}    exclude this test
+    Should Contain    ${OPTIONS.exclude}    exclude this test
+
+Skip-tags Available As Automatic Variables
+    Should Contain    ${OPTIONS.skip}    Skip_Me
+    Should Contain    ${OPTIONS.skiponfailure}    me_too
 
 Suite Name
     Should Be Equal    ${SUITE_NAME}    ${EXP_SUITE_NAME}

--- a/atest/testdata/variables/automatic_variables/auto2.robot
+++ b/atest/testdata/variables/automatic_variables/auto2.robot
@@ -4,6 +4,7 @@ Suite Setup       Check Variables In Suite Setup    Automatic Variables.Auto2
 Suite Teardown    Check Variables In Suite Teardown    Automatic Variables.Auto2    FAIL
 ...               1 test, 0 passed, 1 failed
 ...               @{LAST_TEST}
+Force Tags        include this test
 Resource          resource.robot
 
 *** Variable ***

--- a/doc/userguide/src/CreatingTestData/Variables.rst
+++ b/doc/userguide/src/CreatingTestData/Variables.rst
@@ -1007,12 +1007,14 @@ can be changed dynamically using keywords from the `BuiltIn`_ library.
    +------------------------+-------------------------------------------------------+------------+
    | ${PREV TEST MESSAGE}   | The possible error message of the previous test case. | Everywhere |
    +------------------------+-------------------------------------------------------+------------+
-   | ${SETTINGS}            | A dictionary exposing some command line options used  | Everywhere |
-   |                        | for running the current test:                         |            |
-   |                        | - EXCLUDE_TAGS                                        |            |
-   |                        |   A list of tags provided by the -exclude (-e) option |            |
-   |                        | - INCLUDE_TAGS                                        |            |
-   |                        |   A list of tags provided by the -include (-i) option |            |
+   | ${OPTIONS}             | A dictionary exposing command line options used for   | Everywhere |
+   |                        | running the current test. The dictionary keys are     |            |
+   |                        | matching the command line options. New in RF 5.0.     |            |
+   |                        | Currently available:                                  |            |
+   |                        | - :option:`--exclude` `${OPTIONS.exclude}`            |            |
+   |                        | - :option:`--include` `${OPTIONS.include}`            |            |
+   |                        | - :option:`--skip` `${OPTIONS.skip}`                  |            |
+   |                        | - :option:`--skiponfailure` `${OPTIONS.skiponfailure}`|            |
    +------------------------+-------------------------------------------------------+------------+
    | ${SUITE NAME}          | The full name of the current test suite.              | Everywhere |
    +------------------------+-------------------------------------------------------+------------+

--- a/doc/userguide/src/CreatingTestData/Variables.rst
+++ b/doc/userguide/src/CreatingTestData/Variables.rst
@@ -1007,6 +1007,13 @@ can be changed dynamically using keywords from the `BuiltIn`_ library.
    +------------------------+-------------------------------------------------------+------------+
    | ${PREV TEST MESSAGE}   | The possible error message of the previous test case. | Everywhere |
    +------------------------+-------------------------------------------------------+------------+
+   | ${SETTINGS}            | A dictionary exposing some command line options used  | Everywhere |
+   |                        | for running the current test:                         |            |
+   |                        | - EXCLUDE_TAGS                                        |            |
+   |                        |   A list of tags provided by the -exclude (-e) option |            |
+   |                        | - INCLUDE_TAGS                                        |            |
+   |                        |   A list of tags provided by the -include (-i) option |            |
+   +------------------------+-------------------------------------------------------+------------+
    | ${SUITE NAME}          | The full name of the current test suite.              | Everywhere |
    +------------------------+-------------------------------------------------------+------------+
    | ${SUITE SOURCE}        | An absolute path to the suite file or directory.      | Everywhere |

--- a/src/robot/variables/scopes.py
+++ b/src/robot/variables/scopes.py
@@ -185,6 +185,8 @@ class GlobalVariables(Variables):
     def _set_built_in_variables(self, settings):
         for name, value in [('${TEMPDIR}', abspath(tempfile.gettempdir())),
                             ('${EXECDIR}', abspath('.')),
+                            ('&{SETTINGS}',    {"EXCLUDE_TAGS": settings.suite_config['exclude_tags'], 
+                                                "INCLUDE_TAGS": settings.suite_config['include_tags']}),
                             ('${/}', os.sep),
                             ('${:}', os.pathsep),
                             ('${\\n}', os.linesep),

--- a/src/robot/variables/scopes.py
+++ b/src/robot/variables/scopes.py
@@ -19,6 +19,7 @@ import tempfile
 from robot.errors import DataError
 from robot.output import LOGGER
 from robot.utils import abspath, find_file, get_error_details, NormalizedDict
+from robot.model import Tags
 
 from .variables import Variables
 
@@ -185,8 +186,10 @@ class GlobalVariables(Variables):
     def _set_built_in_variables(self, settings):
         for name, value in [('${TEMPDIR}', abspath(tempfile.gettempdir())),
                             ('${EXECDIR}', abspath('.')),
-                            ('&{SETTINGS}',    {"EXCLUDE_TAGS": settings.suite_config['exclude_tags'], 
-                                                "INCLUDE_TAGS": settings.suite_config['include_tags']}),
+                            ('&{OPTIONS}',      {"exclude": Tags(settings.suite_config['exclude_tags']), 
+                                                 "include": Tags(settings.suite_config['include_tags']),
+                                                 "skip": Tags(settings.skipped_tags),
+                                                 "skiponfailure": Tags(settings.skip_on_failure)}),
                             ('${/}', os.sep),
                             ('${:}', os.pathsep),
                             ('${\\n}', os.linesep),


### PR DESCRIPTION
This PR adds a new disctionary "SETTINGS" to the automatic variables to expose exclude and include tags command line options (for now).

Based on previous discussions in #4052 