### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,9 @@ setup(
     author       = 'Pekka Kl\xe4rck',
     author_email = 'peke@eliga.fi',
     url          = 'https://robotframework.org/',
+    project_urls = {
+        'Source': 'https://github.com/robotframework/robotframework',
+    },
     download_url = 'https://pypi.org/project/robotframework/',
     license      = 'Apache License 2.0',
     description  = DESCRIPTION,


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)