### PR TITLE
Modals for type definitions to docs

### DIFF
--- a/src/robot/htmldata/libdoc/libdoc.css
+++ b/src/robot/htmldata/libdoc/libdoc.css
@@ -714,6 +714,9 @@ span.or {
     z-index: 2;
     transition-delay: 0.1s;
 }
+.modal-content {
+    margin-bottom: 3rem;
+}
 .modal > .modal-content > .data-type-container {
     border-top: none;
 }

--- a/src/robot/htmldata/libdoc/libdoc.css
+++ b/src/robot/htmldata/libdoc/libdoc.css
@@ -734,3 +734,6 @@ span.or {
     opacity: 1;
     pointer-events: all;
 }
+#data-types-container {
+    display: none;
+}

--- a/src/robot/htmldata/libdoc/libdoc.css
+++ b/src/robot/htmldata/libdoc/libdoc.css
@@ -701,6 +701,9 @@ span.or {
     z-index: 1;
 }
 .modal {
+    display: flex;
+    flex-wrap: nowrap;
+    flex-direction: column;
     width: 720px;
     max-width: calc(100vw - 2rem);
     margin: 3rem auto;
@@ -710,6 +713,19 @@ span.or {
     border: 1px solid var(--border-color);
     z-index: 2;
     transition-delay: 0.1s;
+}
+.modal > .modal-content > .data-type-container {
+    border-top: none;
+}
+.modal-close-button-wrapper {
+    display: flex;
+    justify-content: flex-end;
+}
+.modal-close-button {
+    margin: 0.5rem;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--border-color);
+    cursor: pointer;
 }
 .modal-background.visible, .modal.visible {
     opacity: 1;

--- a/src/robot/htmldata/libdoc/libdoc.css
+++ b/src/robot/htmldata/libdoc/libdoc.css
@@ -669,3 +669,49 @@ span.or {
 .no-match .kw-name {
     color: var(--less-important-text-color);
 }
+
+.modal-icon {
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 600;
+    margin: 0 0.25rem;
+    width: 1rem;
+    height: 1rem;
+    padding: 0;
+    border: none;
+    background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" height="100%" width="100%"><path stroke="black" fill="none" stroke-width="2px" stroke-linecap="round" d="M1 8 L1 1 L8 1 M16 1 L23 1 L23 8 M23 16 L23 23 L16 23 M8 23 L1 23 L1 16"></path><path fill="black" stroke="none" stroke-width="1px" transform="scale(1.3) translate(-3 -2.5)" d="M19 7.97zm-8 9.2-4-2.3v-4.63l4 2.33v4.6zm1-6.33L8.04 8.53 12 6.25l3.96 2.28L12 10.84zm5 4.03-4 2.3v-4.6l4-2.33v4.63z"></path></svg>');
+}
+@media (prefers-color-scheme: dark) {
+    .modal-icon {
+        background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" height="100%" width="100%"><path stroke="%23e2e1d7" fill="none" stroke-width="2px" stroke-linecap="round" d="M1 8 L1 1 L8 1 M16 1 L23 1 L23 8 M23 16 L23 23 L16 23 M8 23 L1 23 L1 16"></path><path fill="%23e2e1d7" stroke="none" stroke-width="1px" transform="scale(1.3) translate(-3 -2.5)" d="M19 7.97zm-8 9.2-4-2.3v-4.63l4 2.33v4.6zm1-6.33L8.04 8.53 12 6.25l3.96 2.28L12 10.84zm5 4.03-4 2.3v-4.6l4-2.33v4.63z"></path></svg>');
+    }
+}
+.modal-background, .modal {
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s;
+}
+.modal-background {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background-color: rgba(0, 0, 0, 0.7);
+    z-index: 1;
+}
+.modal {
+    width: 720px;
+    max-width: calc(100vw - 2rem);
+    margin: 3rem auto;
+    height: calc(100vh - 6rem);
+    overflow: auto;
+    background-color: var(--background-color);
+    border: 1px solid var(--border-color);
+    z-index: 2;
+    transition-delay: 0.1s;
+}
+.modal-background.visible, .modal.visible {
+    opacity: 1;
+    pointer-events: all;
+}

--- a/src/robot/htmldata/libdoc/libdoc.html
+++ b/src/robot/htmldata/libdoc/libdoc.html
@@ -77,6 +77,7 @@
           }
       }, 0);
         workaroundFirefoxWidthBug();
+        createModal();
     });
 
     function parseTemplates() {
@@ -549,7 +550,7 @@ ${name}
   <span class="arg-type">
     {{each types}}
       {{if $value in $data.typedocs}}
-          &lt;<a class="type" href="#${$data.typedocs[$value]}" onclick="showModal(${$value})" title="Click to show type information">${$value}</a>>&gt;
+          &lt;<a style="cursor: pointer;" class="type" title="Click to show type information" onclick="showModal(${$data.typedocs[$value]})">${$value}</a>&gt;
       {{else}}
           &lt;<span class="type">${$value}</span>&gt;
       {{/if}}

--- a/src/robot/htmldata/libdoc/libdoc.html
+++ b/src/robot/htmldata/libdoc/libdoc.html
@@ -259,6 +259,44 @@
         history.replaceState && history.replaceState(null, '', location.pathname);
     }
 
+    function createModal() {
+        const modalBackground = document.createElement('div');
+        modalBackground.id = 'modal-background';
+        modalBackground.classList.add('modal-background');
+        modalBackground.addEventListener('click', ({ target }) => {
+            if (target.id === 'modal-background') hideModal()
+        })
+        const modal = document.createElement('div');
+        modal.id = 'modal';
+        modal.classList.add('modal');
+        modal.addEventListener('click', ({ target }) => {
+            if (target.tagName.toUpperCase() === 'A') hideModal()
+        })
+        modalBackground.appendChild(modal);
+        document.body.appendChild(modalBackground);
+    }
+
+    function showModal(content) {
+        const modalBackground = document.getElementById('modal-background');
+        const modal = document.getElementById('modal');
+        modalBackground.classList.add('visible');
+        modal.classList.add('visible');
+        console.log(content)
+        modal.appendChild(content.cloneNode(true));
+        document.body.style.overflow = 'hidden'
+    }
+
+    function hideModal() {
+        const modalBackground = document.getElementById('modal-background');
+        const modal = document.getElementById('modal');
+        modalBackground.classList.remove('visible');
+        modal.classList.remove('visible');
+        document.body.style.overflow = 'auto'
+        setTimeout(() => {
+            modal.innerHTML = ''
+        }, 200)
+    }
+
     // http://stackoverflow.com/a/18484799
     var delay = (function () {
         var timer = 0;

--- a/src/robot/htmldata/libdoc/libdoc.html
+++ b/src/robot/htmldata/libdoc/libdoc.html
@@ -291,7 +291,6 @@
         modal.appendChild(modalContent);
 
         modalBackground.appendChild(modal);
-        console.log(modal)
         document.body.appendChild(modalBackground);
         document.addEventListener('keydown', ({ key }) => {
             if (key === 'Escape') hideModal()
@@ -300,7 +299,6 @@
     function showModal(content) {
         const modalBackground = document.getElementById('modal-background');
         const modal = document.getElementById('modal');
-        console.log(modal)
         const modalContent = document.getElementById('modal-content');
         modalBackground.classList.add('visible');
         modal.classList.add('visible');
@@ -551,7 +549,7 @@ ${name}
   <span class="arg-type">
     {{each types}}
       {{if $value in $data.typedocs}}
-          &lt;<a class="type" href="#${$data.typedocs[$value]}" title="Click to show type information">${$value}</a><button class="modal-icon" onclick="showModal(${$value})">&nbsp;</button>&gt;
+          &lt;<a class="type" href="#${$data.typedocs[$value]}" onclick="showModal(${$value})" title="Click to show type information">${$value}</a>>&gt;
       {{else}}
           &lt;<span class="type">${$value}</span>&gt;
       {{/if}}

--- a/src/robot/htmldata/libdoc/libdoc.html
+++ b/src/robot/htmldata/libdoc/libdoc.html
@@ -266,34 +266,58 @@
         modalBackground.addEventListener('click', ({ target }) => {
             if (target.id === 'modal-background') hideModal()
         })
+
         const modal = document.createElement('div');
         modal.id = 'modal';
         modal.classList.add('modal');
         modal.addEventListener('click', ({ target }) => {
             if (target.tagName.toUpperCase() === 'A') hideModal()
         })
-        modalBackground.appendChild(modal);
-        document.body.appendChild(modalBackground);
-    }
 
+        const modalCloseButtonWrapper = document.createElement('div');
+        modalCloseButtonWrapper.classList.add('modal-close-button-wrapper');
+        const modalCloseButton = document.createElement('button');
+        modalCloseButton.innerHTML = 'X';
+        modalCloseButton.classList.add('modal-close-button');
+        modalCloseButtonWrapper.appendChild(modalCloseButton)
+        modalCloseButton.addEventListener('click', () => {
+            hideModal()
+        })
+        modal.appendChild(modalCloseButtonWrapper);
+
+        const modalContent = document.createElement('div');
+        modalContent.id = 'modal-content';
+        modalContent.classList.add('modal-content');
+        modal.appendChild(modalContent);
+
+        modalBackground.appendChild(modal);
+        console.log(modal)
+        document.body.appendChild(modalBackground);
+        document.addEventListener('keydown', ({ key }) => {
+            if (key === 'Escape') hideModal()
+        })
+    }
     function showModal(content) {
         const modalBackground = document.getElementById('modal-background');
         const modal = document.getElementById('modal');
+        console.log(modal)
+        const modalContent = document.getElementById('modal-content');
         modalBackground.classList.add('visible');
         modal.classList.add('visible');
-        console.log(content)
-        modal.appendChild(content.cloneNode(true));
+        modalContent.appendChild(content.cloneNode(true));
         document.body.style.overflow = 'hidden'
     }
-
     function hideModal() {
         const modalBackground = document.getElementById('modal-background');
         const modal = document.getElementById('modal');
+        const modalContent = document.getElementById('modal-content');
+
         modalBackground.classList.remove('visible');
         modal.classList.remove('visible');
         document.body.style.overflow = 'auto'
+        // modal is hidden with a fading transition, timeout prevents premature emptying of modal
         setTimeout(() => {
-            modal.innerHTML = ''
+            modalContent.innerHTML = ''
         }, 200)
     }
 
@@ -527,7 +551,7 @@ ${name}
   <span class="arg-type">
     {{each types}}
       {{if $value in $data.typedocs}}
-          &lt;<a class="type" href="#${$data.typedocs[$value]}" title="Click to show type information">${$value}</a>&gt;
+          &lt;<a class="type" href="#${$data.typedocs[$value]}" title="Click to show type information">${$value}</a><button class="modal-icon" onclick="showModal(${$value})">&nbsp;</button>&gt;
       {{else}}
           &lt;<span class="type">${$value}</span>&gt;
       {{/if}}


### PR DESCRIPTION
- hide type documentation list from the bottom of doc
- clicking type opens a modal with type documentation
- close modal by eithet clicking background, clicking close-button or pressing esc
- support for desktop and mobile layouts