### PR TITLE
Don't retry libdoc with :: and show all error messages.

### DIFF
--- a/atest/robot/libdoc/cli.robot
+++ b/atest/robot/libdoc/cli.robot
@@ -61,7 +61,7 @@ Resource file in PYTHONPATH
 Non-existing resource
     [Template]    NONE
     ${stdout} =    Run Libdoc    nonexisting.resource whatever.xml
-    Should Be Equal    ${stdout}     Resource file 'nonexisting.resource' does not exist.${USAGE TIP}\n
+    Should contain    ${stdout}     Resource file 'nonexisting.resource' does not exist.${USAGE TIP}\n
 
 *** Keywords ***
 Run Libdoc And Verify Created Output File

--- a/src/robot/libdocpkg/builder.py
+++ b/src/robot/libdocpkg/builder.py
@@ -48,9 +48,15 @@ def _build(builder, source):
         # did not exist has been considered to be a library earlier, now we try to
         # parse it as a resource file.
         if (isinstance(builder, LibraryDocBuilder)
+                and '::' not in source
                 and not os.path.exists(source)
                 and _get_extension(source) in RESOURCE_EXTENSIONS):
-            return _build(ResourceDocBuilder(), source)
+            initial_error_message = get_error_message()
+            try:
+                return _build(ResourceDocBuilder(), source)
+            except DataError:
+                raise DataError("Building library '%s' failed. Failures:\n%s\n%s"
+                                % (source, initial_error_message, get_error_message()))
         raise
     except:
         raise DataError("Building library '%s' failed: %s"


### PR DESCRIPTION
This fixes a case where the user trying to build a library
(say `test_lib`) with arguments such as:

`test_lib::d:/testRepo/functions2.txt`

fails.

Given that `::` is present, it's no longer retried as a resource.

Also, the message shown to the user will now mention all errors
and not just the message saying that the resource file does not exist.

p.s.: see: https://github.com/robocorp/robotframework-lsp/issues/608#issuecomment-1073241116 for a case where this was misleading.