### PR TITLE
doc: Honor SOURCE_DATE_EPOCH for documentation timestamps.

### DIFF
--- a/BUILD.rst
+++ b/BUILD.rst
@@ -204,6 +204,12 @@ Creating distributions
 
 7. Documentation
 
+   - For a reproducible build, set the ``SOURCE_DATE_EPOCH``
+     environment variable to a constant value, corresponding to the
+     date in seconds since the Epoch (also known as Epoch time).  For
+     more information regarding this environment variable, see
+     https://reproducible-builds.org/docs/source-date-epoch/.
+
    - Generate library documentation::
 
        invoke library-docs all

--- a/atest/robot/libdoc/html_output.robot
+++ b/atest/robot/libdoc/html_output.robot
@@ -15,7 +15,7 @@ Version
 
 Generated
     [Template]    Should Match Regexp
-    ${MODEL}[generated]     \\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}
+    ${MODEL}[generated]     \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}[+-]\\d{2}:\\d{2}
 
 Scope
     ${MODEL}[scope]         GLOBAL

--- a/atest/robot/libdoc/json_output.robot
+++ b/atest/robot/libdoc/json_output.robot
@@ -15,7 +15,7 @@ Version
 
 Generated
     [Template]    Should Match Regexp
-    ${MODEL}[generated]     \\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}
+    ${MODEL}[generated]     \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}[+-]\\d{2}:\\d{2}
 
 Scope
     ${MODEL}[scope]         GLOBAL

--- a/atest/robot/libdoc/libdoc_resource.robot
+++ b/atest/robot/libdoc/libdoc_resource.robot
@@ -93,7 +93,13 @@ Lineno Should Be
     Element Attribute Should Be    ${LIBDOC}    lineno    ${lineno}
 
 Generated Should Be Defined
-    Element Attribute Should Match    ${LIBDOC}    generated    ????-??-??T??:??:??Z
+    # For example, '1970-01-01T00:00:01+00:00'.
+    Element Attribute Should Match    ${LIBDOC}    generated    ????-??-??T??:??:?????:??
+
+Generated Should Be
+    [Arguments]    ${generated}
+    Generated Should Be Defined
+    Element Attribute Should Be    ${LIBDOC}    generated    ${generated}
 
 Spec version should be correct
     Element Attribute Should Be    ${LIBDOC}    specversion    4

--- a/atest/robot/libdoc/spec_library.robot
+++ b/atest/robot/libdoc/spec_library.robot
@@ -1,4 +1,5 @@
 *** Settings ***
+Library           OperatingSystem
 Suite Setup       Run Libdoc And Parse Output    ${TESTDATADIR}/ExampleSpec.xml
 Resource          libdoc_resource.robot
 
@@ -97,6 +98,13 @@ Keyword Source Info
     Copy File    ${TESTDATADIR}/ExampleSpec.xml    %{TEMPDIR}/Example.libspec
     Run Libdoc And Parse Output    %{TEMPDIR}/Example.libspec
     Test Everything
+
+SOURCE_DATE_EPOCH is honored in Libdoc output
+    [Setup]    Set Environment Variable    SOURCE_DATE_EPOCH    0
+    Copy File    ${TESTDATADIR}/ExampleSpec.xml    %{TEMPDIR}/Example.libspec
+    Run Libdoc And Parse Output    %{TEMPDIR}/Example.libspec
+    Generated Should Be    1970-01-01T00:00:00+00:00
+    [Teardown]    Remove Environment Variable    SOURCE_DATE_EPOCH
 
 *** Keywords ***
 Test Everything

--- a/atest/robot/standard_libraries/operating_system/modified_time.robot
+++ b/atest/robot/standard_libraries/operating_system/modified_time.robot
@@ -8,7 +8,7 @@ ${TESTFILE}       %{TEMPDIR}${/}robot-os-tests${/}f1.txt
 *** Test Cases ***
 Get Modified Time As Timestamp
     ${tc} =    Check Test Case    ${TESTNAME}
-    Should Match Regexp    ${tc.kws[0].msgs[0].message}    Last modified time of '<a href=.*</a>' is 20\\d\\d-\\d\\d-\\d\\d \\d\\d:\\d\\d:\\d\\d
+    Should Match Regexp    ${tc.kws[0].msgs[0].message}    Last modified time of '<a href=.*</a>' is \\d\\d\\d\\d-\\d\\d-\\d\\d \\d\\d:\\d\\d:\\d\\d
 
 Get Modified Time As Seconds After Epoch
     ${tc} =    Check Test Case    ${TESTNAME}

--- a/atest/testdata/standard_libraries/builtin/get_time.robot
+++ b/atest/testdata/standard_libraries/builtin/get_time.robot
@@ -11,18 +11,18 @@ Get Time As Timestamp
 
 Get Time As Seconds After Epoch
     ${time} =    Get Time    epoch
-    Should Be True    1000000000 < ${time} < 2000000000
+    Should Be True    0 < ${time}
 
 Get Time As Parts
     @{time} =    Get Time    year, month, day, hour, min, sec
-    Should Be True    2000 < ${time}[0] < 2100
+    Should Match Regexp    ${time}[0]    \\d{4}
     Should Be True    1 <= int('${time}[1]') <= 12
     Should Be True    1 <= int('${time}[2]') <= 31
     Should Be True    0 <= int('${time}[3]') <= 23
     Should Be True    0 <= int('${time}[4]') <= 59
     Should Be True    0 <= int('${time}[5]') <= 59
     ${year}    ${min}    ${sec} =    Get Time    seconds and minutes and year and whatnot
-    Should Be True    2000 < ${year} < 2100
+    Should Match Regexp    ${year}    \\d{4}
     Should Be True    0 <= int('${min}') <= 59
     Should Be True    0 <= int('${sec}') <= 59
 

--- a/atest/testdata/standard_libraries/operating_system/modified_time.robot
+++ b/atest/testdata/standard_libraries/operating_system/modified_time.robot
@@ -14,13 +14,13 @@ Get Modified Time As Timestamp
 
 Get Modified Time As Seconds After Epoch
     ${dirtime} =    Get Modified Time    ${CURDIR}    epoch
-    Should Be True    1000000000 < ${dirtime} < 2000000000
+    Should Be True    ${dirtime} > 0
     ${current} =    Get Time    epoch
     Should Be True    ${current} >= ${dirtime}
 
 Get Modified Time As Parts
     ${year} =    Get Modified Time    ${CURDIR}    year
-    Should Be True    2000 < ${year} < 2100
+    Should Match Regexp    ${year}    \\d{4}
     ${yyyy}    ${mm}    ${dd} =    Get Modified Time    ${CURDIR}    year, month, day
     Should Be Equal    ${yyyy}    ${year}
     # Must use `int('x')` because otherwise 08 and 09 are considered octal

--- a/doc/userguide/ug2html.py
+++ b/doc/userguide/ug2html.py
@@ -150,8 +150,7 @@ def create_userguide():
     install_file = _copy_installation_instructions()
 
     description = 'HTML generator for Robot Framework User Guide.'
-    arguments = ['--time',
-                 '--stylesheet-path', ['src/userguide.css'],
+    arguments = ['--stylesheet-path', ['src/userguide.css'],
                  'src/RobotFrameworkUserGuide.rst',
                  'RobotFrameworkUserGuide.html']
     os.chdir(CURDIR)

--- a/src/robot/libdocpkg/model.py
+++ b/src/robot/libdocpkg/model.py
@@ -19,11 +19,11 @@ from itertools import chain
 
 from robot.model import Tags
 from robot.running import ArgumentSpec
-from robot.utils import getshortdoc, get_timestamp, Sortable, setter
+from robot.utils import getshortdoc, Sortable, setter
 
 from .htmlutils import DocFormatter, DocToHtml, HtmlToText
 from .writer import LibdocWriter
-from .output import LibdocOutput
+from .output import LibdocOutput, get_generation_time
 
 
 class LibraryDoc:
@@ -114,7 +114,7 @@ class LibraryDoc:
             'name': self.name,
             'doc': self.doc,
             'version': self.version,
-            'generated': get_timestamp(daysep='-', millissep=None),
+            'generated': get_generation_time(),
             'type': self.type,
             'scope': self.scope,
             'docFormat': self.doc_format,

--- a/src/robot/libdocpkg/output.py
+++ b/src/robot/libdocpkg/output.py
@@ -13,7 +13,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import datetime
 import os
+import time
 
 from robot.utils import file_writer
 
@@ -40,3 +42,14 @@ class LibdocOutput:
                 os.remove(self._output_path)
             except OSError:
                 pass
+
+
+def get_generation_time():
+    """Return a timestamp that honors `SOURCE_DATE_EPOCH`.
+
+    This timestamp is to be used for embedding in output files, so
+    that builds can be made reproducible.
+    """
+    ts = float(os.getenv('SOURCE_DATE_EPOCH', time.time()))
+    dt = datetime.datetime.fromtimestamp(round(ts), datetime.timezone.utc)
+    return dt.isoformat()

--- a/src/robot/libdocpkg/xmlwriter.py
+++ b/src/robot/libdocpkg/xmlwriter.py
@@ -13,9 +13,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from datetime import datetime
-
 from robot.utils import XmlWriter
+
+from .output import get_generation_time
 
 
 class LibdocXmlWriter:
@@ -32,12 +32,11 @@ class LibdocXmlWriter:
         self._write_end(writer)
 
     def _write_start(self, libdoc, writer):
-        generated = datetime.utcnow().replace(microsecond=0).isoformat() + 'Z'
         attrs = {'name': libdoc.name,
                  'type': libdoc.type,
                  'format': libdoc.doc_format,
                  'scope': libdoc.scope,
-                 'generated': generated,
+                 'generated': get_generation_time(),
                  'specversion': '4'}
         self._add_source_info(attrs, libdoc)
         writer.start('keywordspec', attrs)


### PR DESCRIPTION
Fixes #4262.

* doc/userguide/ug2html.py (create_userguide): Do not embed
timestamps.
* src/robot/utils/robottime.py (get_timestamp_for_doc): New procedure.
* src/robot/utils/__init__.py: Export it.
* src/robot/libdocpkg/model.py (LibraryDoc.to_dictionary): Use it.
* src/robot/libdocpkg/xmlwriter.py (LibdocXmlWriter._write_start):
Likewise.
* BUILD.rst: Document it.