### PR TITLE
Support disabling continue-on-failure mode in teardown and with template

### DIFF
--- a/atest/robot/running/continue_on_failure_tag.robot
+++ b/atest/robot/running/continue_on_failure_tag.robot
@@ -63,8 +63,14 @@ Recursive continue in test with Set Tags and two nested UK without tag
 Recursive continue in test with tag and two nested UK with and without tag
     Check Test Case    ${TESTNAME}
 
+Recursive continue in test with tag and UK with no-continue tag
+    Check Test Case    ${TESTNAME}
+
 Recursive continue in user keyword
     Check Test Case    ${TESTNAME}
 
 Recursive continue in nested keyword
     Check Test Case    ${TESTNAME}
+
+No-continue-on-failure in Teardown
+    Check Test Case    ${TESTNAME}     FAIL    Teardown failed:\n1

--- a/atest/robot/running/continue_on_failure_tag.robot
+++ b/atest/robot/running/continue_on_failure_tag.robot
@@ -73,7 +73,10 @@ Recursive continue in nested keyword
     Check Test Case    ${TESTNAME}
 
 No-continue-on-failure in Teardown
-    Check Test Case    ${TESTNAME}     FAIL    Teardown failed:\nkw1a
+    Check Test Case    ${TESTNAME}
 
 No-continue-on-failure-2 in Teardown
-    Check Test Case    ${TESTNAME}     FAIL    Teardown failed:\n1
+    Check Test Case    ${TESTNAME}
+
+No-continue-on-failure in User Keyword
+    Check Test Case    ${TESTNAME}

--- a/atest/robot/running/continue_on_failure_tag.robot
+++ b/atest/robot/running/continue_on_failure_tag.robot
@@ -73,4 +73,4 @@ Recursive continue in nested keyword
     Check Test Case    ${TESTNAME}
 
 No-continue-on-failure in Teardown
-    Check Test Case    ${TESTNAME}     FAIL    Teardown failed:\n1
+    Check Test Case    ${TESTNAME}     FAIL    Teardown failed:\nkw1a

--- a/atest/robot/running/continue_on_failure_tag.robot
+++ b/atest/robot/running/continue_on_failure_tag.robot
@@ -80,3 +80,6 @@ No-continue-on-failure-2 in Teardown
 
 No-continue-on-failure in User Keyword
     Check Test Case    ${TESTNAME}
+
+No-continue-on-failure with Template
+    Check Test Case    ${TESTNAME}

--- a/atest/robot/running/continue_on_failure_tag.robot
+++ b/atest/robot/running/continue_on_failure_tag.robot
@@ -74,3 +74,6 @@ Recursive continue in nested keyword
 
 No-continue-on-failure in Teardown
     Check Test Case    ${TESTNAME}     FAIL    Teardown failed:\nkw1a
+
+No-continue-on-failure-2 in Teardown
+    Check Test Case    ${TESTNAME}     FAIL    Teardown failed:\n1

--- a/atest/testdata/running/continue_on_failure_tag.robot
+++ b/atest/testdata/running/continue_on_failure_tag.robot
@@ -217,6 +217,12 @@ No-continue-on-failure in Teardown
     [Teardown]   Failure in user keyword with no-continue tag
     Log    does not matter
 
+No-continue-on-failure-2 in Teardown
+    [Documentation]    FAIL 1
+    [Tags]   robot:no-continue-on-failure
+    [Teardown]   Run Keywords   Fail   1   AND   Fail  2
+    Log    does not matter
+
 *** Keywords ***
 Failure in user keyword with tag
     [Arguments]    ${run_kw}=No Operation

--- a/atest/testdata/running/continue_on_failure_tag.robot
+++ b/atest/testdata/running/continue_on_failure_tag.robot
@@ -188,6 +188,14 @@ Recursive continue in test with tag and two nested UK with and without tag
     Failure in user keyword with tag     run_kw=Failure in user keyword without tag
     Fail   This should be executed
 
+Recursive continue in test with tag and UK with no-continue tag
+    [Documentation]    FAIL ${HEADER}\n\n
+    ...    1) kw1a\n\n
+    ...    2) This should be executed
+    [Tags]   robot:recursive-continue-on-failure
+    Failure in user keyword with no-continue tag
+    Fail   This should be executed
+
 Recursive continue in user keyword
     [Documentation]    FAIL ${HEADER}\n\n
     ...    1) kw1a\n\n
@@ -203,6 +211,11 @@ Recursive continue in nested keyword
     ...    2) kw1b
     Failure in user keyword without tag     run_kw=Failure in user keyword with recursive tag
     Fail   This should not be executed
+
+No-continue-on-failure in Teardown
+    [Documentation]    FAIL 1
+    [Teardown]   teardown-no-continue-on-failure
+    Log    does not matter
 
 *** Keywords ***
 Failure in user keyword with tag
@@ -226,6 +239,12 @@ Failure in user keyword with recursive tag
     Fail   kw1b
     Log    This should be executed
     Run Keyword   ${run_kw}
+
+Failure in user keyword with no-continue tag
+    [Tags]   robot:no-continue-on-failure
+    Fail   kw1a
+    Log    This should not be executed
+    Fail   kw1b
 
 FOR loop in in user keyword with tag
     [Tags]   robot:continue-on-failure
@@ -262,3 +281,9 @@ IF in user keyword without tag
         Fail    kw1c
         Fail    kw1d
     END
+
+teardown-no-continue-on-failure
+    [Tags]    robot:no-continue-on-failure
+    Fail   1
+    Log    this should not be executed
+    Fail   2

--- a/atest/testdata/running/continue_on_failure_tag.robot
+++ b/atest/testdata/running/continue_on_failure_tag.robot
@@ -228,6 +228,14 @@ No-continue-on-failure in User Keyword
     [Teardown]   User Keyword Teardown
     No Operation
 
+No-continue-on-failure with Template
+    [Documentation]    FAIL    42 != 43
+    [Tags]   robot:no-continue-on-failure
+    [Template]    Should Be Equal
+    Same         Same
+    42           43
+    Something    Different
+
 *** Keywords ***
 Failure in user keyword with tag
     [Arguments]    ${run_kw}=No Operation

--- a/atest/testdata/running/continue_on_failure_tag.robot
+++ b/atest/testdata/running/continue_on_failure_tag.robot
@@ -213,8 +213,8 @@ Recursive continue in nested keyword
     Fail   This should not be executed
 
 No-continue-on-failure in Teardown
-    [Documentation]    FAIL 1
-    [Teardown]   teardown-no-continue-on-failure
+    [Documentation]    FAIL kw1a
+    [Teardown]   Failure in user keyword with no-continue tag
     Log    does not matter
 
 *** Keywords ***
@@ -281,9 +281,3 @@ IF in user keyword without tag
         Fail    kw1c
         Fail    kw1d
     END
-
-teardown-no-continue-on-failure
-    [Tags]    robot:no-continue-on-failure
-    Fail   1
-    Log    this should not be executed
-    Fail   2

--- a/atest/testdata/running/continue_on_failure_tag.robot
+++ b/atest/testdata/running/continue_on_failure_tag.robot
@@ -213,15 +213,20 @@ Recursive continue in nested keyword
     Fail   This should not be executed
 
 No-continue-on-failure in Teardown
-    [Documentation]    FAIL kw1a
+    [Documentation]    FAIL    Teardown failed:\nkw1a
     [Teardown]   Failure in user keyword with no-continue tag
-    Log    does not matter
+    No Operation
 
 No-continue-on-failure-2 in Teardown
-    [Documentation]    FAIL 1
+    [Documentation]    FAIL    Teardown failed:\n1
     [Tags]   robot:no-continue-on-failure
     [Teardown]   Run Keywords   Fail   1   AND   Fail  2
     Log    does not matter
+
+No-continue-on-failure in User Keyword
+    [Documentation]    FAIL    Teardown failed:\nKeyword teardown failed:\nkw1a
+    [Teardown]   User Keyword Teardown
+    No Operation
 
 *** Keywords ***
 Failure in user keyword with tag
@@ -251,6 +256,11 @@ Failure in user keyword with no-continue tag
     Fail   kw1a
     Log    This should not be executed
     Fail   kw1b
+
+User Keyword Teardown
+    [Tags]   robot:no-continue-on-failure
+    [Teardown]   Run Keywords    Fail  kw1a   AND   Fail   kw1b
+    No Operation
 
 FOR loop in in user keyword with tag
     [Tags]   robot:continue-on-failure

--- a/src/robot/errors.py
+++ b/src/robot/errors.py
@@ -146,9 +146,7 @@ class ExecutionStatus(RobotError):
             return False
         if context.in_teardown:
             return context.continue_on_failure_in_teardown
-        if context.continue_on_failure:
-            return True
-        return self.continue_on_failure
+        return context.continue_on_failure or self.continue_on_failure
 
     def get_errors(self):
         return [self]

--- a/src/robot/errors.py
+++ b/src/robot/errors.py
@@ -139,13 +139,13 @@ class ExecutionStatus(RobotError):
         if self.syntax or self.exit or self.skip or self.test_timeout:
             return False
         if templated:
-            return True
+            return context.continue_on_failure_default_on
         if self.keyword_timeout:
             if context.in_teardown:
                 self.keyword_timeout = False
             return False
         if context.in_teardown:
-            return context.continue_on_failure_in_teardown
+            return context.continue_on_failure_default_on
         return context.continue_on_failure or self.continue_on_failure
 
     def get_errors(self):

--- a/src/robot/errors.py
+++ b/src/robot/errors.py
@@ -144,7 +144,9 @@ class ExecutionStatus(RobotError):
             if context.in_teardown:
                 self.keyword_timeout = False
             return False
-        if context.in_teardown or context.continue_on_failure:
+        if context.in_teardown:
+            return context.continue_on_failure_in_teardown
+        if context.continue_on_failure:
             return True
         return self.continue_on_failure
 

--- a/src/robot/running/context.py
+++ b/src/robot/running/context.py
@@ -133,7 +133,18 @@ class _ExecutionContext:
             return False
         if 'robot:continue-on-failure' in parents[-1].tags:
             return True
+        if 'robot:no-continue-on-failure' in parents[-1].tags:
+            return False
         return any('robot:recursive-continue-on-failure' in p.tags for p in parents)
+
+    @property
+    def continue_on_failure_in_teardown(self):
+        parents = ([self.test] if self.test else []) + self.user_keywords
+        if not parents:
+            return True
+        if 'robot:no-continue-on-failure' in parents[-1].tags:
+            return False
+        return True
 
     @property
     def allow_loop_control(self):

--- a/src/robot/running/context.py
+++ b/src/robot/running/context.py
@@ -138,11 +138,10 @@ class _ExecutionContext:
         return any('robot:recursive-continue-on-failure' in p.tags for p in parents)
 
     @property
-    def continue_on_failure_in_teardown(self):
+    def continue_on_failure_default_on(self):
+        # logic for teardown/template where continue-on-failure is on by default
         parents = ([self.test] if self.test else []) + self.user_keywords
-        if not parents:
-            return True
-        if 'robot:no-continue-on-failure' in parents[-1].tags:
+        if parents and 'robot:no-continue-on-failure' in parents[-1].tags:
             return False
         return True
 


### PR DESCRIPTION
Enable a user-keyword executed within teardown context to override the default continue-on-failure behaviour in teardown, i.e. 

```
No-continue-on-failure in Teardown
    [Documentation]    FAIL kw1a
    [Teardown]   Failure in user keyword with no-continue tag
    Log    does not matter

*** Keywords ***
Failure in user keyword with no-continue tag
    [Tags]   robot:no-continue-on-failure
    Fail   kw1a
    Log    This should not be executed
    Fail   kw1b
```

Also allow the user to disable default for continue-on-failure with templates. The below test case will abort the test case after the 2nd iteration (42!=43), the last values (Something and Different) are not compared

```
No-continue-on-failure with Template
    [Documentation]    FAIL    42 != 43
    [Tags]   robot:no-continue-on-failure
    [Template]    Should Be Equal
    Same         Same
    42           43
    Something    Different
```

This addresses #4303 
