### PR TITLE
Include source file path on xunit report output

### DIFF
--- a/src/robot/reporting/xunitwriter.py
+++ b/src/robot/reporting/xunitwriter.py
@@ -70,6 +70,7 @@ class XUnitFileWriter(ResultVisitor):
         self._writer.start('testcase',
                            {'classname': test.parent.longname,
                             'name': test.name,
+                            'file': test.source,
                             'time': self._time_as_seconds(test.elapsedtime)})
         if test.failed:
             self._writer.element('failure', attrs={'message': test.message,


### PR DESCRIPTION
This includes the source file path to the xunit report output.  This is equivalent to the foramat of RspecJunitFormatter.