### PR TITLE
Possibility to change keyword status (to failed) with listeners v3 'end_keyword' 

### DIFF
--- a/src/robot/output/listeners.py
+++ b/src/robot/output/listeners.py
@@ -130,7 +130,6 @@ class ListenerProxy(AbstractLoggerProxy):
         self.name = name
         self.version = self._get_version(listener)
         if self.version == 3:
-            self.start_keyword = self.end_keyword = None
             self.library_import = self.resource_import = self.variables_import = None
 
     def _import_listener(self, listener):

--- a/src/robot/running/statusreporter.py
+++ b/src/robot/running/statusreporter.py
@@ -61,7 +61,14 @@ class StatusReporter:
         if self.initial_test_status == 'PASS':
             context.test.status = result.status
         result.endtime = get_timestamp()
+        result_status_before = result.status
         context.end_keyword(ModelCombiner(self.data, result))
+        # check if status have changed in listener's end_keyword
+        if result_status_before != result.status and result.failed:
+            failure = ExecutionFailed(
+                message=f"Keyword {self.data.name} failed in listener method 'end_keyword'.",
+                exit=True,
+            )
         if failure is not exc_val:
             raise failure
         return self.suppress

--- a/src/robot/running/statusreporter.py
+++ b/src/robot/running/statusreporter.py
@@ -66,7 +66,8 @@ class StatusReporter:
         # check if status have changed in listener's end_keyword
         if result_status_before != result.status and result.failed:
             failure = ExecutionFailed(
-                message=f"Keyword {self.data.name} failed in listener method 'end_keyword'.",
+                message=f"Keyword {self.data.name} failed in listener "
+                        f"method 'end_keyword'.",
                 exit=True,
             )
         if failure is not exc_val:


### PR DESCRIPTION
Added possibility to fail keyword execution with listener v3 method 'end_keyword'. Issue #3296

Use case: 
For one of our current projects, there is a need to monitor certain conditions after each keyword and stop test execution if these conditions aren't satisfied.  