### PR TITLE
Keyword visibility modifiers for resource files (#430)

### DIFF
--- a/atest/robot/libdoc/html_output.robot
+++ b/atest/robot/libdoc/html_output.robot
@@ -105,6 +105,15 @@ User keyword documentation formatting
     ...    </tr>
     ...    </table>
 
+Private keyword should be excluded
+    [Template]    None
+    Run Libdoc And Parse Model From HTML    ${TESTDATADIR}/resource.robot
+    FOR    ${keyword}    IN    @{MODEL}[keywords]
+        IF    '${keyword}[name]' == 'Private'
+            Fail    Keyword 'Private' should be excluded from html
+        END
+    END
+
 *** Keywords ***
 Verify Argument Models
     [Arguments]    ${arg_models}    @{expected_reprs}

--- a/atest/robot/libdoc/html_output.robot
+++ b/atest/robot/libdoc/html_output.robot
@@ -106,12 +106,10 @@ User keyword documentation formatting
     ...    </table>
 
 Private keyword should be excluded
+    [Setup]    Run Libdoc And Parse Model From HTML    ${TESTDATADIR}/resource.robot
     [Template]    None
-    Run Libdoc And Parse Model From HTML    ${TESTDATADIR}/resource.robot
     FOR    ${keyword}    IN    @{MODEL}[keywords]
-        IF    '${keyword}[name]' == 'Private'
-            Fail    Keyword 'Private' should be excluded from html
-        END
+        Should Not Be Equal    ${keyword}[name]    Private
     END
 
 *** Keywords ***

--- a/atest/robot/libdoc/json_output.robot
+++ b/atest/robot/libdoc/json_output.robot
@@ -105,6 +105,11 @@ User keyword documentation formatting
     ...    </tr>
     ...    </table>
 
+Private user keyword should be included
+    [Template]    None
+    Run Libdoc And Parse Model From JSON    ${TESTDATADIR}/resource.robot
+    Should Be Equal As Strings    ${MODEL}[keywords][11][name]    Private
+
 *** Keywords ***
 Verify Argument Models
     [Arguments]    ${arg_models}    @{expected_reprs}

--- a/atest/robot/libdoc/json_output.robot
+++ b/atest/robot/libdoc/json_output.robot
@@ -106,9 +106,10 @@ User keyword documentation formatting
     ...    </table>
 
 Private user keyword should be included
-    [Template]    None
-    Run Libdoc And Parse Model From JSON    ${TESTDATADIR}/resource.robot
-    Should Be Equal As Strings    ${MODEL}[keywords][11][name]    Private
+    [Setup]    Run Libdoc And Parse Model From JSON    ${TESTDATADIR}/resource.robot
+    [Template]    Should Be Equal As Strings
+    ${MODEL}[keywords][-1][name]    Private
+    ${MODEL}[keywords][-1][tags]    ['robot:private']
 
 *** Keywords ***
 Verify Argument Models

--- a/atest/robot/libdoc/resource_file.robot
+++ b/atest/robot/libdoc/resource_file.robot
@@ -43,7 +43,7 @@ Spec version
 
 Resource Tags
     Specfile Tags Should Be          \${3}    ?!?!??    a      b    bar    dar
-    ...                              foo      Has       kw4    tags
+    ...                              foo      Has       kw4    robot:private    tags
 
 Resource Has No Inits
     Should Have No Init

--- a/atest/robot/running/private.robot
+++ b/atest/robot/running/private.robot
@@ -28,14 +28,28 @@ Invalid Usage in Resource File
 
 Keyword With Same Name Should Resolve Public Keyword
     ${tc}=    Check Test Case    ${TESTNAME}
-    Check Log Message
-    ...    ${tc.body[0].body[0]}
-    ...    There were both public and private keyword found with the name 'Same Name', 'private.Same Name' being public and 'private2.Same Name' being private. The public keyword is used. To select explicitly, and to get rid of this warning, use either 'private.Same Name' or 'private2.Same Name'.
-    ...    WARN
+    ${warning}=    Catenate
+    ...    There were both public and private keyword found with the name 'Same Name',
+    ...    'private.Same Name' being public and 'private2.Same Name' being private.
+    ...    The public keyword is used.
+    ...    To select explicitly, and to get rid of this warning,
+    ...    use either 'private.Same Name' or 'private2.Same Name'.
+    Public And Private Keyword Conflict Warning Should Be    ${warning}    ${tc.body[0].body[0]}    ${ERRORS[3]}
     Length Should Be    ${tc.body[0].body}    2
 
 If Both Keywords Are Private Raise Multiple Keywords Found
     Check Test Case    ${TESTNAME}
+
+If One Keyword Is Public And Multiple Private Keywords Run Public And Warn
+    ${tc}=    Check Test Case    ${TESTNAME}
+    ${warning}=    Catenate
+    ...    There were both public and private keyword found with the name 'Possible Keyword',
+    ...    'private.Possible Keyword' being public and 'private2.Possible Keyword' / 'private3.Possible Keyword' being private.
+    ...    The public keyword is used.
+    ...    To select explicitly, and to get rid of this warning,
+    ...    use either 'private.Possible Keyword' or 'private2.Possible Keyword' / 'private3.Possible Keyword'.
+    Public And Private Keyword Conflict Warning Should Be    ${warning}    ${tc.body[0].body[0].body[0]}    ${ERRORS[4]}
+    Length Should Be    ${tc.body[0].body[0].body}    2
 
 *** Keywords ***
 Private Call Warning Should Be
@@ -44,4 +58,10 @@ Private Call Warning Should Be
         Check Log Message     ${message}
         ...    Keyword '${name}' is private and should only be called by keywords in the same file.
         ...    WARN
+    END
+
+Public And Private Keyword Conflict Warning Should Be
+    [Arguments]    ${warning}    @{messages}
+    FOR    ${message}    IN    @{messages}
+        Check Log Message    ${message}    ${warning}    WARN
     END

--- a/atest/robot/running/private.robot
+++ b/atest/robot/running/private.robot
@@ -1,0 +1,36 @@
+*** Settings ***
+Suite Setup       Run Tests    ${EMPTY}    running/private.robot
+Resource          atest_resource.robot
+
+*** Test Cases ***
+Valid Usage With Local Keyword
+    ${tc}=    Check Test Case    ${TESTNAME}
+    Length Should Be    ${tc.body[0].body}    1
+
+Invalid Usage With Local Keyword
+    ${tc}=    Check Test Case    ${TESTNAME}
+    Private Call Warning Should Be    Private Keyword    ${tc.body[0].body[0]}    ${ERRORS[0]}
+    Length Should Be    ${tc.body[0].body}    2
+
+Valid Usage With Resource Keyword
+    ${tc}=    Check Test Case    ${TESTNAME}
+    Length Should Be    ${tc.body[0].body}    1
+
+Invalid Usage With Resource Keyword
+    ${tc}=    Check Test Case    ${TESTNAME}
+    Private Call Warning Should Be    private.Private Keyword In Resource    ${tc.body[0].body[0]}    ${ERRORS[1]}
+    Length Should Be    ${tc.body[0].body}    2
+
+Invalid Usage in Resource File
+    ${tc}=    Check Test Case    ${TESTNAME}
+    Private Call Warning Should Be    private2.Private Keyword In Resource 2   ${tc.body[0].body[0].body[0]}    ${ERRORS[2]}
+    Length Should Be    ${tc.body[0].body[0].body}    2
+
+*** Keywords ***
+Private Call Warning Should Be
+    [Arguments]    ${name}    @{messages}
+    FOR    ${message}    IN    @{messages}
+        Check Log Message     ${message}
+        ...    Keyword '${name}' is private and should only be called by keywords in the same file.
+        ...    WARN
+    END

--- a/atest/robot/running/private.robot
+++ b/atest/robot/running/private.robot
@@ -28,7 +28,14 @@ Invalid Usage in Resource File
 
 Keyword With Same Name Should Resolve Public Keyword
     ${tc}=    Check Test Case    ${TESTNAME}
-    Length Should Be    ${tc.body[0].body}    1
+    Check Log Message
+    ...    ${tc.body[0].body[0]}
+    ...    There were both public and private keyword found with the name 'Same Name', 'private.Same Name' being public and 'private2.Same Name' being private. The public keyword is used. To select explicitly, and to get rid of this warning, use either 'private.Same Name' or 'private2.Same Name'.
+    ...    WARN
+    Length Should Be    ${tc.body[0].body}    2
+
+If Both Keywords Are Private Raise Multiple Keywords Found
+    Check Test Case    ${TESTNAME}
 
 *** Keywords ***
 Private Call Warning Should Be

--- a/atest/robot/running/private.robot
+++ b/atest/robot/running/private.robot
@@ -26,6 +26,10 @@ Invalid Usage in Resource File
     Private Call Warning Should Be    private2.Private Keyword In Resource 2   ${tc.body[0].body[0].body[0]}    ${ERRORS[2]}
     Length Should Be    ${tc.body[0].body[0].body}    2
 
+Keyword With Same Name Should Resolve Public Keyword
+    ${tc}=    Check Test Case    ${TESTNAME}
+    Length Should Be    ${tc.body[0].body}    1
+
 *** Keywords ***
 Private Call Warning Should Be
     [Arguments]    ${name}    @{messages}

--- a/atest/testdata/libdoc/resource.robot
+++ b/atest/testdata/libdoc/resource.robot
@@ -69,3 +69,6 @@ non ascii doc
 
 Deprecation
     [Documentation]    *DEPRECATED* for some reason.
+
+Private
+    [Tags]    robot:private

--- a/atest/testdata/running/private.resource
+++ b/atest/testdata/running/private.resource
@@ -7,17 +7,20 @@ Public Keyword In Resource
 
 Private Keyword In Resource
     [Tags]    robot:private
-    Log    Hello
+    No Operation
 
 Call Private Keyword From Private 2 Resource
     Private Keyword In Resource 2
 
 Same Name
-    Log    Public
+    No Operation
 
 First Public Keyword With Nested Private Keyword
     Nested Private Keyword
 
 Nested Private Keyword
     [Tags]    robot:private
-    Log    Nested private
+    No Operation
+
+Possible Keyword
+    No Operation

--- a/atest/testdata/running/private.resource
+++ b/atest/testdata/running/private.resource
@@ -14,3 +14,10 @@ Call Private Keyword From Private 2 Resource
 
 Same Name
     Log    Public
+
+First Public Keyword With Nested Private Keyword
+    Nested Private Keyword
+
+Nested Private Keyword
+    [Tags]    robot:private
+    Log    Nested private

--- a/atest/testdata/running/private.resource
+++ b/atest/testdata/running/private.resource
@@ -1,0 +1,13 @@
+*** Settings ***
+Resource    private2.resource
+
+*** Keywords ***
+Public Keyword In Resource
+    Private Keyword In Resource
+
+Private Keyword In Resource
+    [Tags]    robot:private
+    Log    Hello
+
+Call Private Keyword From Private 2 Resource
+    Private Keyword In Resource 2

--- a/atest/testdata/running/private.resource
+++ b/atest/testdata/running/private.resource
@@ -11,3 +11,6 @@ Private Keyword In Resource
 
 Call Private Keyword From Private 2 Resource
     Private Keyword In Resource 2
+
+Same Name
+    Log    Public

--- a/atest/testdata/running/private.robot
+++ b/atest/testdata/running/private.robot
@@ -17,6 +17,9 @@ Invalid Usage With Resource Keyword
 Invalid Usage In Resource file
     Call Private Keyword From Private 2 Resource
 
+Keyword With Same Name Should Resolve Public Keyword
+    Same Name
+
 *** Keywords ***
 Public Keyword
     Private Keyword

--- a/atest/testdata/running/private.robot
+++ b/atest/testdata/running/private.robot
@@ -20,6 +20,14 @@ Invalid Usage In Resource file
 Keyword With Same Name Should Resolve Public Keyword
     Same Name
 
+If Both Keywords Are Private Raise Multiple Keywords Found
+    [Documentation]    FAIL Multiple keywords with name 'Nested Private Keyword' found. \
+    ...    Give the full name of the keyword you want to use:
+    ...    ${SPACE*4}private.Nested Private Keyword
+    ...    ${SPACE*4}private2.Nested Private Keyword
+    First Public Keyword With Nested Private Keyword
+    Second Public Keyword With Nested Private Keyword
+
 *** Keywords ***
 Public Keyword
     Private Keyword

--- a/atest/testdata/running/private.robot
+++ b/atest/testdata/running/private.robot
@@ -1,0 +1,26 @@
+*** Settings ***
+Resource    private.resource
+
+*** Test Cases ***
+Valid Usage With Local Keyword
+    Public Keyword
+
+Invalid Usage With Local Keyword
+    Private Keyword
+
+Valid Usage With Resource Keyword
+    Public Keyword In Resource
+
+Invalid Usage With Resource Keyword
+    Private Keyword In Resource
+
+Invalid Usage In Resource file
+    Call Private Keyword From Private 2 Resource
+
+*** Keywords ***
+Public Keyword
+    Private Keyword
+
+Private Keyword
+    [Tags]    robot:private
+    Log    Hello

--- a/atest/testdata/running/private.robot
+++ b/atest/testdata/running/private.robot
@@ -1,5 +1,7 @@
 *** Settings ***
 Resource    private.resource
+Resource    private2.resource
+Resource    private3.resource
 
 *** Test Cases ***
 Valid Usage With Local Keyword
@@ -28,10 +30,16 @@ If Both Keywords Are Private Raise Multiple Keywords Found
     First Public Keyword With Nested Private Keyword
     Second Public Keyword With Nested Private Keyword
 
+If One Keyword Is Public And Multiple Private Keywords Run Public And Warn
+    Keyword With One Public And Two Private Possible Keywords
+
 *** Keywords ***
 Public Keyword
     Private Keyword
 
 Private Keyword
     [Tags]    robot:private
-    Log    Hello
+    No Operation
+
+Keyword With One Public And Two Private Possible Keywords
+    Possible Keyword

--- a/atest/testdata/running/private2.resource
+++ b/atest/testdata/running/private2.resource
@@ -1,0 +1,4 @@
+*** Keywords ***
+Private Keyword In Resource 2
+    [Tags]    robot:private
+    Log    Private

--- a/atest/testdata/running/private2.resource
+++ b/atest/testdata/running/private2.resource
@@ -6,3 +6,10 @@ Private Keyword In Resource 2
 Same Name
     [Tags]    robot:private
     Log    Private
+
+Second Public Keyword With Nested Private Keyword
+    Nested Private Keyword
+
+Nested Private Keyword
+    [Tags]    robot:private
+    Log    Nested private

--- a/atest/testdata/running/private2.resource
+++ b/atest/testdata/running/private2.resource
@@ -1,15 +1,19 @@
 *** Keywords ***
 Private Keyword In Resource 2
     [Tags]    robot:private
-    Log    Private
+    No Operation
 
 Same Name
     [Tags]    robot:private
-    Log    Private
+    No Operation
 
 Second Public Keyword With Nested Private Keyword
     Nested Private Keyword
 
 Nested Private Keyword
     [Tags]    robot:private
-    Log    Nested private
+    No Operation
+
+Possible Keyword
+    [Tags]    robot:private
+    No Operation

--- a/atest/testdata/running/private2.resource
+++ b/atest/testdata/running/private2.resource
@@ -2,3 +2,7 @@
 Private Keyword In Resource 2
     [Tags]    robot:private
     Log    Private
+
+Same Name
+    [Tags]    robot:private
+    Log    Private

--- a/atest/testdata/running/private3.resource
+++ b/atest/testdata/running/private3.resource
@@ -1,0 +1,4 @@
+*** Keywords ***
+Possible Keyword
+    [Tags]    robot:private
+    No Operation

--- a/doc/userguide/src/CreatingTestData/CreatingUserKeywords.rst
+++ b/doc/userguide/src/CreatingTestData/CreatingUserKeywords.rst
@@ -894,3 +894,27 @@ can also be a variable.
        [Teardown]    ${TEARDOWN}
 
 __ `test setup and teardown`_
+
+Private user keywords
+---------------------
+
+You can tag User Keywords as private to indicate that they should only
+be used in the file where they are created.
+
+To achieve this, tag them as `robot:private`.
+
+.. sourcecode:: robotframework
+
+   # resource_1.resource
+
+   *** Keywords ***
+   Public Keyword
+       Private Keyword
+
+   Private Keyword
+       [Tags]    robot:private
+       [Documentation]    This is a private keyword.
+       ...     It should only be used in keywords within the same file.
+       No Operation
+
+Private user keywords are new since Robot Framework 5.1

--- a/doc/userguide/src/CreatingTestData/CreatingUserKeywords.rst
+++ b/doc/userguide/src/CreatingTestData/CreatingUserKeywords.rst
@@ -905,8 +905,6 @@ To achieve this, tag them as `robot:private`.
 
 .. sourcecode:: robotframework
 
-   # resource_1.resource
-
    *** Keywords ***
    Public Keyword
        Private Keyword
@@ -916,5 +914,8 @@ To achieve this, tag them as `robot:private`.
        [Documentation]    This is a private keyword.
        ...     It should only be used in keywords within the same file.
        No Operation
+
+If there is both a private and a public User Keyword with the same name
+in the current scope, Robot Framework will execute the public one.
 
 Private user keywords are new since Robot Framework 5.1

--- a/doc/userguide/src/CreatingTestData/CreatingUserKeywords.rst
+++ b/doc/userguide/src/CreatingTestData/CreatingUserKeywords.rst
@@ -915,7 +915,8 @@ To achieve this, tag them as `robot:private`.
        ...     It should only be used in keywords within the same file.
        No Operation
 
-If there is both a private and a public User Keyword with the same name
-in the current scope, Robot Framework will execute the public one.
+If there is both a public and one or more private User Keywords with the same name
+in the current scope, Robot Framework will execute the public one. In addition to that,
+a warning will be emitted.
 
 Private user keywords are new since Robot Framework 5.1

--- a/src/robot/libdocpkg/htmlwriter.py
+++ b/src/robot/libdocpkg/htmlwriter.py
@@ -33,4 +33,4 @@ class LibdocModelWriter(ModelWriter):
         self.output.write('<script type="text/javascript">\n'
                           'libdoc = %s\n'
                           '</script>\n'
-                          % self.libdoc.to_json())
+                          % self.libdoc.to_json(include_private=False))

--- a/src/robot/libdocpkg/model.py
+++ b/src/robot/libdocpkg/model.py
@@ -108,7 +108,7 @@ class LibraryDoc:
                 type_doc.doc = formatter.html(type_doc.doc)
         self.doc_format = 'HTML'
 
-    def to_dictionary(self):
+    def to_dictionary(self, include_private=False):
         return {
             'specversion': 1,
             'name': self.name,
@@ -122,7 +122,8 @@ class LibraryDoc:
             'lineno': self.lineno,
             'tags': list(self.all_tags),
             'inits': [init.to_dictionary() for init in self.inits],
-            'keywords': [kw.to_dictionary() for kw in self.keywords],
+            'keywords': [kw.to_dictionary() for kw in self.keywords
+                        if include_private or not kw.private],
             # 'dataTypes' was deprecated in RF 5, 'typedoc' should be used instead.
             'dataTypes': self._get_data_types(self.type_docs),
             'typedocs': [t.to_dictionary() for t in sorted(self.type_docs)]
@@ -136,8 +137,8 @@ class LibraryDoc:
             'typedDicts': [t.to_dictionary(legacy=True) for t in typed_dicts]
         }
 
-    def to_json(self, indent=None):
-        data = self.to_dictionary()
+    def to_json(self, indent=None, include_private=True):
+        data = self.to_dictionary(include_private)
         return json.dumps(data, indent=indent)
 
 
@@ -170,6 +171,10 @@ class KeywordDoc(Sortable):
     @shortdoc.setter
     def shortdoc(self, shortdoc):
         self._shortdoc = shortdoc
+
+    @property
+    def private(self):
+        return 'robot:private' in self.tags
 
     @property
     def deprecated(self):

--- a/src/robot/running/context.py
+++ b/src/robot/running/context.py
@@ -108,6 +108,13 @@ class _ExecutionContext:
             self.namespace.end_user_keyword()
             self.user_keywords.pop()
 
+    def warn_on_invalid_private_call(self, handler):
+        if 'robot:private' in handler.tags:
+            parent = self.user_keywords[-1] if self.user_keywords else None
+            if not parent or parent.source != handler.source:
+                self.warn(f"Keyword '{handler.longname}' is private and should only "
+                          f"be called by keywords in the same file.")
+
     @contextmanager
     def timeout(self, timeout):
         self._add_timeout(timeout)

--- a/src/robot/running/namespace.py
+++ b/src/robot/running/namespace.py
@@ -320,6 +320,7 @@ class KeywordStore:
         if not found:
             return None
         if len(found) > 1:
+            found = self._remove_private_keywords(found)
             found = self._get_runner_based_on_search_order(found)
         if len(found) == 1:
             return found[0]
@@ -337,6 +338,12 @@ class KeywordStore:
         if len(found) == 1:
             return found[0]
         self._raise_multiple_keywords_found(name, found)
+
+    def _remove_private_keywords(self, runners):
+        for runner in runners:
+            if 'robot:private' in runner.tags:
+                runners.remove(runner)
+        return runners
 
     def _get_runner_based_on_search_order(self, runners):
         for libname in self.search_order:

--- a/src/robot/running/userkeywordrunner.py
+++ b/src/robot/running/userkeywordrunner.py
@@ -52,6 +52,7 @@ class UserKeywordRunner:
         assignment = VariableAssignment(kw.assign)
         result = self._get_result(kw, assignment, context.variables)
         with StatusReporter(kw, result, context, run):
+            context.warn_on_invalid_private_call(self._handler)
             with assignment.assigner(context) as assigner:
                 if run:
                     return_value = self._run(context, kw.args, result)

--- a/src/robot/running/userkeywordrunner.py
+++ b/src/robot/running/userkeywordrunner.py
@@ -44,6 +44,10 @@ class UserKeywordRunner:
         return self._handler.libname
 
     @property
+    def tags(self):
+        return self._handler.tags
+
+    @property
     def arguments(self):
         """:rtype: :py:class:`robot.running.arguments.ArgumentSpec`"""
         return self._handler.arguments

--- a/src/robot/running/userkeywordrunner.py
+++ b/src/robot/running/userkeywordrunner.py
@@ -33,6 +33,7 @@ class UserKeywordRunner:
     def __init__(self, handler, name=None):
         self._handler = handler
         self.name = name or handler.name
+        self.pre_run_messages = None
 
     @property
     def longname(self):
@@ -77,6 +78,9 @@ class UserKeywordRunner:
                              type=kw.type)
 
     def _run(self, context, args, result):
+        if self.pre_run_messages:
+            for message in self.pre_run_messages:
+                context.output.message(message)
         variables = context.variables
         args = self._resolve_arguments(args, variables)
         with context.user_keyword(self._handler):
@@ -216,6 +220,9 @@ class UserKeywordRunner:
             self._dry_run(context, kw.args, result)
 
     def _dry_run(self, context, args, result):
+        if self.pre_run_messages:
+            for message in self.pre_run_messages:
+                context.output.message(message)
         self._resolve_arguments(args)
         with context.user_keyword(self._handler):
             timeout = self._get_timeout()


### PR DESCRIPTION
Resolves #430.
- User keywords can now be marked as private by tagging them `robot:private`.
- Using them in resources within the same file is fine and intended
- Using them in a test case in the same file or in a user keyword in another file will cause a warning
- Keywords tagged as `robot:private` are removed from libdoc's html output
- They are, however, still included in libdoc's spec files, for other tools to pick up on them
- If there is both a public and a private User Keyword with the same name in the current scope, Robot Framework will execute the public one

