### PR TITLE
User guide: Update inheritance example

### DIFF
--- a/doc/userguide/src/ExtendingRobotFramework/CreatingTestLibraries.rst
+++ b/doc/userguide/src/ExtendingRobotFramework/CreatingTestLibraries.rst
@@ -3262,10 +3262,12 @@ inheritance. This is illustrated by the example below that adds new
 .. sourcecode:: python
 
    from SeleniumLibrary import SeleniumLibrary
+   from SeleniumLibrary.base import keyword
 
 
    class ExtendedSeleniumLibrary(SeleniumLibrary):
 
+       @keyword
        def title_should_start_with(self, expected):
            title = self.get_title()
            if not title.startswith(expected):


### PR DESCRIPTION
The current version of the inheritance example does not work, because `SeleniumLibrary` needs `keyword` decoration for implemented methods to be recognized as Robot Framework keywords.

Either update according to my changes or switch to some other example that does not require decoration.

https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#using-inheritance