### PR TITLE
Adds Portuguese pt-pt translations.

### DIFF
--- a/atest/robot/parsing/translations.robot
+++ b/atest/robot/parsing/translations.robot
@@ -20,6 +20,14 @@ Invalid
     ...    .*${USAGE TIP}
     Should Match Regexp    ${result.stderr}    (?s)^\\[ ERROR \\] ${error}$
 
+Portuguese language test case
+    Run Tests    --lang pt    parsing/portuguese_test.robot
+    Validate Translations
+
+Portuguese language task
+    Run Tests    --lang pt-pt    parsing/portuguese_task.robot
+    Validate Translations
+
 *** Keywords ***
 Validate Translations
     Should Be Equal    ${SUITE.doc}                   Suite documentation.

--- a/atest/testdata/parsing/portuguese.resource
+++ b/atest/testdata/parsing/portuguese.resource
@@ -1,0 +1,9 @@
+*** Definição ***
+Documentação       Example documentation.
+
+*** Variável ***
+${RESOURCE FILE}    variable in resource file
+
+*** Palavra-Chave ***
+Keyword In Resource
+    No Operation

--- a/atest/testdata/parsing/portuguese_task.robot
+++ b/atest/testdata/parsing/portuguese_task.robot
@@ -1,0 +1,60 @@
+*** Definições ***
+Documentação                  Suite documentation.
+Metadados                     Metadata    Value
+Inicialização de Suíte        Suite Setup
+Finalização de Suíte          Suite Teardown
+Inicialização de Tarefa       Test Setup
+Finalização de Tarefa         Test Teardown
+Modelo de Tarefa              Test Template
+Tempo Limite de Teste         1 minute
+Etiquetas de Tarefas          test    tags
+Etiquetas de Palavra-Chave    keyword    tags
+Biblioteca                    OperatingSystem
+Recurso                       portuguese.resource
+Variável                      variables.py
+
+*** Variáveis ***
+${VARIABLE}         variable value
+
+*** Tarefas ***
+Test without settings
+    Nothing to see here
+
+Test with settings
+    [Documentação]     Test documentation.
+    [Etiquetas]        own tag
+    [Inicialização]    NONE
+    [Finalização]      NONE
+    [Modelo]           NONE
+    [Tempo Limite]     NONE
+    Keyword            ${VARIABLE}
+
+*** Palavras-Chave ***
+Suite Setup
+    Directory Should Exist    ${CURDIR}
+
+Suite Teardown
+    Keyword In Resource
+
+Test Setup
+    Should Be Equal    ${VARIABLE}         variable value
+    Should Be Equal    ${RESOURCE FILE}    variable in resource file
+    Should Be Equal    ${VARIABLE FILE}    variable in variable file
+
+Test Teardown
+    No Operation
+
+Test Template
+    [Argumentos]    ${message}
+    Log    ${message}
+
+Keyword
+    [Documentação]     Keyword documentation.
+    [Argumentos]       ${arg}
+    [Etiquetas]        own tag
+    [Tempo Limite]     1h
+    Should Be Equal    ${arg}    ${VARIABLE}
+    [Finalização]      No Operation
+
+*** Comentários ***
+Ignored comments.

--- a/atest/testdata/parsing/portuguese_test.robot
+++ b/atest/testdata/parsing/portuguese_test.robot
@@ -1,0 +1,60 @@
+*** Definições ***
+Documentação                  Suite documentation.
+Metadados                     Metadata    Value
+Inicialização de Suíte        Suite Setup
+Finalização de Suíte          Suite Teardown
+Inicialização de Teste        Test Setup
+Finalização de Teste          Test Teardown
+Modelo de Teste               Test Template
+Tempo Limite de Teste         1 minute
+Etiquetas de Testes           test    tags
+Etiquetas de Palavra-Chave    keyword    tags
+Biblioteca                    OperatingSystem
+Recurso                       portuguese.resource
+Variável                      variables.py
+
+*** Variáveis ***
+${VARIABLE}         variable value
+
+*** Casos de Teste ***
+Test without settings
+    Nothing to see here
+
+Test with settings
+    [Documentação]     Test documentation.
+    [Etiquetas]        own tag
+    [Inicialização]    NONE
+    [Finalização]      NONE
+    [Modelo]           NONE
+    [Tempo Limite]     NONE
+    Keyword            ${VARIABLE}
+
+*** Palavras-Chave ***
+Suite Setup
+    Directory Should Exist    ${CURDIR}
+
+Suite Teardown
+    Keyword In Resource
+
+Test Setup
+    Should Be Equal    ${VARIABLE}         variable value
+    Should Be Equal    ${RESOURCE FILE}    variable in resource file
+    Should Be Equal    ${VARIABLE FILE}    variable in variable file
+
+Test Teardown
+    No Operation
+
+Test Template
+    [Argumentos]    ${message}
+    Log    ${message}
+
+Keyword
+    [Documentação]     Keyword documentation.
+    [Argumentos]       ${arg}
+    [Etiquetas]        own tag
+    [Tempo Limite]     1h
+    Should Be Equal    ${arg}    ${VARIABLE}
+    [Finalização]      No Operation
+
+*** Comentários ***
+Ignored comments.

--- a/src/robot/conf/languages.py
+++ b/src/robot/conf/languages.py
@@ -191,3 +191,35 @@ class Fi(Language):
     timeout = 'Aikaraja'
     arguments = 'Argumentit'
     bdd_prefixes = {'Oletetaan', 'Kun', 'Niin', 'Ja', 'Mutta'}
+
+
+class Pt(Language):
+    """Portuguese pt-pt"""
+    # https://robotframework.crowdin.com/robot-framework
+    # 2022/07/12
+    setting_headers = {'Definição', 'Definições'}
+    variable_headers = {'Variável', 'Variáveis'}
+    test_case_headers = {'Caso de Teste', 'Casos de Teste'}
+    task_headers = {'Tarefa', 'Tarefas'}
+    keyword_headers = {'Palavra-Chave', 'Palavras-Chave'}
+    comment_headers = {'Comentário', 'Comentários'}
+    library = 'Biblioteca'
+    resource = 'Recurso'
+    variables = 'Variável'
+    documentation = 'Documentação'
+    metadata = 'Metadados'
+    suite_setup = 'Inicialização de Suíte'
+    suite_teardown = 'Finalização de Suíte'
+    test_setup = 'Inicialização de Teste'
+    test_teardown = 'Finalização de Teste'
+    test_template = 'Modelo de Teste'
+    test_timeout = 'Tempo Limite de Teste'
+    test_tags = 'Etiquetas de Testes'
+    keyword_tags = 'Etiquetas de Palavra-Chave'
+    tags = 'Etiquetas'
+    setup = 'Inicialização'
+    teardown = 'Finalização'
+    template = 'Modelo'
+    timeout = 'Tempo Limite'
+    arguments = 'Argumentos'
+    bdd_prefixes = {'Dado', 'Quando', 'Então', 'E', 'Mas'}


### PR DESCRIPTION
Tests are failing because of three words values.

@pekkaklarck In the cases we have an article there will be three words, and seems the parser is not linking it ;)

I tried the pt-pt variant and it was not accepted. Will the pt-br be accepted, for the class PtBr?

Example: 
Test Cases --> Cases of Test --> Casos de Teste