### PR TITLE
document current behaviour of robot:continue-on-failure not affecting `[Setup]` behaviour

### DIFF
--- a/atest/robot/running/continue_on_failure_tag.robot
+++ b/atest/robot/running/continue_on_failure_tag.robot
@@ -129,3 +129,8 @@ Test recursive-stop-recursive-continue
 Test recursive-stop-recursive-continue-recursive-stop
     Check Test Case    ${TESTNAME}
 
+Test test setup with continue-on-failure
+    Check Test Case    ${TESTNAME}
+
+Test test setup with recursive-continue-on-failure
+    Check Test Case    ${TESTNAME}

--- a/atest/testdata/running/continue_on_failure_tag.robot
+++ b/atest/testdata/running/continue_on_failure_tag.robot
@@ -350,6 +350,21 @@ Test recursive-stop-recursive-continue-recursive-stop
     Failure in user keyword with recursive continue tag    run_kw=Failure in user keyword with recursive stop tag
     Fail    2
 
+Test test setup with continue-on-failure
+    [Documentation]    FAIL Setup failed:\n
+    ...    setup-1
+    [Tags]      robot:continue-on-failure
+    [Setup]     test setup
+    Fail    should-not-run
+
+Test test setup with recursive-continue-on-failure
+    [Documentation]    FAIL Setup failed:\n${HEADER}\n\n
+    ...    1) setup-1\n\n
+    ...    2) setup-2
+    [Tags]      robot:recursive-continue-on-failure
+    [Setup]     test setup
+    Fail    should-not-run
+
 *** Keywords ***
 Failure in user keyword with continue tag
     [Arguments]    ${run_kw}=No Operation
@@ -447,3 +462,7 @@ run-kw-and-continue failure in user keyword with stop tag
     Fail    kw10b
     Log    This is not executed
     Fail    kw10c
+
+test setup
+    Fail    setup-1
+    Fail    setup-2

--- a/doc/userguide/src/ExecutingTestCases/TestExecution.rst
+++ b/doc/userguide/src/ExecutingTestCases/TestExecution.rst
@@ -474,6 +474,11 @@ keywords in the following example are executed:
        Should be Equal    5    6
        Log    This is executed
 
+Setting `robot:continue-on-failure` or `robot:recursive-continue-on-failure` in a
+test case does NOT alter the behaviour of a failure in the keyword(s) executed
+as part of the `[Setup]`:setting:: The test case is marked as failed and no
+test case keywords are executed.
+
 .. note:: The `robot:continue-on-failure` and `robot:recursive-continue-on-failure`
           tags are new in Robot Framework 4.1. They do not work properly with
           `WHILE` loops prior to Robot Framework 5.1.


### PR DESCRIPTION
fixes #4404