### PR TITLE
Change german Variables to plural form

### DIFF
--- a/src/robot/conf/languages.py
+++ b/src/robot/conf/languages.py
@@ -352,7 +352,7 @@ class De(Language):
     comment_headers = {'Kommentar', 'Kommentare'}
     library = 'Bibliothek'
     resource = 'Ressource'
-    variables = 'Variable'
+    variables = 'Variablen'
     documentation = 'Dokumentation'
     metadata = 'Metadaten'
     suite_setup = 'Suitevorbereitung'


### PR DESCRIPTION
In german the plural form of the english word "Variables" is "Variablen". Maybe we can change this ;-)