### PR TITLE
Added countdown timer capability to the public logging API for test libraries

### DIFF
--- a/src/robot/api/logger.py
+++ b/src/robot/api/logger.py
@@ -65,6 +65,7 @@ Example
         logger.info('<i>This</i> is a boring example.', html=True)
 """
 
+import time
 import logging
 
 from robot.output import librarylogger
@@ -138,3 +139,12 @@ def console(msg, newline=True, stream='stdout'):
     argument value ``'stderr'``.
     """
     librarylogger.console(msg, newline, stream)
+
+
+def countdown(time_in_second):
+    while time_in_second:
+        minutes, seconds = divmod(time_in_second, 60)
+        timer = '{:02d}:{:02d}'.format(minutes, seconds)
+        librarylogger.countdown(timer)
+        time.sleep(1)
+        time_in_second -= 1

--- a/src/robot/output/librarylogger.py
+++ b/src/robot/output/librarylogger.py
@@ -27,7 +27,6 @@ from robot.utils import console_encode
 from .logger import LOGGER
 from .loggerhelper import Message
 
-
 LOGGING_THREADS = ('MainThread', 'RobotFrameworkTimeoutThread')
 
 
@@ -69,6 +68,14 @@ def console(msg, newline=True, stream='stdout'):
     msg = str(msg)
     if newline:
         msg += '\n'
+    stream = sys.__stdout__ if stream.lower() != 'stderr' else sys.__stderr__
+    stream.write(console_encode(msg, stream=stream))
+    stream.flush()
+
+
+def countdown(timer, stream='stdout'):
+    msg = str(timer)
+    msg += '\r'
     stream = sys.__stdout__ if stream.lower() != 'stderr' else sys.__stderr__
     stream.write(console_encode(msg, stream=stream))
     stream.flush()


### PR DESCRIPTION
- `logger.countdown(3)` will sleep for 180 seconds and print the countdown timer to the standard output
- looks like this in console - ![robotframework_ss](https://user-images.githubusercontent.com/38760033/188431913-c40fca90-1672-41e0-a84f-21b4f8e7a3ac.png)
- Could be of help when two test cases depends on a time based event and you could know how much time will it take for the next test to execute.