### PR TITLE
Fixes issue #4464 when naming conflicts happen in libdoc datatypes

### DIFF
--- a/src/robot/htmldata/libdoc/libdoc.html
+++ b/src/robot/htmldata/libdoc/libdoc.html
@@ -561,7 +561,7 @@ ${name}
   <span class="arg-type">
     {{each types}}
       {{if $value in $data.typedocs}}
-          &lt;<a style="cursor: pointer;" class="type" title="Click to show type information" onclick="showModal(${$data.typedocs[$value]})">${$value}</a>&gt;
+          &lt;<a style="cursor: pointer;" class="type" title="Click to show type information" onclick="showModal(document.querySelector('#${$data.typedocs[$value]}'))">${$value}</a>&gt;
       {{else}}
           &lt;<span class="type">${$value}</span>&gt;
       {{/if}}


### PR DESCRIPTION
Datatype `Proxy` conflicts with function `Proxy` therefore type doc can not be shown in HTML.