### PR TITLE
Update the minimum release notes in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ you can simply run::
 For more detailed installation instructions, including installing Python, see
 `<INSTALL.rst>`__.
 
-Robot Framework requires Python 3.6 or newer and runs also on `PyPy <http://pypy.org>`_.
+Robot Framework requires Python 3.7 or newer and runs also on `PyPy <http://pypy.org>`_.
 If you need to use Python 2, `Jython <http://jython.org>`_ or
 `IronPython <http://ironpython.net>`_, you can use `Robot Framework 4.1.3`__.
 


### PR DESCRIPTION
The minimum version should be modified to 3.7+. Because the 3.6 version has already ended support. Version 3.7 will also end support on June 27 next year.