### PR TITLE
Explain Sleep's default value is seconds

### DIFF
--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -2891,7 +2891,9 @@ class _Misc(_BuiltInBase):
         ``time`` may be either a number or a time string. Time strings are in
         a format such as ``1 day 2 hours 3 minutes 4 seconds 5milliseconds`` or
         ``1d 2h 3m 4s 5ms``, and they are fully explained in an appendix of
-        Robot Framework User Guide. Optional `reason` can be used to explain why
+        Robot Framework User Guide. Providing a value without specifying minutes
+        or seconds, defaults to seconds.
+        Optional `reason` can be used to explain why
         sleeping is necessary. Both the time slept and the reason are logged.
 
         Examples:


### PR DESCRIPTION
I know from experience that when you provide a value for the `Sleep` keyword, that this value defaults to seconds.
However, when I tried to verify that in the documentation and in the keyword's definition, I couldn't.
That is the reason I am raising this PR. Since it confused me, it will confuse others as well.

Feel free to reject my PR and write it with your own wording. It doesn't matter much to me, as long as we explicitly mention it in Sleep's docstring.