### PR TITLE
Make it possible to generate libdocs for suites

### DIFF
--- a/src/robot/libdocpkg/robotbuilder.py
+++ b/src/robot/libdocpkg/robotbuilder.py
@@ -95,7 +95,7 @@ class ResourceDocBuilder:
 
     def _import_resource(self, path):
         ast = ResourceFileBuilder(process_curdir=False).build(
-            self._find_resource_file(path))
+            self._find_resource_file(path), True)
         return UserLibrary(ast)
 
     def _find_resource_file(self, path):

--- a/src/robot/libdocpkg/robotbuilder.py
+++ b/src/robot/libdocpkg/robotbuilder.py
@@ -83,10 +83,10 @@ class LibraryDocBuilder:
 class ResourceDocBuilder:
 
     def build(self, path):
-        res = self._import_resource(path)
+        res, type = self._import_resource(path)
         libdoc = LibraryDoc(name=res.name,
                             doc=self._get_doc(res),
-                            type='RESOURCE',
+                            type=type,
                             scope='GLOBAL',
                             source=res.source,
                             lineno=1)
@@ -96,7 +96,7 @@ class ResourceDocBuilder:
     def _import_resource(self, path):
         ast = ResourceFileBuilder(process_curdir=False).build(
             self._find_resource_file(path), True)
-        return UserLibrary(ast)
+        return UserLibrary(ast), ast.type
 
     def _find_resource_file(self, path):
         if os.path.isfile(path):

--- a/src/robot/running/builder/builders.py
+++ b/src/robot/running/builder/builders.py
@@ -201,9 +201,9 @@ class ResourceFileBuilder:
         self.lang = lang
         self.process_curdir = process_curdir
 
-    def build(self, source):
+    def build(self, source, parse_as_suite=False):
         LOGGER.info("Parsing resource file '%s'." % source)
-        resource = self._parse(source)
+        resource = self._parse(source, parse_as_suite)
         if resource.imports or resource.variables or resource.keywords:
             LOGGER.info("Imported resource file '%s' (%d keywords)."
                         % (source, len(resource.keywords)))
@@ -211,7 +211,7 @@ class ResourceFileBuilder:
             LOGGER.warn("Imported resource file '%s' is empty." % source)
         return resource
 
-    def _parse(self, source):
+    def _parse(self, source, parse_as_suite=False):
         if os.path.splitext(source)[1].lower() in ('.rst', '.rest'):
-            return RestParser(self.lang, self.process_curdir).parse_resource_file(source)
-        return RobotParser(self.lang, self.process_curdir).parse_resource_file(source)
+            return RestParser(self.lang, self.process_curdir).parse_resource_file(source, parse_as_suite)
+        return RobotParser(self.lang, self.process_curdir).parse_resource_file(source, parse_as_suite)

--- a/src/robot/running/builder/parsers.py
+++ b/src/robot/running/builder/parsers.py
@@ -78,9 +78,13 @@ class RobotParser(BaseParser):
     def _get_source(self, source):
         return source
 
-    def parse_resource_file(self, source):
-        model = get_resource_model(self._get_source(source), data_only=True,
-                                   curdir=self._get_curdir(source), lang=self.lang)
+    def parse_resource_file(self, source, parse_as_suite=False):
+        if parse_as_suite:
+            model = get_model(self._get_source(source), data_only=True,
+                                    curdir=self._get_curdir(source), lang=self.lang)
+        else:
+            model = get_resource_model(self._get_source(source), data_only=True,
+                                    curdir=self._get_curdir(source), lang=self.lang)
         resource = ResourceFile(source=source)
         ErrorReporter(source).visit(model)
         ResourceBuilder(resource).visit(model)

--- a/src/robot/running/builder/transformers.py
+++ b/src/robot/running/builder/transformers.py
@@ -145,6 +145,10 @@ class ResourceBuilder(NodeVisitor):
     def visit_Keyword(self, node):
         KeywordBuilder(self.resource, self.defaults).visit(node)
 
+    def visit_TestCaseSection(self, node):
+        self.resource.type = "SUITE"
+
+
 
 class TestCaseBuilder(NodeVisitor):
 

--- a/src/robot/running/model.py
+++ b/src/robot/running/model.py
@@ -435,6 +435,7 @@ class ResourceFile:
         self.imports = []
         self.keywords = []
         self.variables = []
+        self.type="RESOURCE"
 
     @setter
     def imports(self, imports):


### PR DESCRIPTION
With the current implementation, if you want to create a libdoc for a `.robot` file that contains test cases, you get the error: `Resource file with 'Test Cases' section is invalid`
This PR make it possible to create also libdocs for this files.