### PR TITLE
add a newline to start_test output message

### DIFF
--- a/src/robot/output/console/verbose.py
+++ b/src/robot/output/console/verbose.py
@@ -46,6 +46,7 @@ class VerboseOutput:
 
     def start_test(self, test):
         self._writer.info(test.name, test.doc)
+        self._writer.stdout('\n')
         self._running_test = True
 
     def end_test(self, test):


### PR DESCRIPTION
`robot.output.console.verbose.start_test` should only output the name and docs to the console. However, it does not put a newline at the end of the line, so the first use of `Log To Console` lands on that line as well.

robot version: 5 and up
python version: 3.10.4
OS: Windows 10 Enterprise

Given the test cases:
![Screenshot 2022-12-06 083907](https://user-images.githubusercontent.com/119923080/205852814-06dc4bc5-e05a-4388-aa6d-d35ab3e5f135.png)

the output looks like this:
![Screenshot 2022-12-06 083840](https://user-images.githubusercontent.com/119923080/205852857-119f66c2-92c0-400a-9378-7f4198b010df.png)

The proposed change makes it look like this:
![Screenshot 2022-12-06 083618](https://user-images.githubusercontent.com/119923080/205852922-741ec6c4-f0e1-49a8-acf4-c384946f3297.png)

 believe this looks cleaner and is what a user would expect of logging.
The `--dotted` and `--quiet` options are unaffected.

The downside of this change is that tests that don't log to console print the name of the test twice:
![Screenshot 2022-12-06 091538](https://user-images.githubusercontent.com/119923080/205857191-9b5a027b-c305-4bb9-aac0-1c9909267b52.png)

Fixing that would take more invasive changes.