### PR TITLE
Support long command line options with hyphens like --pre-run-modifier

### DIFF
--- a/atest/robot/cli/console/colors_and_width.robot
+++ b/atest/robot/cli/console/colors_and_width.robot
@@ -17,7 +17,7 @@ Console Colors On
     Outputs should have ANSI colors when not on Windows
 
 Console Colors ANSI
-    Run Tests With Colors    --ConsoleColors AnSi
+    Run Tests With Colors    --Console-Colors AnSi
     Outputs should have ANSI colors
 
 Invalid Console Colors

--- a/atest/robot/cli/runner/argumentfile.robot
+++ b/atest/robot/cli/runner/argumentfile.robot
@@ -33,7 +33,7 @@ Argument File
 Two Argument Files
     Create Argument File    ${ARGFILE}    --metadata A1:Value1    --metadata A2:to be overridden
     Create Argument File    ${ARGFILE2}    --metadata A2:Value2
-    ${result} =    Run Tests    -A ${ARGFILE} --ArgumentFile ${ARGFILE2}    ${TESTFILE}
+    ${result} =    Run Tests    -A ${ARGFILE} --Argument-File ${ARGFILE2}    ${TESTFILE}
     Execution Should Have Succeeded    ${result}
     Should Be Equal    ${SUITE.metadata['A1']}    Value1
     Should Be Equal    ${SUITE.metadata['A2']}    Value2

--- a/atest/robot/cli/runner/rerunfailedsuites_corners.robot
+++ b/atest/robot/cli/runner/rerunfailedsuites_corners.robot
@@ -7,7 +7,7 @@ ${RUN FAILED FROM}    %{TEMPDIR}${/}run-failed-output.xml
 
 *** Test Cases ***
 Runs everything when output is set to NONE
-    Run Tests  --ReRunFailedSuites NoNe  cli/runfailed/onlypassing
+    Run Tests  --Re-Run-Failed-Suites NoNe  cli/runfailed/onlypassing
     File Should Exist  ${OUTFILE}
     Check Test Case    Passing
 

--- a/atest/robot/cli/runner/run_empty_suite.robot
+++ b/atest/robot/cli/runner/run_empty_suite.robot
@@ -17,7 +17,7 @@ No tests in directory
      [Teardown]    Remove directory    ${NO TESTS DIR}
 
 Empty suite after filtering by tags
-     Run empty suite   --RunEmptySuite --include nonex   ${TEST FILE}
+     Run empty suite   --Run-Empty-Suite --include nonex   ${TEST FILE}
 
 Empty suite after filtering by names
      Run empty suite   --RunEmptySuite --test nonex   ${TEST FILE}

--- a/doc/userguide/src/ExecutingTestCases/BasicUsage.rst
+++ b/doc/userguide/src/ExecutingTestCases/BasicUsage.rst
@@ -125,9 +125,9 @@ and shortened options are practical when executing test cases
 manually, but long options are recommended in `start-up scripts`_,
 because they are easier to understand.
 
-The long option format is case-insensitive, which facilitates writing option
-names in an easy-to-read format. For example, :option:`--SuiteStatLevel`
-is equivalent to, but easier to read than :option:`--suitestatlevel`.
+The long option format is case-insensitive and hyphen-insensitive, which facilitates writing option
+names in an easy-to-read format. For example, :option:`--SuiteStatLevel` and :option:`--suite-stat-level`
+are equivalent to, but easier to read than :option:`--suitestatlevel`.
 
 Setting option values
 ~~~~~~~~~~~~~~~~~~~~~

--- a/src/robot/utils/argumentparser.py
+++ b/src/robot/utils/argumentparser.py
@@ -356,7 +356,9 @@ class ArgFileParser:
         for opt in self._options:
             start = opt + '=' if opt.startswith('--') else opt
             for index, arg in enumerate(args):
-                normalized_arg = arg.lower() if opt.startswith('--') else arg
+                normalized_arg = (
+                    '--' + arg.lower().replace('-', '') if opt.startswith('--') else arg
+                )
                 # Handles `--argumentfile foo` and `-A foo`
                 if normalized_arg == opt and index + 1 < len(args):
                     return args[index+1], slice(index, index+2)

--- a/src/robot/utils/argumentparser.py
+++ b/src/robot/utils/argumentparser.py
@@ -165,20 +165,20 @@ class ArgumentParser:
         return opts, args
 
     def _parse_args(self, args):
-        args = [self._lowercase_long_option(a) for a in args]
+        args = [self._normalize_long_option(a) for a in args]
         try:
             opts, args = getopt.getopt(args, self._short_opts, self._long_opts)
         except getopt.GetoptError as err:
             raise DataError(err.msg)
         return self._process_opts(opts), self._glob_args(args)
 
-    def _lowercase_long_option(self, opt):
+    def _normalize_long_option(self, opt):
         if not opt.startswith('--'):
             return opt
         if '=' not in opt:
-            return opt.lower()
+            return '--%s' % opt.lower().replace('-', '')
         opt, value = opt.split('=', 1)
-        return '%s=%s' % (opt.lower(), value)
+        return '--%s=%s' % (opt.lower().replace('-', ''), value)
 
     def _process_possible_argfile(self, args):
         options = ['--argumentfile']
@@ -232,7 +232,7 @@ class ArgumentParser:
             res = self._opt_line_re.match(line)
             if res:
                 self._create_option(short_opts=[o[1] for o in res.group(1).split()],
-                                    long_opt=res.group(3).lower(),
+                                    long_opt=res.group(3).lower().replace('-', ''),
                                     takes_arg=bool(res.group(4)),
                                     is_multi=bool(res.group(5)))
 

--- a/utest/utils/test_argumentparser.py
+++ b/utest/utils/test_argumentparser.py
@@ -102,6 +102,11 @@ class TestArgumentParserInit(unittest.TestCase):
         self.assert_short_opts('fB', ap)
         self.assert_long_opts(['foo', 'bar'], ap)
 
+    def test_long_options_with_hyphens(self):
+        ap = ArgumentParser(' -f --f-o-o\n -B --bar--\n')
+        self.assert_short_opts('fB', ap)
+        self.assert_long_opts(['foo', 'bar'], ap)
+
     def test_same_option_multiple_times(self):
         for usage in [' --foo\n --foo\n',
                       ' --foo\n -f --Foo\n',
@@ -195,6 +200,21 @@ class TestArgumentParserParseArgs(unittest.TestCase):
         opts, args = self.ap.parse_args('--VariAble=X:y --VARIABLE=ZzZ'.split())
         assert_equal(opts['variable'], ['X:y', 'ZzZ'])
         assert_equal(args, [])
+
+    def test_long_options_with_hyphens(self):
+        opts, args = self.ap.parse_args('--var-i-a--ble x-y ----toggle---- arg'.split())
+        assert_equal(opts['variable'], ['x-y'])
+        assert_equal(opts['toggle'], True)
+        assert_equal(args, ['arg'])
+
+    def test_long_options_with_hyphens_with_equal_sign(self):
+        opts, args = self.ap.parse_args('--var-i-a--ble=x-y ----variable----=--z--'.split())
+        assert_equal(opts['variable'], ['x-y', '--z--'])
+        assert_equal(args, [])
+
+    def test_long_options_with_hyphens_only(self):
+        args = '-----=value1'.split()
+        assert_raises(DataError, self.ap.parse_args, args)
 
     def test_split_pythonpath(self):
         ap = ArgumentParser('ignored')

--- a/utest/utils/test_argumentparser.py
+++ b/utest/utils/test_argumentparser.py
@@ -256,7 +256,7 @@ class TestArgumentParserParseArgs(unittest.TestCase):
         ap = ArgumentParser('''Usage:
  -h --help
  -v --version
- --argumentfile path
+ --Argument-File path
  --option
 ''')
         opts, args = ap.parse_args(['--option'])


### PR DESCRIPTION
Hello everyone,

This PR fixes #4547.

It adds support for the usual CLI options as well as the special "--argumentfile" option (#2535).

I added a few unit tests and edited some existing acceptance tests.
I also updated the user guide to briefly describe the new behavior.

Thank you in advance for taking the time to review this PR, and please let me know if I need to fix anything. 