### PR TITLE
(🎁) Support only vararg in custom converters

### DIFF
--- a/atest/robot/keywords/type_conversion/custom_converters.robot
+++ b/atest/robot/keywords/type_conversion/custom_converters.robot
@@ -33,6 +33,9 @@ Failing conversion
 `None` as strict converter
     Check Test Case    ${TESTNAME}
 
+Only vararg
+    Check Test Case    ${TESTNAME}
+
 With library as argument to converter
     Check Test Case    ${TESTNAME}
 

--- a/atest/testdata/keywords/type_conversion/CustomConverters.py
+++ b/atest/testdata/keywords/type_conversion/CustomConverters.py
@@ -78,6 +78,11 @@ class AcceptSubscriptedGenerics:
         self.sum = sum(numbers)
 
 
+class OnlyVarArg:
+    def __init__(self, *varargs):
+        self.value = varargs[0]
+
+
 class Strict:
     pass
 
@@ -96,7 +101,7 @@ class TooManyArgs:
 
 
 class NoPositionalArg:
-    def __init__(self, *varargs):
+    def __init__(self, *, args):
         pass
 
 
@@ -113,6 +118,7 @@ ROBOT_LIBRARY_CONVERTERS = {Number: string_to_int,
                             ClassAsConverter: ClassAsConverter,
                             ClassWithHintsAsConverter: ClassWithHintsAsConverter,
                             AcceptSubscriptedGenerics: AcceptSubscriptedGenerics,
+                            OnlyVarArg: OnlyVarArg,
                             Strict: None,
                             Invalid: 666,
                             TooFewArgs: TooFewArgs,
@@ -120,6 +126,11 @@ ROBOT_LIBRARY_CONVERTERS = {Number: string_to_int,
                             NoPositionalArg: NoPositionalArg,
                             KwOnlyNotOk: KwOnlyNotOk,
                             'Bad': int}
+
+
+def only_var_arg(argument: OnlyVarArg, expected):
+    assert isinstance(argument, OnlyVarArg)
+    assert argument.value == expected
 
 
 def number(argument: Number, expected: int = 0):

--- a/atest/testdata/keywords/type_conversion/custom_converters.robot
+++ b/atest/testdata/keywords/type_conversion/custom_converters.robot
@@ -69,6 +69,9 @@ Failing conversion
     Conversion should fail    Strict    wrong type
     ...    type=Strict    error=TypeError: Only Strict instances are accepted, got string.
 
+Only vararg
+    Only var arg    10    10
+
 With library as argument to converter
     String    ${123}
 

--- a/src/robot/running/arguments/customconverters.py
+++ b/src/robot/running/arguments/customconverters.py
@@ -78,7 +78,7 @@ class ConverterInfo:
             raise TypeError(f'Custom converters must be callable, converter for '
                             f'{type_name(type_)} is {type_name(converter)}.')
         spec = cls._get_arg_spec(converter)
-        arg_type = spec.types.get(spec.positional[0])
+        arg_type = spec.types.get(spec.positional and spec.positional[0] or spec.var_positional)
         if arg_type is None:
             accepts = ()
         elif is_union(arg_type):
@@ -96,7 +96,7 @@ class ConverterInfo:
             required = seq2str([a for a in spec.positional if a not in spec.defaults])
             raise TypeError(f"Custom converters cannot have more than two mandatory "
                             f"arguments, '{converter.__name__}' has {required}.")
-        if not spec.positional:
+        if not spec.maxargs:
             raise TypeError(f"Custom converters must accept one positional argument, "
                             f"'{converter.__name__}' accepts none.")
         if spec.named_only and set(spec.named_only) - set(spec.defaults):
@@ -109,3 +109,4 @@ class ConverterInfo:
         if not self.library:
             return self.converter(value)
         return self.converter(value, self.library.get_instance())
+


### PR DESCRIPTION
This allows registering a custom converter that only has vararg arguments