### PR TITLE
(🎁) literal converter

### DIFF
--- a/atest/robot/keywords/type_conversion/literals.robot
+++ b/atest/robot/keywords/type_conversion/literals.robot
@@ -1,0 +1,22 @@
+*** Settings ***
+Suite Setup       Run Tests    ${EMPTY}    keywords/type_conversion/literals.robot
+Resource          atest_resource.robot
+
+*** Test Cases ***
+Literal
+    Check Test Case    ${TESTNAME}
+
+Invalid Literal
+    Check Test Case    ${TESTNAME}
+
+External literal
+    Check Test Case    ${TESTNAME}
+
+literal string is not an alias
+    Check Test Case    ${TESTNAME}
+
+Argument not matching
+    Check Test Case    ${TESTNAME}
+
+Nested Literal
+    Check Test Case    ${TESTNAME}

--- a/atest/testdata/keywords/type_conversion/literals.py
+++ b/atest/testdata/keywords/type_conversion/literals.py
@@ -1,0 +1,35 @@
+from enum import Enum
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal  # python < 3.8
+from typing_extensions import Literal as ExtLiteral
+
+
+class MyEnum(Enum):
+    a = 1
+
+
+def literal_of_all_types(argument: Literal[1, True, MyEnum.a, 'b', None, b'd'], expected,
+                         enum=False):
+    assert argument == (eval(expected) if enum else expected)
+
+
+def invalid_literal(_argument: Literal[1.1]):
+    pass
+
+
+def literal_string_is_not_an_alias(argument: Literal['int']):
+    pass
+
+
+L = Literal[Literal[1], ExtLiteral[2]]
+
+
+def nested_literal(argument: Literal[L]):
+    ...
+
+
+def external_literal(argument: ExtLiteral[L]):
+    ...

--- a/atest/testdata/keywords/type_conversion/literals.robot
+++ b/atest/testdata/keywords/type_conversion/literals.robot
@@ -1,0 +1,42 @@
+*** Settings ***
+Library           literals.py
+Resource          conversion.resource
+
+*** Test Cases ***
+Literal
+    [Template]    Literal of all types
+    1          ${1}
+    True       ${True}
+    a          MyEnum.a    enum=True
+    b          b
+    None       ${None}
+    d          ${{b'd'}}
+
+Nested Literal
+    nested literal    1
+    Conversion Should Fail    Nested Literal    3    type=Literal[1, 2]
+
+Invalid Literal
+    TRY
+        Invalid literal    1.1
+    EXCEPT      TypeError: 1.1 (float) is not valid as an argument for Literal
+        No Operation
+    ELSE
+        Fail    This should literally never work
+    END
+
+External literal
+    External literal    1
+    Conversion Should Fail    External literal    3    type=Literal[1, 2]
+
+literal string is not an alias
+    Conversion Should Fail    Literal string is not an alias    1    type=Literal['int']
+    Conversion Should Fail    Literal string is not an alias    ${{int}}    type=Literal['int']    arg_type=integer
+    Literal string is not an alias    int
+
+Argument not matching
+    [Template]    Conversion Should Fail
+    Literal of all types    ${2}    ${2}      type=Literal[1, True, MyEnum.a, 'b', None, b'd']  arg_type=integer
+    Literal of all types    ${{type('Custom', (), {})()}}    1
+    ...                                       type=Literal[1, True, MyEnum.a, 'b', None, b'd']    arg_type=Custom
+    Literal of all types    c    b     type=Literal[1, True, MyEnum.a, 'b', None, b'd']

--- a/src/robot/utils/robottypes.py
+++ b/src/robot/utils/robottypes.py
@@ -36,6 +36,15 @@ except ImportError:
 else:
     typeddict_types += (type(ExtTypedDict('Dummy', {})),)
 
+try:
+    from typing import Literal as LiteralType
+except ImportError:  # Python < 3.8
+    try:
+        from typing_extensions import Literal as LiteralType
+    except ImportError:  # no typing_extensions
+        LiteralType = ()
+
+
 from .platform import PY_VERSION
 
 

--- a/utest/requirements.txt
+++ b/utest/requirements.txt
@@ -1,4 +1,4 @@
 # External Python modules required by unit tests.
 docutils >= 0.10
 jsonschema
-typing_extensions; python_version <= '3.8'
+typing_extensions


### PR DESCRIPTION
This adds a converter for `typing.Literal` / `typing_extensions.Literal` type annotations.

- converts and validates correct values
- checks that values in the annotation conform to the pep

TODO:
- I think there is an issue where `typing_extensions` aren't flattening nested literals or something.