### PR TITLE
Run Keyword And Warn Message

### DIFF
--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -2085,6 +2085,26 @@ class _RunKeyword(_BuiltInBase):
         status, message = self.run_keyword_and_ignore_error(name, *args)
         if status == 'FAIL':
             logger.warn("Executing keyword '%s' failed:\n%s" % (name, message))
+        return status, 
+        
+    @run_keyword_variant(resolve=0)
+    def run_keyword_and_warn_message(self, success_msg, failure_msg, name, *args):
+        """Runs the given keyword with given arguments and logs a warning.
+
+        This keyword is similar to `Run Keyword And Warn On Failure` but a message is 
+        always logged to the *Test Execution Errors* - wether the keyword fails or succeeds. 
+        It makes the result of this keyword more visible and gives quick access to it. 
+
+        The keyword name and arguments work as in `Run Keyword`.
+
+        Example:
+        | `Run Keyword And Warn Message` | SOLVED: 4663 | PENDING: https://github.com/robotframework/robotframework/issues/4663 | Keyword | args | 
+        """
+        status, message = self.run_keyword_and_ignore_error(name, *args)
+        if status == 'FAIL':
+            logger.warn("%s - Executing keyword '%s' failed: %s" % (failure_msg, name, message))
+        else:
+            logger.warn("%s" % (success_msg))
         return status, message
 
     @run_keyword_variant(resolve=0, dry_run=True)


### PR DESCRIPTION
I have this functionality in my user-defined keyword and I thought about submitting it here.

When we are dealing with non blocking bugs (in the context of an application), we want them not to block the execution of the test and be visible in the logs so we know they are still pending. We then use the Builtin `Run Keyword And Warn On Failure`. It is great because it gives visibility and a quick link to the Keyword from within the "Test Execution Errors" section.

Though, this Keyword does not provide the ability to add a custom message to give further information and context. For example, when dealing with many bugs across an application - some of them impacting several areas and therefore present in several test suites - it's nice to be able to display the ticket id and/or link for a quick access to the bug description. 

This Keyword would be an enhancement of `Run Keyword And Warn On Failure` providing the ability to add a message when the keyword fails or succeeds.

![image](https://user-images.githubusercontent.com/15931812/220954889-8fff8028-39ce-42f0-a056-cd6cd0cc03bb.png)

![image](https://user-images.githubusercontent.com/15931812/220955156-18214054-0c17-4a4d-abf9-754e3a0f73f1.png)

This raises the question of log levels and the ability to customise the label and the colors.