### PR TITLE
Issues/4536

### DIFF
--- a/atest/robot/standard_libraries/builtin/log.robot
+++ b/atest/robot/standard_libraries/builtin/log.robot
@@ -54,6 +54,11 @@ Log also to console
     Stdout Should Contain    Hello, console!\n
     Stdout Should Contain    ${HTML}\n
 
+CONSOLE pseudo level
+    ${tc} =    Check Test Case    ${TEST NAME}
+    Check Log Message    ${tc.kws[0].msgs[0]}    Hello, info and console!
+    Stdout Should Contain    Hello, info and console!\n
+    
 repr=True
     ${tc} =    Check Test Case    ${TEST NAME}
     Check Log Message    ${tc.kws[0].msgs[0]}    The 'repr' argument of 'BuiltIn.Log' is deprecated. Use 'formatter=repr' instead.    WARN

--- a/atest/robot/test_libraries/print_logging.robot
+++ b/atest/robot/test_libraries/print_logging.robot
@@ -19,9 +19,10 @@ Logging with levels
     Check Log Message    ${tc.kws[0].msgs[1]}    Trace message    TRACE
     Check Log Message    ${tc.kws[0].msgs[2]}    Debug message    DEBUG
     Check Log Message    ${tc.kws[0].msgs[3]}    Info message     INFO
-    Check Log Message    ${tc.kws[0].msgs[4]}    Html message     INFO    html=True
-    Check Log Message    ${tc.kws[0].msgs[5]}    Warn message     WARN
-    Check Log Message    ${tc.kws[0].msgs[6]}    Error message    ERROR
+    Check Log Message    ${tc.kws[0].msgs[4]}    Console message     INFO
+    Check Log Message    ${tc.kws[0].msgs[5]}    Html message     INFO    html=True
+    Check Log Message    ${tc.kws[0].msgs[6]}    Warn message     WARN
+    Check Log Message    ${tc.kws[0].msgs[7]}    Error message    ERROR
     Check Log Message    ${ERRORS[0]}    Warn message     WARN
     Check Log Message    ${ERRORS[1]}    Error message    ERROR
 
@@ -63,6 +64,11 @@ Logging HTML
     Check Log Message    ${tc.kws[1].msgs[2]}    This is not html <br>    INFO
     Check Log Message    ${tc.kws[2].msgs[0]}    <i>Hello, stderr!!</i>    HTML
     Stderr Should Contain    *HTML* <i>Hello, stderr!!</i>
+
+Logging CONSOLE
+    ${tc} =    Check Test Case    ${TEST NAME}
+    Check Log Message    ${tc.kws[0].msgs[0]}    Hello info and console!
+    Stdout Should Contain    Hello info and console!
 
 FAIL is not valid log level
     ${tc} =    Check Test Case    ${TEST NAME}

--- a/atest/testdata/standard_libraries/builtin/log.robot
+++ b/atest/testdata/standard_libraries/builtin/log.robot
@@ -51,6 +51,9 @@ Log also to console
     Log    Hello, console!    console=yepyep    html=false
     Log    ${HTML}    debug    enable both html    and console
 
+CONSOLE pseudo level
+    Log    Hello, info and console!    console
+
 repr=True
     [Setup]    Set Log Level    DEBUG
     Log    Nothing special here    repr=false

--- a/atest/testdata/test_libraries/PrintLib.py
+++ b/atest/testdata/test_libraries/PrintLib.py
@@ -16,6 +16,10 @@ def print_html_to_stderr():
     print('*HTML* <i>Hello, stderr!!</i>', file=sys.stderr)
 
 
+def print_console():
+    print('*CONSOLE* Hello info and console!')
+
+
 def print_with_all_levels():
-    for level in 'TRACE DEBUG INFO HTML WARN ERROR'.split():
+    for level in 'TRACE DEBUG INFO CONSOLE HTML WARN ERROR'.split():
         print('*%s* %s message' % (level, level.title()))

--- a/atest/testdata/test_libraries/print_logging.robot
+++ b/atest/testdata/test_libraries/print_logging.robot
@@ -45,5 +45,8 @@ Logging HTML
     Print Many HTML Lines
     Print HTML To Stderr
 
+Logging CONSOLE
+    Print Console
+
 FAIL is not valid log level
     Print    *FAIL* is not failure

--- a/doc/userguide/src/ExtendingRobotFramework/CreatingTestLibraries.rst
+++ b/doc/userguide/src/ExtendingRobotFramework/CreatingTestLibraries.rst
@@ -2169,7 +2169,8 @@ messages, specify the log level explicitly by embedding the level into
 the message in the format `*LEVEL* Actual log message`, where
 `*LEVEL*` must be in the beginning of a line and `LEVEL` is
 one of the available logging levels `TRACE`, `DEBUG`,
-`INFO`, `WARN`, `ERROR` and `HTML`.
+`INFO`, `WARN`, `ERROR`, `HTML` and `CONSOLE`. Log level `CONSOLE`
+is new in Robot Framework 6.1.
 
 Errors and warnings
 '''''''''''''''''''
@@ -2274,7 +2275,8 @@ In most cases, the `INFO` level is adequate. The levels below it,
 These messages are normally not shown, but they can facilitate debugging
 possible problems in the library itself. The `WARN` or `ERROR` level can
 be used to make messages more visible and `HTML` is useful if any
-kind of formatting is needed.
+kind of formatting is needed. Level `CONSOLE` can be used when the
+message needs to shown both in console and in the log file.
 
 The following examples clarify how logging with different levels
 works.
@@ -2288,6 +2290,7 @@ works.
    print('This will be part of the previous message.')
    print('*INFO* This is a new message.')
    print('*INFO* This is <b>normal text</b>.')
+   print('*CONSOLE* This logs into console and log file.')
    print('*HTML* This is <b>bold</b>.')
    print('*HTML* <a href="http://robotframework.org">Robot Framework</a>')
 
@@ -2323,6 +2326,11 @@ works.
        <td class="time">16:18:42.123</td>
        <td class="info level">INFO</td>
        <td class="msg">This is &lt;b&gt;normal text&lt;/b&gt;.</td>
+     </tr>
+     <tr>
+       <td class="time">16:18:42.123</td>
+       <td class="info level">INFO</td>
+       <td class="msg">This logs into console and log file.</td>
      </tr>
      <tr>
        <td class="time">16:18:42.123</td>

--- a/src/robot/api/logger.py
+++ b/src/robot/api/logger.py
@@ -75,8 +75,12 @@ def write(msg, level='INFO', html=False):
     """Writes the message to the log file using the given level.
 
     Valid log levels are ``TRACE``, ``DEBUG``, ``INFO`` (default), ``WARN``, and
-    ``ERROR``. Additionally it is possible to use ``HTML`` pseudo log level that
-    logs the message as HTML using the ``INFO`` level.
+    ``ERROR``. Additionally there are two pseudo log levels: ``HTML``and ``CONSOLE``.
+    ``HTML`` pseudo log level logs the message as HTML using the ``INFO`` level.
+    ``CONSOLE`` pseudo log level logs the message to stdout and to the log file
+    using ``INFO`` level. Pseudo log levels are are converted to ``INFO`` level if
+    Robot Framework is not running when calling this function.
+    Log level ``CONSOLE`` is new in Robot Framework 6.1.
 
     Instead of using this method, it is generally better to use the level
     specific methods such as ``info`` and ``debug`` that have separate
@@ -89,6 +93,7 @@ def write(msg, level='INFO', html=False):
         level = {'TRACE': logging.DEBUG // 2,
                  'DEBUG': logging.DEBUG,
                  'INFO': logging.INFO,
+                 'CONSOLE': logging.INFO,
                  'HTML': logging.INFO,
                  'WARN': logging.WARN,
                  'ERROR': logging.ERROR}[level]

--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -2980,6 +2980,7 @@ class _Misc(_BuiltInBase):
         Messages below the current active log level are ignored. See
         `Set Log Level` keyword and ``--loglevel`` command line option
         for more details about setting the level.
+        Log level CONSOLE is new in Robot Framework 6.1.
 
         Messages logged with the WARN or ERROR levels will be automatically
         visible also in the console and in the Test Execution Errors section
@@ -2993,11 +2994,11 @@ class _Misc(_BuiltInBase):
         the ``html`` argument is using the HTML pseudo log level. It logs
         the message as HTML using the INFO level.
 
-        If the ``console`` argument is true, the message will be written to
-        the console where test execution was started from in addition to
-        the log file. This keyword always uses the standard output stream
-        and adds a newline after the written message. Use `Log To Console`
-        instead if either of these is undesirable,
+        If the ``console`` argument is true or the log level is ``CONSOLE``,
+        the message will be written to the console where test execution was
+        started from in addition to the log file. This keyword always uses the
+        standard output stream and adds a newline after the written message.
+        Use `Log To Console` instead if either of these is undesirable,
     Mimic html section...
         
 
@@ -3020,6 +3021,7 @@ class _Misc(_BuiltInBase):
         | Log | <b>Hello</b>, world! | HTML     |   | # Same as above.         |
         | Log | <b>Hello</b>, world! | DEBUG    | html=true | # DEBUG as HTML. |
         | Log | Hello, console!   | console=yes | | # Log also to the console. |
+        | Log | Hello, console!   | CONSOLE     | | # Log also to the console. |
         | Log | Null is \x00    | formatter=repr | | # Log ``'Null is \x00'``. |
 
         See `Log Many` if you want to log multiple messages in one go, and

--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -2976,7 +2976,7 @@ class _Misc(_BuiltInBase):
             repr='DEPRECATED', formatter='str'):
         r"""Logs the given message with the given level.
 
-        Valid levels are TRACE, DEBUG, INFO (default), HTML, WARN, and ERROR.
+        Valid levels are TRACE, DEBUG, INFO (default), CONSOLE, HTML, WARN, and ERROR.
         Messages below the current active log level are ignored. See
         `Set Log Level` keyword and ``--loglevel`` command line option
         for more details about setting the level.
@@ -2998,6 +2998,8 @@ class _Misc(_BuiltInBase):
         the log file. This keyword always uses the standard output stream
         and adds a newline after the written message. Use `Log To Console`
         instead if either of these is undesirable,
+    Mimic html section...
+        
 
         The ``formatter`` argument controls how to format the string
         representation of the message. Possible values are ``str`` (default),

--- a/src/robot/output/loggerhelper.py
+++ b/src/robot/output/loggerhelper.py
@@ -13,9 +13,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import sys
+
 from robot.errors import DataError
 from robot.model import Message as BaseMessage
-from robot.utils import get_timestamp, is_string, safe_str
+from robot.utils import get_timestamp, is_string, safe_str, console_encode
 
 
 LEVELS = {
@@ -28,6 +30,15 @@ LEVELS = {
   'DEBUG' : 1,
   'TRACE' : 0,
 }
+
+
+def write_to_console(msg, newline=True, stream='stdout'):
+    msg = str(msg)
+    if newline:
+        msg += '\n'
+    stream = sys.__stdout__ if stream.lower() != 'stderr' else sys.__stderr__
+    stream.write(console_encode(msg, stream=stream))
+    stream.flush()
 
 
 class AbstractLogger:
@@ -96,6 +107,8 @@ class Message(BaseMessage):
         level = level.upper()
         if level == 'HTML':
             return 'INFO', True
+        if level == 'CONSOLE':
+            level = 'INFO'
         if level not in LEVELS:
             raise DataError("Invalid log level '%s'." % level)
         return level, html

--- a/src/robot/output/stdoutlogsplitter.py
+++ b/src/robot/output/stdoutlogsplitter.py
@@ -16,15 +16,14 @@
 import re
 
 from robot.utils import format_time
-
-from .loggerhelper import Message
+from .loggerhelper import Message, write_to_console
 
 
 class StdoutLogSplitter:
     """Splits messages logged through stdout (or stderr) into Message objects"""
 
     _split_from_levels = re.compile(r'^(?:\*'
-                                    r'(TRACE|DEBUG|INFO|HTML|WARN|ERROR)'
+                                    r'(TRACE|DEBUG|INFO|CONSOLE|HTML|WARN|ERROR)'
                                     r'(:\d+(?:\.\d+)?)?'  # Optional timestamp
                                     r'\*)', re.MULTILINE)
 
@@ -33,6 +32,9 @@ class StdoutLogSplitter:
 
     def _get_messages(self, output):
         for level, timestamp, msg in self._split_output(output):
+            if level == 'CONSOLE':
+                write_to_console(msg)
+                level = 'INFO'
             if timestamp:
                 timestamp = self._format_timestamp(timestamp[1:])
             yield Message(msg.strip(), level, timestamp=timestamp)

--- a/utest/api/test_logging_api.py
+++ b/utest/api/test_logging_api.py
@@ -85,6 +85,9 @@ class TestRedirectToPythonLogging(unittest.TestCase):
         logger.write("Joo", 'HTML')
         assert_equal(self.handler.messages, ['Foo', 'Doo', 'Joo'])
 
+    def test_logger_to_python_with_console(self):
+        logger.write("Foo", 'CONSOLE')
+        assert_equal(self.handler.messages, ['Foo'])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
https://github.com/robotframework/robotframework/issues/4536

Worked this one out with @pekkaklarck during Robocon Online.

In addition to what was implemented at Robocon Online I added `CONSOLE` level handling to `robot.api.logger.write()` when using it without RF execution context (contextful implementation was done during the session).
This was done to keep log level parity between contextful and contextless calls of the function.

I'm not sure if it makes sense to turn the contextless `robot.api.logger.write("message", "CONSOLE")` calls to `INFO` level but at least the behavior is documented for both the `HTML` and `CONSOLE` pseudo levels.