### PR TITLE
adding a simple test for the zipapp usage of robotframework

### DIFF
--- a/.github/workflows/acceptance_tests_cpython.yml
+++ b/.github/workflows/acceptance_tests_cpython.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           python -m zipapp -m "robot:run_cli" src -o robot.pyz -c
           python robot.pyz --output NONE atest/testdata/core/test_suite_dir
-        if:  ${{matrix.python-version >= 3.9 }}
+        if:  ${{matrix.python-version >= 3.9 || ${{matrix.python-version < 3.5 }}
 
       - name: Delete output.xml (on Win)
         run: |

--- a/.github/workflows/acceptance_tests_cpython.yml
+++ b/.github/workflows/acceptance_tests_cpython.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           python -m zipapp -m "robot:run_cli" src -o robot.pyz -c
           python robot.pyz --output NONE atest/testdata/core/test_suite_dir
-        if:  ${{matrix.python-version >= 3.9 || ${{matrix.python-version < 3.5 }}
+        if:  ${{matrix.python-version >= 3.9 || matrix.python-version < 3.5 }}
 
       - name: Delete output.xml (on Win)
         run: |

--- a/.github/workflows/acceptance_tests_cpython.yml
+++ b/.github/workflows/acceptance_tests_cpython.yml
@@ -88,6 +88,11 @@ jobs:
           ${{ matrix.set_display }}
           ${{ env.ATEST_PYTHON }} atest/run.py --interpreter ${{ env.BASE_PYTHON }} --exclude no-ci ${{ matrix.atest_args }} atest/robot
 
+      - name: Run zipapptest
+        run: |
+          python -m zipapp -m "robot:run_cli" src -o robot.pyz -c
+          python robot.pyz --output NONE atest/testdata/core/test_suite_dir
+
       - name: Delete output.xml (on Win)
         run: |
           Get-ChildItem atest/results -Include output.xml -Recurse | Remove-Item

--- a/.github/workflows/acceptance_tests_cpython.yml
+++ b/.github/workflows/acceptance_tests_cpython.yml
@@ -92,6 +92,7 @@ jobs:
         run: |
           python -m zipapp -m "robot:run_cli" src -o robot.pyz -c
           python robot.pyz --output NONE atest/testdata/core/test_suite_dir
+        if:  ${{matrix.python-version >= 3.9 }}
 
       - name: Delete output.xml (on Win)
         run: |

--- a/.github/workflows/acceptance_tests_cpython_pr.yml
+++ b/.github/workflows/acceptance_tests_cpython_pr.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           python -m zipapp -m "robot:run_cli" src -o robot.pyz -c
           python robot.pyz --output NONE atest/testdata/core/test_suite_dir
-        if:  ${{matrix.python-version >= 3.9 }}
+        if:  ${{matrix.python-version >= 3.9 || ${{matrix.python-version < 3.5 }}
 
       - name: Delete output.xml (on Win)
         run: |

--- a/.github/workflows/acceptance_tests_cpython_pr.yml
+++ b/.github/workflows/acceptance_tests_cpython_pr.yml
@@ -76,6 +76,11 @@ jobs:
           ${{ matrix.set_display }}
           ${{ env.ATEST_PYTHON }} atest/run.py --interpreter ${{ env.BASE_PYTHON }} --exclude no-ci ${{ matrix.atest_args }} atest/robot
 
+      - name: Run zipapptest
+        run: |
+          python -m zipapp -m "robot:run_cli" src -o robot.pyz -c
+          python robot.pyz --output NONE atest/testdata/core/test_suite_dir
+
       - name: Delete output.xml (on Win)
         run: |
           Get-ChildItem atest/results -Include output.xml -Recurse | Remove-Item

--- a/.github/workflows/acceptance_tests_cpython_pr.yml
+++ b/.github/workflows/acceptance_tests_cpython_pr.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           python -m zipapp -m "robot:run_cli" src -o robot.pyz -c
           python robot.pyz --output NONE atest/testdata/core/test_suite_dir
-        if:  ${{matrix.python-version >= 3.9 || ${{matrix.python-version < 3.5 }}
+        if:  ${{matrix.python-version >= 3.9 || matrix.python-version < 3.5 }}
 
       - name: Delete output.xml (on Win)
         run: |

--- a/.github/workflows/acceptance_tests_cpython_pr.yml
+++ b/.github/workflows/acceptance_tests_cpython_pr.yml
@@ -80,6 +80,7 @@ jobs:
         run: |
           python -m zipapp -m "robot:run_cli" src -o robot.pyz -c
           python robot.pyz --output NONE atest/testdata/core/test_suite_dir
+        if:  ${{matrix.python-version >= 3.9 }}
 
       - name: Delete output.xml (on Win)
         run: |


### PR DESCRIPTION
There is an ugly hack to detect which python versions are supposed to work with zipapps in github actions...

Once the minimum python version for robotframework is 3.7.:

We can eliminate this hack provided we support zipapps natively in robotframework (using importlib.resources.open_text for python < 3.9 and importlib.resources.files for python >= 3.9).

The choice to use importlib.resources.open_text for backwards compatibility once 3.6 is no longer supported would reduce the usage of __file__ in the part of robotframework which gets distributed as a wheel to.:

pythonpathsetter.py
utils/importer.py (using getattr)

Both places are not problematic for zipapps.