### PR TITLE
Add type hints for model.testcase

### DIFF
--- a/src/robot/model/testcase.py
+++ b/src/robot/model/testcase.py
@@ -122,7 +122,7 @@ class TestCase(ModelObject):
         return self._teardown
 
     @teardown.setter
-    def teardown(self, teardown: 'Keyword|None'):
+    def teardown(self, teardown: 'Keyword|Mapping|None'):
         self._teardown = create_fixture(teardown, self, Keyword.TEARDOWN)
 
     @property
@@ -201,9 +201,9 @@ class TestCase(ModelObject):
 class TestCases(ItemList[TestCase]):
     __slots__ = []
 
-    def __init__(self, test_class: Type[TestCase]= TestCase,
+    def __init__(self, test_class: Type[TestCase] = TestCase,
                  parent: 'TestSuite|None' = None,
-                  tests: 'Sequence[TestCase|Mapping]' = ()):
+                 tests: 'Sequence[TestCase|Mapping]' = ()):
         super().__init__(test_class, {'parent': parent}, tests)
 
     def _check_type_and_set_attrs(self, test):

--- a/src/robot/model/testcase.py
+++ b/src/robot/model/testcase.py
@@ -13,6 +13,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from pathlib import Path
+from typing import TYPE_CHECKING, Sequence, Type
+
 from robot.utils import setter
 
 from .body import Body
@@ -21,6 +24,10 @@ from .itemlist import ItemList
 from .keyword import Keyword, Keywords
 from .modelobject import ModelObject
 from .tags import Tags
+
+if TYPE_CHECKING:
+    from robot.model.testsuite import TestSuite
+    from robot.model.visitor import SuiteVisitor
 
 
 class TestCase(ModelObject):
@@ -34,8 +41,9 @@ class TestCase(ModelObject):
     repr_args = ('name',)
     __slots__ = ['parent', 'name', 'doc', 'timeout', 'lineno', '_setup', '_teardown']
 
-    def __init__(self, name='', doc='', tags=None, timeout=None, lineno=None,
-                 parent=None):
+    def __init__(self, name: str = '', doc: str = '', tags: Sequence[str] = (),
+                 timeout: 'str|None' = None, lineno: 'int|None' = None,
+                 parent: 'TestSuite|None' = None):
         self.name = name
         self.doc = doc
         self.tags = tags
@@ -43,21 +51,21 @@ class TestCase(ModelObject):
         self.lineno = lineno
         self.parent = parent
         self.body = None
-        self._setup = None
-        self._teardown = None
+        self._setup: 'Keyword|None' = None
+        self._teardown: 'Keyword|None' = None
 
     @setter
-    def body(self, body):
+    def body(self, body) -> Body:
         """Test body as a :class:`~robot.model.body.Body` object."""
         return self.body_class(self, body)
 
     @setter
-    def tags(self, tags):
+    def tags(self, tags: Sequence[str]) -> Tags:
         """Test tags as a :class:`~.model.tags.Tags` object."""
         return Tags(tags)
 
     @property
-    def setup(self):
+    def setup(self) -> Keyword:
         """Test setup as a :class:`~.model.keyword.Keyword` object.
 
         This attribute is a ``Keyword`` object also when a test has no setup
@@ -81,16 +89,16 @@ class TestCase(ModelObject):
         New in Robot Framework 4.0. Earlier setup was accessed like
         ``test.keywords.setup``.
         """
-        if self._setup is None and self:
+        if self._setup is None:
             self._setup = create_fixture(None, self, Keyword.SETUP)
         return self._setup
 
     @setup.setter
-    def setup(self, setup):
+    def setup(self, setup: 'Keyword|None'):
         self._setup = create_fixture(setup, self, Keyword.SETUP)
 
     @property
-    def has_setup(self):
+    def has_setup(self) -> bool:
         """Check does a suite have a setup without creating a setup object.
 
         A difference between using ``if test.has_setup:`` and ``if test.setup:``
@@ -104,21 +112,21 @@ class TestCase(ModelObject):
         return bool(self._setup)
 
     @property
-    def teardown(self):
+    def teardown(self) -> Keyword:
         """Test teardown as a :class:`~.model.keyword.Keyword` object.
 
         See :attr:`setup` for more information.
         """
-        if self._teardown is None and self:
+        if self._teardown is None:
             self._teardown = create_fixture(None, self, Keyword.TEARDOWN)
         return self._teardown
 
     @teardown.setter
-    def teardown(self, teardown):
+    def teardown(self, teardown: 'Keyword|None'):
         self._teardown = create_fixture(teardown, self, Keyword.TEARDOWN)
 
     @property
-    def has_teardown(self):
+    def has_teardown(self) -> bool:
         """Check does a test have a teardown without creating a teardown object.
 
         See :attr:`has_setup` for more information.
@@ -128,7 +136,7 @@ class TestCase(ModelObject):
         return bool(self._teardown)
 
     @property
-    def keywords(self):
+    def keywords(self) -> Keywords:
         """Deprecated since Robot Framework 4.0
 
         Use :attr:`body`, :attr:`setup` or :attr:`teardown` instead.
@@ -141,7 +149,7 @@ class TestCase(ModelObject):
         Keywords.raise_deprecation_error()
 
     @property
-    def id(self):
+    def id(self) -> str:
         """Test case id in format like ``s1-t3``.
 
         See :attr:`TestSuite.id <robot.model.testsuite.TestSuite.id>` for
@@ -154,17 +162,17 @@ class TestCase(ModelObject):
         return f'{self.parent.id}-t{index + 1}'
 
     @property
-    def longname(self):
+    def longname(self) -> str:
         """Test name prefixed with the long name of the parent suite."""
         if not self.parent:
             return self.name
         return f'{self.parent.longname}.{self.name}'
 
     @property
-    def source(self):
+    def source(self) -> 'Path|None':
         return self.parent.source if self.parent is not None else None
 
-    def visit(self, visitor):
+    def visit(self, visitor: 'SuiteVisitor'):
         """:mod:`Visitor interface <robot.model.visitor>` entry-point."""
         visitor.visit_test(self)
 
@@ -172,7 +180,8 @@ class TestCase(ModelObject):
         return self.name
 
     def to_dict(self):
-        data = {'name': self.name}
+        data = {}
+        data['name'] = self.name
         if self.doc:
             data['doc'] = self.doc
         if self.tags:
@@ -189,14 +198,16 @@ class TestCase(ModelObject):
         return data
 
 
-class TestCases(ItemList):
+class TestCases(ItemList[TestCase]):
     __slots__ = []
 
-    def __init__(self, test_class=TestCase, parent=None, tests=None):
+    def __init__(self, test_class: Type[TestCase]= TestCase,
+                 parent: 'TestSuite|None' = None, tests: Sequence[TestCase] = ()):
         super().__init__(test_class, {'parent': parent}, tests)
 
     def _check_type_and_set_attrs(self, test):
         test = super()._check_type_and_set_attrs(test)
-        for visitor in test.parent._visitors:
-            test.visit(visitor)
+        if test.parent:
+            for visitor in test.parent._visitors:
+                test.visit(visitor)
         return test

--- a/src/robot/model/testcase.py
+++ b/src/robot/model/testcase.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Sequence, Type
+from typing import Iterable, Mapping, Sequence, TYPE_CHECKING, Type
 
 from robot.utils import setter
 
@@ -50,12 +50,12 @@ class TestCase(ModelObject):
         self.timeout = timeout
         self.lineno = lineno
         self.parent = parent
-        self.body = None
+        self.body = []
         self._setup: 'Keyword|None' = None
         self._teardown: 'Keyword|None' = None
 
     @setter
-    def body(self, body) -> Body:
+    def body(self, body: 'Iterable[Keyword|Mapping]') -> Body:
         """Test body as a :class:`~robot.model.body.Body` object."""
         return self.body_class(self, body)
 
@@ -94,7 +94,7 @@ class TestCase(ModelObject):
         return self._setup
 
     @setup.setter
-    def setup(self, setup: 'Keyword|None'):
+    def setup(self, setup: 'Keyword|Mapping|None'):
         self._setup = create_fixture(setup, self, Keyword.SETUP)
 
     @property
@@ -176,10 +176,10 @@ class TestCase(ModelObject):
         """:mod:`Visitor interface <robot.model.visitor>` entry-point."""
         visitor.visit_test(self)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
         data = {}
         data['name'] = self.name
         if self.doc:
@@ -202,7 +202,8 @@ class TestCases(ItemList[TestCase]):
     __slots__ = []
 
     def __init__(self, test_class: Type[TestCase]= TestCase,
-                 parent: 'TestSuite|None' = None, tests: Sequence[TestCase] = ()):
+                 parent: 'TestSuite|None' = None,
+                  tests: 'Sequence[TestCase|Mapping]' = ()):
         super().__init__(test_class, {'parent': parent}, tests)
 
     def _check_type_and_set_attrs(self, test):

--- a/src/robot/model/testsuite.py
+++ b/src/robot/model/testsuite.py
@@ -148,7 +148,7 @@ class TestSuite(ModelObject):
         return self._setup
 
     @setup.setter
-    def setup(self, setup: 'Keyword | None'):
+    def setup(self, setup: 'Keyword|None'):
         self._setup = create_fixture(setup, self, Keyword.SETUP)
 
     @property
@@ -176,7 +176,7 @@ class TestSuite(ModelObject):
         return self._teardown
 
     @teardown.setter
-    def teardown(self, teardown: 'Keyword | None'):
+    def teardown(self, teardown: 'Keyword|None'):
         self._teardown = create_fixture(teardown, self, Keyword.TEARDOWN)
 
     @property

--- a/src/robot/model/testsuite.py
+++ b/src/robot/model/testsuite.py
@@ -148,7 +148,7 @@ class TestSuite(ModelObject):
         return self._setup
 
     @setup.setter
-    def setup(self, setup: 'Keyword|None'):
+    def setup(self, setup: 'Keyword|Mapping|None'):
         self._setup = create_fixture(setup, self, Keyword.SETUP)
 
     @property
@@ -176,7 +176,7 @@ class TestSuite(ModelObject):
         return self._teardown
 
     @teardown.setter
-    def teardown(self, teardown: 'Keyword|None'):
+    def teardown(self, teardown: 'Keyword|Mapping|None'):
         self._teardown = create_fixture(teardown, self, Keyword.TEARDOWN)
 
     @property


### PR DESCRIPTION
1. Added type hints to `model.testcase`
2. minor change to `model.testsuite` to keep consistent with the convention of no spaces inside stringified type hints