### PR TITLE
add xmlschema to dev dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ wheel
 docutils
 pygments >= 2.8
 pydantic
+xmlschema


### PR DESCRIPTION
I was unable to run the acceptance test suite locally (fedora, python 3.11) with the currently defined dependencies in `requirements-dev.txt`. In my case, `xmlschema` was needed to in addition to the other dependencies.