### PR TITLE
Add the @set_type_hints decorator

### DIFF
--- a/src/robot/model/__init__.py
+++ b/src/robot/model/__init__.py
@@ -37,7 +37,7 @@ from .modifier import ModelModifier
 from .namepatterns import SuiteNamePatterns, TestNamePatterns
 from .statistics import Statistics
 from .tags import Tags, TagPattern, TagPatterns
-from .testcase import TestCase
-from .testsuite import TestSuite
+from .testcase import TestCase, TestCases
+from .testsuite import TestSuite, TestSuites
 from .totalstatistics import TotalStatisticsBuilder
 from .visitor import SuiteVisitor

--- a/src/robot/model/itemlist.py
+++ b/src/robot/model/itemlist.py
@@ -17,7 +17,7 @@ from functools import total_ordering
 from typing import (Any, Iterable, Iterator, MutableSequence, overload, TYPE_CHECKING,
                     Type, TypeVar)
 
-from robot.utils import copy_signature, known_at_runtime, type_name
+from robot.utils import copy_signature, KnownAtRuntime, type_name
 
 from .modelobject import DataDict
 
@@ -46,7 +46,7 @@ class ItemList(MutableSequence[T]):
 
     __slots__ = ['_item_class', '_common_attrs', '_items']
     # TypeVar T needs to be applied to a variable to be compatible with @copy_signature
-    item_type: Type[T] = known_at_runtime
+    item_type: Type[T] = KnownAtRuntime
 
     def __init__(self, item_class: Type[T],
                  common_attrs: 'dict[str, Any]|None' = None,

--- a/src/robot/model/itemlist.py
+++ b/src/robot/model/itemlist.py
@@ -17,8 +17,7 @@ from functools import total_ordering
 from typing import (Any, Iterable, Iterator, MutableSequence, overload, TYPE_CHECKING,
                     Type, TypeVar)
 
-from robot.utils import type_name
-from ..utils import copy_signature
+from robot.utils import copy_signature, known_at_runtime, type_name
 
 from .modelobject import DataDict
 
@@ -46,8 +45,8 @@ class ItemList(MutableSequence[T]):
     """
 
     __slots__ = ['_item_class', '_common_attrs', '_items']
-    # TypeVar T needs to be applied to a variable to be compatible with @set_type_hints
-    item_type: Type[T] = Any
+    # TypeVar T needs to be applied to a variable to be compatible with @copy_signature
+    item_type: Type[T] = known_at_runtime
 
     def __init__(self, item_class: Type[T],
                  common_attrs: 'dict[str, Any]|None' = None,
@@ -60,7 +59,7 @@ class ItemList(MutableSequence[T]):
 
     @copy_signature(item_type)
     def create(self, *args, **kwargs) -> T:
-        """Create a new item using the provided aguments."""
+        """Create a new item using the provided arguments."""
         return self.append(self._item_class(*args, **kwargs))
 
     def append(self, item: 'T|DataDict') -> T:

--- a/src/robot/model/itemlist.py
+++ b/src/robot/model/itemlist.py
@@ -18,6 +18,7 @@ from typing import (Any, Iterable, Iterator, MutableSequence, overload, TYPE_CHE
                     Type, TypeVar)
 
 from robot.utils import type_name
+from ..utils import copy_signature
 
 from .modelobject import DataDict
 
@@ -45,6 +46,8 @@ class ItemList(MutableSequence[T]):
     """
 
     __slots__ = ['_item_class', '_common_attrs', '_items']
+    # TypeVar T needs to be applied to a variable to be compatible with @set_type_hints
+    item_type: Type[T] = Any
 
     def __init__(self, item_class: Type[T],
                  common_attrs: 'dict[str, Any]|None' = None,
@@ -55,8 +58,9 @@ class ItemList(MutableSequence[T]):
         if items:
             self.extend(items)
 
+    @copy_signature(item_type)
     def create(self, *args, **kwargs) -> T:
-        """Create a new item using the provided arguments."""
+        """Create a new item using the provided aguments."""
         return self.append(self._item_class(*args, **kwargs))
 
     def append(self, item: 'T|DataDict') -> T:

--- a/src/robot/model/testcase.py
+++ b/src/robot/model/testcase.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 
 from pathlib import Path
-from typing import Any, Sequence, Type, TYPE_CHECKING
+from typing import Any, Iterable, Sequence, Type, TYPE_CHECKING, TypeVar
 
 from robot.utils import setter
 
@@ -199,13 +199,14 @@ class TestCase(ModelObject):
         data['body'] = self.body.to_dicts()
         return data
 
+TC = TypeVar("TC", bound=TestCase)
 
-class TestCases(ItemList[TestCase]):
+class TestCases(ItemList[TC]):
     __slots__ = []
 
-    def __init__(self, test_class: Type[TestCase] = TestCase,
+    def __init__(self, test_class: Type[TC] = TestCase,
                  parent: 'TestSuite|None' = None,
-                 tests: 'Sequence[TestCase|DataDict]' = ()):
+                 tests: 'Sequence[TC|DataDict]' = ()):
         super().__init__(test_class, {'parent': parent}, tests)
 
     def _check_type_and_set_attrs(self, test):

--- a/src/robot/model/testcase.py
+++ b/src/robot/model/testcase.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 
 from pathlib import Path
-from typing import Any, Iterable, Sequence, Type, TYPE_CHECKING, TypeVar
+from typing import Any, Sequence, Type, TYPE_CHECKING, TypeVar
 
 from robot.utils import setter
 
@@ -28,6 +28,9 @@ from .tags import Tags
 if TYPE_CHECKING:
     from .testsuite import TestSuite
     from .visitor import SuiteVisitor
+
+
+TC = TypeVar("TC", bound="TestCase")
 
 
 class TestCase(ModelObject):
@@ -199,7 +202,6 @@ class TestCase(ModelObject):
         data['body'] = self.body.to_dicts()
         return data
 
-TC = TypeVar("TC", bound=TestCase)
 
 class TestCases(ItemList[TC]):
     __slots__ = []

--- a/src/robot/model/testsuite.py
+++ b/src/robot/model/testsuite.py
@@ -156,7 +156,7 @@ class TestSuite(ModelObject):
 
     @setter
     def suites(self, suites: 'Sequence[TestSuite|DataDict]') -> 'TestSuites[TestSuite]':
-        return TestSuites["TestSuite"](self.__class__, self, suites)
+        return TestSuites['TestSuite'](self.__class__, self, suites)
 
     @setter
     def tests(self, tests: 'Sequence[TestCase|DataDict]') -> TestCases[TestCase]:
@@ -375,7 +375,7 @@ class TestSuite(ModelObject):
             data['suites'] = self.suites.to_dicts()
         return data
 
-TS = TypeVar("TS", bound=TestSuite)
+TS = TypeVar('TS', bound=TestSuite)
 
 class TestSuites(ItemList[TS]):
     __slots__ = []

--- a/src/robot/model/testsuite.py
+++ b/src/robot/model/testsuite.py
@@ -15,7 +15,7 @@
 
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Iterator, Sequence, Type
+from typing import Any, Iterator, Sequence, Type, TypeVar
 
 from robot.utils import seq2str, setter
 
@@ -155,12 +155,12 @@ class TestSuite(ModelObject):
         return Metadata(metadata)
 
     @setter
-    def suites(self, suites: 'Sequence[TestSuite|DataDict]') -> 'TestSuites':
-        return TestSuites(self.__class__, self, suites)
+    def suites(self, suites: 'Sequence[TestSuite|DataDict]') -> 'TestSuites[TestSuite]':
+        return TestSuites["TestSuite"](self.__class__, self, suites)
 
     @setter
-    def tests(self, tests: 'Sequence[TestCase|DataDict]') -> TestCases:
-        return TestCases(self.test_class, self, tests)
+    def tests(self, tests: 'Sequence[TestCase|DataDict]') -> TestCases[TestCase]:
+        return TestCases[TestCase](self.test_class, self, tests)
 
     @property
     def setup(self) -> Keyword:
@@ -375,11 +375,12 @@ class TestSuite(ModelObject):
             data['suites'] = self.suites.to_dicts()
         return data
 
+TS = TypeVar("TS", bound=TestSuite)
 
-class TestSuites(ItemList[TestSuite]):
+class TestSuites(ItemList[TS]):
     __slots__ = []
 
-    def __init__(self, suite_class: Type[TestSuite] = TestSuite,
-                 parent: 'TestSuite|None' = None,
-                 suites: 'Sequence[TestSuite|DataDict]' = ()):
+    def __init__(self, suite_class: Type[TS] = TestSuite,
+                 parent: 'TS|None' = None,
+                 suites: 'Sequence[TS|DataDict]' = ()):
         super().__init__(suite_class, {'parent': parent}, suites)

--- a/src/robot/model/testsuite.py
+++ b/src/robot/model/testsuite.py
@@ -31,6 +31,9 @@ from .testcase import TestCase, TestCases
 from .visitor import SuiteVisitor
 
 
+TS = TypeVar('TS', bound="TestSuite")
+
+
 class TestSuite(ModelObject):
     """Base model for single suite.
 
@@ -374,8 +377,6 @@ class TestSuite(ModelObject):
         if self.suites:
             data['suites'] = self.suites.to_dicts()
         return data
-
-TS = TypeVar('TS', bound=TestSuite)
 
 class TestSuites(ItemList[TS]):
     __slots__ = []

--- a/src/robot/result/model.py
+++ b/src/robot/result/model.py
@@ -41,10 +41,8 @@ from typing import Sequence
 import warnings
 
 from robot import model
-from robot.model import BodyItem, create_fixture, Keywords, Tags, TotalStatisticsBuilder
-from robot.model.modelobject import DataDict
-from robot.model.testcase import TestCases
-from robot.model.testsuite import TestSuites
+from robot.model import (BodyItem, create_fixture, Keywords, Tags,
+                         TotalStatisticsBuilder, DataDict, TestCases, TestSuites)
 from robot.utils import get_elapsed_time, setter
 
 from .configurer import SuiteConfigurer
@@ -745,12 +743,12 @@ class TestSuite(model.TestSuite, StatusMixin):
                    chain(self.suites, self.tests, (self.setup, self.teardown)))
 
     @setter
-    def suites(self, suites: 'Sequence[TestSuite|DataDict]') -> 'TestSuites[TestSuite]':
+    def suites(self, suites: 'Sequence[TestSuite|DataDict]') -> TestSuites['TestSuite']:
         return TestSuites['TestSuite'](self.__class__, self, suites)
 
     @setter
-    def tests(self, tests: 'Sequence[TestCase|DataDict]') -> TestCases['TestCase']:
-        return TestCases['TestCase'](self.test_class, self, tests)
+    def tests(self, tests: 'Sequence[TestCase|DataDict]') -> TestCases[TestCase]:
+        return TestCases[TestCase](self.test_class, self, tests)
 
     def remove_keywords(self, how):
         """Remove keywords based on the given condition.

--- a/src/robot/result/model.py
+++ b/src/robot/result/model.py
@@ -37,10 +37,14 @@ __ http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#
 
 from collections import OrderedDict
 from itertools import chain
+from typing import Sequence
 import warnings
 
 from robot import model
 from robot.model import BodyItem, create_fixture, Keywords, Tags, TotalStatisticsBuilder
+from robot.model.modelobject import DataDict
+from robot.model.testcase import TestCases
+from robot.model.testsuite import TestSuites
 from robot.utils import get_elapsed_time, setter
 
 from .configurer import SuiteConfigurer
@@ -739,6 +743,14 @@ class TestSuite(model.TestSuite, StatusMixin):
             return get_elapsed_time(self.starttime, self.endtime)
         return sum(child.elapsedtime for child in
                    chain(self.suites, self.tests, (self.setup, self.teardown)))
+
+    @setter
+    def suites(self, suites: 'Sequence[TestSuite|DataDict]') -> 'TestSuites[TestSuite]':
+        return TestSuites['TestSuite'](self.__class__, self, suites)
+
+    @setter
+    def tests(self, tests: 'Sequence[TestCase|DataDict]') -> TestCases['TestCase']:
+        return TestCases['TestCase'](self.test_class, self, tests)
 
     def remove_keywords(self, how):
         """Remove keywords based on the given condition.

--- a/src/robot/running/model.py
+++ b/src/robot/running/model.py
@@ -45,6 +45,8 @@ from robot import model
 from robot.conf import RobotSettings
 from robot.errors import BreakLoop, ContinueLoop, DataError, ReturnFromKeyword
 from robot.model import BodyItem, create_fixture, DataDict, Keywords, ModelObject
+from robot.model.testcase import TestCases
+from robot.model.testsuite import TestSuites
 from robot.output import LOGGER, Output, pyloggingconf
 from robot.result import (Break as BreakResult, Continue as ContinueResult,
                           Error as ErrorResult, Return as ReturnResult)
@@ -525,6 +527,14 @@ class TestSuite(model.TestSuite):
             to be re-created. Seed value is always shown in logs and reports.
         """
         self.visit(Randomizer(suites, tests, seed))
+
+    @setter
+    def suites(self, suites: 'Sequence[TestSuite|DataDict]') -> 'TestSuites[TestSuite]':
+        return TestSuites['TestSuite'](self.__class__, self, suites)
+
+    @setter
+    def tests(self, tests: 'Sequence[TestCase|DataDict]') -> TestCases['TestCase']:
+        return TestCases['TestCase'](self.test_class, self, tests)
 
     def run(self, settings=None, **options):
         """Executes the suite based on the given ``settings`` or ``options``.

--- a/src/robot/running/model.py
+++ b/src/robot/running/model.py
@@ -44,7 +44,8 @@ if sys.version_info >= (3, 8):
 from robot import model
 from robot.conf import RobotSettings
 from robot.errors import BreakLoop, ContinueLoop, DataError, ReturnFromKeyword
-from robot.model import BodyItem, create_fixture, DataDict, Keywords, ModelObject
+from robot.model import (BodyItem, create_fixture, DataDict, Keywords, ModelObject,
+                         TestCases, TestSuites)
 from robot.model.testcase import TestCases
 from robot.model.testsuite import TestSuites
 from robot.output import LOGGER, Output, pyloggingconf
@@ -529,12 +530,12 @@ class TestSuite(model.TestSuite):
         self.visit(Randomizer(suites, tests, seed))
 
     @setter
-    def suites(self, suites: 'Sequence[TestSuite|DataDict]') -> 'TestSuites[TestSuite]':
+    def suites(self, suites: 'Sequence[TestSuite|DataDict]') -> TestSuites['TestSuite']:
         return TestSuites['TestSuite'](self.__class__, self, suites)
 
     @setter
-    def tests(self, tests: 'Sequence[TestCase|DataDict]') -> TestCases['TestCase']:
-        return TestCases['TestCase'](self.test_class, self, tests)
+    def tests(self, tests: 'Sequence[TestCase|DataDict]') -> TestCases[TestCase]:
+        return TestCases[TestCase](self.test_class, self, tests)
 
     def run(self, settings=None, **options):
         """Executes the suite based on the given ``settings`` or ``options``.

--- a/src/robot/utils/__init__.py
+++ b/src/robot/utils/__init__.py
@@ -70,7 +70,7 @@ from .sortable import Sortable
 from .text import (cut_assign_value, cut_long_message, format_assign_message,
                    get_console_length, getdoc, getshortdoc, pad_console_length,
                    split_tags_from_doc, split_args_from_name_or_path)
-from .typehints import copy_signature, known_at_runtime
+from .typehints import copy_signature, KnownAtRuntime
 from .unic import prepr, safe_str
 
 

--- a/src/robot/utils/__init__.py
+++ b/src/robot/utils/__init__.py
@@ -70,6 +70,7 @@ from .sortable import Sortable
 from .text import (cut_assign_value, cut_long_message, format_assign_message,
                    get_console_length, getdoc, getshortdoc, pad_console_length,
                    split_tags_from_doc, split_args_from_name_or_path)
+from .typehints import copy_signature
 from .unic import prepr, safe_str
 
 

--- a/src/robot/utils/__init__.py
+++ b/src/robot/utils/__init__.py
@@ -70,7 +70,7 @@ from .sortable import Sortable
 from .text import (cut_assign_value, cut_long_message, format_assign_message,
                    get_console_length, getdoc, getshortdoc, pad_console_length,
                    split_tags_from_doc, split_args_from_name_or_path)
-from .typehints import copy_signature
+from .typehints import copy_signature, known_at_runtime
 from .unic import prepr, safe_str
 
 

--- a/src/robot/utils/typehints.py
+++ b/src/robot/utils/typehints.py
@@ -13,23 +13,22 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Any, Callable, TypeVar, Generic
+from typing import Any, Callable, TypeVar
 
 
 T = TypeVar('T', bound=Callable[..., Any])
 
 # Type Alias for objects that are only known at runtime. This should be Used as a
 # default value for generic classes that also use `@copy_signature` decorator
-known_at_runtime = type(object)
+KnownAtRuntime = type(object)
 
 
-class copy_signature(Generic[T]):
-    """A decorator that applies the signature of `F` to any function that it decorates
+def copy_signature(target: T) -> Callable[..., T]:
+    """A decorator that applies the signature of `T` to any function that it decorates
     see https://github.com/python/typing/issues/270#issuecomment-555966301 for source
     and discussion.
     """
+    def decorator(func):
+        return func
 
-    def __init__(self, target: T) -> None: ...
-
-    def __call__(self, wrapped: Callable[..., Any]) -> T:
-        return wrapped  # type: ignore
+    return decorator

--- a/src/robot/utils/typehints.py
+++ b/src/robot/utils/typehints.py
@@ -13,10 +13,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 from typing import Any, Callable, TypeVar, Generic
 
+
 T = TypeVar('T', bound=Callable[..., Any])
+
+# Type Alias for objects that are only known at runtime. This should be Used as a
+# default value for generic classes that also use `@copy_signature` decorator
+known_at_runtime = type(object)
 
 
 class copy_signature(Generic[T]):

--- a/src/robot/utils/typehints.py
+++ b/src/robot/utils/typehints.py
@@ -1,0 +1,31 @@
+#  Copyright 2008-2015 Nokia Networks
+#  Copyright 2016-     Robot Framework Foundation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+from typing import Any, Callable, TypeVar, Generic
+
+T = TypeVar('T', bound=Callable[..., Any])
+
+
+class copy_signature(Generic[T]):
+    """A decorator that applies the signature of `F` to any function that it decorates
+    see https://github.com/python/typing/issues/270#issuecomment-555966301 for source
+    and discussion.
+    """
+
+    def __init__(self, target: T) -> None: ...
+
+    def __call__(self, wrapped: Callable[..., Any]) -> T:
+        return wrapped  # type: ignore


### PR DESCRIPTION
The decorator allows function definitions to shadow other function definitions. 

It has a similar behaviour as `@wraps`, but works purely with type hints.

ItemList working
![image](https://user-images.githubusercontent.com/28574129/236866855-35e76ac7-e28b-4630-bd97-7c098e47aceb.png)

Body working
![image](https://user-images.githubusercontent.com/28574129/236867146-a901acc1-97e8-48a4-ac3d-b10b82a1a50b.png)

Part of #4570 
