### PR TITLE
Allow statistics table to grow with content

### DIFF
--- a/src/robot/htmldata/rebot/common.css
+++ b/src/robot/htmldata/rebot/common.css
@@ -140,7 +140,7 @@ h2 {
 }
 /* Statistics table */
 .statistics {
-    width: 65em;
+    min-width: 65em;
     border-collapse: collapse;
     empty-cells: show;
     margin-bottom: 1em;


### PR DESCRIPTION
Fixes #4025 Setting a min-width keeps the table pretty when suite-names are short, while also allowing the table to for long suite-names. On smaller screens, there is still a word-wrap to avoid a horizontal scroller.