### PR TITLE
Make model.BaseBody accept Generic parameters

### DIFF
--- a/src/robot/model/body.py
+++ b/src/robot/model/body.py
@@ -110,29 +110,16 @@ class BaseBody(ItemList[BodyItem], Generic[KW, F, W, I, T, R, C, B, M, E]):
     """Base class for Body and Branches objects."""
     __slots__ = []
     # Set using 'BaseBody.register' when these classes are created.
-
-    if TYPE_CHECKING:
-        keyword_class: Type[KW] = KnownAtRuntime
-        for_class: Type[F] = KnownAtRuntime
-        while_class: Type[W] = KnownAtRuntime
-        if_class: Type[I] = KnownAtRuntime
-        try_class: Type[T] = KnownAtRuntime
-        return_class: Type[R] = KnownAtRuntime
-        continue_class: Type[C] = KnownAtRuntime
-        break_class: Type[B] = KnownAtRuntime
-        message_class: Type[M] = KnownAtRuntime
-        error_class: Type[E] = KnownAtRuntime
-    else:
-        keyword_class = None
-        for_class = None
-        while_class = None
-        if_class = None
-        try_class = None
-        return_class = None
-        continue_class = None
-        break_class = None
-        message_class = None
-        error_class = None
+    keyword_class: Type[KW] = KnownAtRuntime
+    for_class: Type[F] = KnownAtRuntime
+    while_class: Type[W] = KnownAtRuntime
+    if_class: Type[I] = KnownAtRuntime
+    try_class: Type[T] = KnownAtRuntime
+    return_class: Type[R] = KnownAtRuntime
+    continue_class: Type[C] = KnownAtRuntime
+    break_class: Type[B] = KnownAtRuntime
+    message_class: Type[M] = KnownAtRuntime
+    error_class: Type[E] = KnownAtRuntime
 
     def __init__(self, parent: BodyItemParent = None,
                  items: 'Iterable[BodyItem|DataDict]' = ()):
@@ -169,7 +156,7 @@ class BaseBody(ItemList[BodyItem], Generic[KW, F, W, I, T, R, C, B, M, E]):
 
     def _create(self, cls: 'Type[BI]', name: str, args: 'tuple[Any]',
                 kwargs: 'dict[str, Any]') -> BI:
-        if cls is None:
+        if not issubclass(cls, BodyItem):
             raise TypeError(f"'{full_name(self)}' object does not support '{name}'.")
         return self.append(cls(*args, **kwargs))
 
@@ -238,7 +225,7 @@ class BaseBody(ItemList[BodyItem], Generic[KW, F, W, I, T, R, C, B, M, E]):
         use ``body.filter(keywords=False``, messages=False)``. For more detailed
         filtering it is possible to use ``predicate``.
         """
-        if messages is not None and not self.message_class:
+        if messages is not None and not issubclass(self.message_class, BodyItem):
             raise TypeError(f"'{full_name(self)}' object does not support "
                             f"filtering by 'messages'.")
         return self._filter([(self.keyword_class, keywords),

--- a/src/robot/model/body.py
+++ b/src/robot/model/body.py
@@ -32,17 +32,17 @@ if TYPE_CHECKING:
 
 BodyItemParent = Union['TestSuite', 'TestCase', 'UserKeyword', 'For', 'If', 'IfBranch',
                        'Try', 'TryBranch', 'While', None]
-BI = TypeVar("BI", bound="BodyItem")
-KW = TypeVar("KW", bound="Keyword")
-F = TypeVar("F", bound="For")
-W = TypeVar("W", bound="While")
-I = TypeVar("I", bound="If")
-T = TypeVar("T", bound="Try")
-R = TypeVar("R", bound="Return")
-C = TypeVar("C", bound="Continue")
-B = TypeVar("B", bound="Break")
-M = TypeVar("M", bound="Message")
-E = TypeVar("E", bound="Error")
+BI = TypeVar('BI', bound='BodyItem')
+KW = TypeVar('KW', bound='Keyword')
+F = TypeVar('F', bound='For')
+W = TypeVar('W', bound='While')
+I = TypeVar('I', bound='If')
+T = TypeVar('T', bound='Try')
+R = TypeVar('R', bound='Return')
+C = TypeVar('C', bound='Continue')
+B = TypeVar('B', bound='Break')
+M = TypeVar('M', bound='Message')
+E = TypeVar('E', bound='Error')
 
 
 class BodyItem(ModelObject):

--- a/src/robot/model/body.py
+++ b/src/robot/model/body.py
@@ -262,8 +262,8 @@ class BaseBody(ItemList[BodyItem], Generic[KW, F, W, I, T, R, C, B, M, E]):
         return steps
 
 
-class Body(BaseBody["Keyword", "For", "While", "If", "Try", "Return", "Continue",
-                    "Break", "Message", "Error"]):
+class Body(BaseBody['Keyword', 'For', 'While', 'If', 'Try', 'Return', 'Continue',
+                    'Break', 'Message', 'Error']):
     """A list-like object representing a body of a test, keyword, etc.
 
     Body contains the keywords and other structures such as FOR loops.

--- a/src/robot/model/testcase.py
+++ b/src/robot/model/testcase.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from .visitor import SuiteVisitor
 
 
-TC = TypeVar("TC", bound="TestCase")
+TC = TypeVar('TC', bound='TestCase')
 
 
 class TestCase(ModelObject):

--- a/src/robot/result/model.py
+++ b/src/robot/result/model.py
@@ -53,7 +53,8 @@ from .keywordremover import KeywordRemover
 from .suiteteardownfailed import SuiteTeardownFailed, SuiteTeardownFailureHandler
 
 
-class Body(model.Body):
+class Body(model.BaseBody["Keyword", "For", "While", "If", "Try", "Return", "Continue",
+                          "Break", "Message", "Error"]):
     __slots__ = []
 
 
@@ -685,6 +686,11 @@ class TestCase(model.TestCase, StatusMixin):
     def critical(self):
         warnings.warn("'TestCase.critical' is deprecated and always returns 'True'.")
         return True
+
+    @setter
+    def body(self, body: 'Sequence[BodyItem|DataDict]') -> Body:
+        """Test body as a :class:`~robot.result.Body` object."""
+        return self.body_class(self, body)
 
 
 class TestSuite(model.TestSuite, StatusMixin):

--- a/src/robot/result/model.py
+++ b/src/robot/result/model.py
@@ -53,8 +53,8 @@ from .keywordremover import KeywordRemover
 from .suiteteardownfailed import SuiteTeardownFailed, SuiteTeardownFailureHandler
 
 
-class Body(model.BaseBody["Keyword", "For", "While", "If", "Try", "Return", "Continue",
-                          "Break", "Message", "Error"]):
+class Body(model.BaseBody['Keyword', 'For', 'While', 'If', 'Try', 'Return', 'Continue',
+                          'Break', 'Message', 'Error']):
     __slots__ = []
 
 

--- a/src/robot/running/model.py
+++ b/src/robot/running/model.py
@@ -64,8 +64,8 @@ BodyItemParent = Union['TestSuite', 'TestCase', 'UserKeyword', 'For', 'If', 'IfB
                        'Try', 'TryBranch', 'While', None]
 
 
-class Body(model.BaseBody["Keyword", "For", "While", "If", "Try", "Return", "Continue",
-                          "Break", "model.Message", "Error"]):
+class Body(model.BaseBody['Keyword', 'For', 'While', 'If', 'Try', 'Return', 'Continue',
+                          'Break', 'model.Message', 'Error']):
     __slots__ = []
 
 

--- a/src/robot/running/model.py
+++ b/src/robot/running/model.py
@@ -46,8 +46,6 @@ from robot.conf import RobotSettings
 from robot.errors import BreakLoop, ContinueLoop, DataError, ReturnFromKeyword
 from robot.model import (BodyItem, create_fixture, DataDict, Keywords, ModelObject,
                          TestCases, TestSuites)
-from robot.model.testcase import TestCases
-from robot.model.testsuite import TestSuites
 from robot.output import LOGGER, Output, pyloggingconf
 from robot.result import (Break as BreakResult, Continue as ContinueResult,
                           Error as ErrorResult, Return as ReturnResult)
@@ -66,8 +64,9 @@ BodyItemParent = Union['TestSuite', 'TestCase', 'UserKeyword', 'For', 'If', 'IfB
                        'Try', 'TryBranch', 'While', None]
 
 
-class Body(model.Body):
-    __slots__ = ()
+class Body(model.BaseBody["Keyword", "For", "While", "If", "Try", "Return", "Continue",
+                          "Break", "model.Message", "Error"]):
+    __slots__ = []
 
 
 class WithSource:
@@ -398,6 +397,11 @@ class TestCase(model.TestCase):
         if self.error:
             data['error'] = self.error
         return data
+
+    @setter
+    def body(self, body: 'Sequence[BodyItem|DataDict]') -> Body:
+        """Test body as a :class:`~robot.running.Body` object."""
+        return self.body_class(self, body)
 
 
 class TestSuite(model.TestSuite):


### PR DESCRIPTION
- `Body` sub classes pass in correct types
-  Those types are used with @copy_signature to type the `create_xxx` methods
-  Added correctly typed `body` entries for `running.TestCase` and `result.TestCase`

**Examples of the PR working**
![image](https://github.com/robotframework/robotframework/assets/28574129/355bc536-2d88-4bcb-85c0-8d441066d872)


![image](https://github.com/robotframework/robotframework/assets/28574129/eabe46ea-7760-4f52-8fcb-2b2ebe11639f)

Unfortunately, One side effect of this PR is, that Pyright believes that `Body.register` methods are cyclical dependencies.   

![image](https://github.com/robotframework/robotframework/assets/28574129/ae659a8e-638e-4439-825a-363201a9269d)