### PR TITLE
Make fixture generic to enable type hinting

### DIFF
--- a/src/robot/model/fixture.py
+++ b/src/robot/model/fixture.py
@@ -14,17 +14,33 @@
 #  limitations under the License.
 
 from collections.abc import Mapping
+from typing import Type, TypeVar, TYPE_CHECKING
 
-from .keyword import Keyword
+if TYPE_CHECKING:
+    from robot.model.modelobject import DataDict
+    from robot.model.testcase import TestCase
+    from robot.model.testsuite import TestSuite
+    from robot.model.keyword import Keyword
+    from robot.running.model import UserKeyword
 
+T = TypeVar('T', bound='Keyword')
 
-def create_fixture(fixture, parent, fixture_type) -> Keyword:
-    # TestCase and TestSuite have 'fixture_class', Keyword doesn't.
-    fixture_class = getattr(parent, 'fixture_class', parent.__class__)
+def create_fixture(fixture_class: Type[T],
+                   fixture:'T|DataDict|None',
+                   parent:'TestCase|TestSuite|Keyword|UserKeyword',
+                   fixture_type: str) -> T:
+    """ Configures or creates a `fixture_class`instance """
+
+    # If a fixture instance has been passed in update the config
     if isinstance(fixture, fixture_class):
         return fixture.config(parent=parent, type=fixture_type)
+
+    # If a Mapping has been passed in, create a fixture instance from it
     if isinstance(fixture, Mapping):
         return fixture_class.from_dict(fixture).config(parent=parent, type=fixture_type)
+
+    # If nothing has been passed in then return a new fixture instance from it
     if fixture is None:
         return fixture_class(None, parent=parent, type=fixture_type)
+
     raise TypeError(f"Invalid fixture type '{type(fixture).__name__}'.")

--- a/src/robot/model/fixture.py
+++ b/src/robot/model/fixture.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from robot.model import DataDict, Keyword, TestCase, TestSuite
     from robot.running.model import UserKeyword
 
+
 T = TypeVar('T', bound='Keyword')
 
 
@@ -27,7 +28,7 @@ def create_fixture(fixture_class: Type[T],
                    fixture: 'T|DataDict|None',
                    parent: 'TestCase|TestSuite|Keyword|UserKeyword',
                    fixture_type: str) -> T:
-    """ Configures or creates a `fixture_class`instance """
+    """Create or configure a `fixture_class` instance."""
     # If a fixture instance has been passed in update the config
     if isinstance(fixture, fixture_class):
         return fixture.config(parent=parent, type=fixture_type)

--- a/src/robot/model/fixture.py
+++ b/src/robot/model/fixture.py
@@ -17,30 +17,24 @@ from collections.abc import Mapping
 from typing import Type, TypeVar, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from robot.model.modelobject import DataDict
-    from robot.model.testcase import TestCase
-    from robot.model.testsuite import TestSuite
-    from robot.model.keyword import Keyword
+    from robot.model import DataDict, Keyword, TestCase, TestSuite
     from robot.running.model import UserKeyword
 
 T = TypeVar('T', bound='Keyword')
 
+
 def create_fixture(fixture_class: Type[T],
-                   fixture:'T|DataDict|None',
-                   parent:'TestCase|TestSuite|Keyword|UserKeyword',
+                   fixture: 'T|DataDict|None',
+                   parent: 'TestCase|TestSuite|Keyword|UserKeyword',
                    fixture_type: str) -> T:
     """ Configures or creates a `fixture_class`instance """
-
     # If a fixture instance has been passed in update the config
     if isinstance(fixture, fixture_class):
         return fixture.config(parent=parent, type=fixture_type)
-
     # If a Mapping has been passed in, create a fixture instance from it
     if isinstance(fixture, Mapping):
         return fixture_class.from_dict(fixture).config(parent=parent, type=fixture_type)
-
     # If nothing has been passed in then return a new fixture instance from it
     if fixture is None:
         return fixture_class(None, parent=parent, type=fixture_type)
-
     raise TypeError(f"Invalid fixture type '{type(fixture).__name__}'.")

--- a/src/robot/model/keyword.py
+++ b/src/robot/model/keyword.py
@@ -21,8 +21,6 @@ from .itemlist import ItemList
 from .modelobject import DataDict
 
 if TYPE_CHECKING:
-    from .testcase import TestCase
-    from .testsuite import TestSuite
     from .visitor import SuiteVisitor
 
 

--- a/src/robot/model/testcase.py
+++ b/src/robot/model/testcase.py
@@ -96,12 +96,12 @@ class TestCase(ModelObject):
         ``test.keywords.setup``.
         """
         if self._setup is None:
-            self._setup = create_fixture(None, self, Keyword.SETUP)
+            self._setup = create_fixture(self.fixture_class, None, self, Keyword.SETUP)
         return self._setup
 
     @setup.setter
     def setup(self, setup: 'Keyword|DataDict|None'):
-        self._setup = create_fixture(setup, self, Keyword.SETUP)
+        self._setup = create_fixture(self.fixture_class, setup, self, Keyword.SETUP)
 
     @property
     def has_setup(self) -> bool:
@@ -124,12 +124,12 @@ class TestCase(ModelObject):
         See :attr:`setup` for more information.
         """
         if self._teardown is None:
-            self._teardown = create_fixture(None, self, Keyword.TEARDOWN)
+            self._teardown = create_fixture(self.fixture_class, None, self, Keyword.TEARDOWN)
         return self._teardown
 
     @teardown.setter
     def teardown(self, teardown: 'Keyword|DataDict|None'):
-        self._teardown = create_fixture(teardown, self, Keyword.TEARDOWN)
+        self._teardown = create_fixture(self.fixture_class, teardown, self, Keyword.TEARDOWN)
 
     @property
     def has_teardown(self) -> bool:

--- a/src/robot/model/testsuite.py
+++ b/src/robot/model/testsuite.py
@@ -192,12 +192,12 @@ class TestSuite(ModelObject):
         ``suite.keywords.setup``.
         """
         if self._setup is None:
-            self._setup = create_fixture(None, self, Keyword.SETUP)
+            self._setup = create_fixture(self.fixture_class, None, self, Keyword.SETUP)
         return self._setup
 
     @setup.setter
     def setup(self, setup: 'Keyword|DataDict|None'):
-        self._setup = create_fixture(setup, self, Keyword.SETUP)
+        self._setup = create_fixture(self.fixture_class, setup, self, Keyword.SETUP)
 
     @property
     def has_setup(self) -> bool:
@@ -214,18 +214,18 @@ class TestSuite(ModelObject):
         return bool(self._setup)
 
     @property
-    def teardown(self) -> Keyword:
+    def teardown(self) -> fixture_class:
         """Suite teardown.
 
         See :attr:`setup` for more information.
         """
         if self._teardown is None:
-            self._teardown = create_fixture(None, self, Keyword.TEARDOWN)
+            self._teardown = create_fixture(self.fixture_class, None, self, Keyword.TEARDOWN)
         return self._teardown
 
     @teardown.setter
     def teardown(self, teardown: 'Keyword|DataDict|None'):
-        self._teardown = create_fixture(teardown, self, Keyword.TEARDOWN)
+        self._teardown = create_fixture(self.fixture_class, teardown, self, Keyword.TEARDOWN)
 
     @property
     def has_teardown(self) -> bool:

--- a/src/robot/model/testsuite.py
+++ b/src/robot/model/testsuite.py
@@ -214,7 +214,7 @@ class TestSuite(ModelObject):
         return bool(self._setup)
 
     @property
-    def teardown(self) -> fixture_class:
+    def teardown(self) -> Keyword:
         """Suite teardown.
 
         See :attr:`setup` for more information.

--- a/src/robot/result/model.py
+++ b/src/robot/result/model.py
@@ -41,7 +41,7 @@ from collections import OrderedDict
 from datetime import datetime, timedelta
 from itertools import chain
 from pathlib import Path
-from typing import cast, Generic, Mapping, Sequence, Type, Union, TypeVar
+from typing import Generic, Mapping, Sequence, Type, Union, TypeVar
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -736,15 +736,15 @@ class Keyword(model.Keyword, StatusMixin):
         ``keyword.keywords.teardown``. :attr:`has_teardown` is new in Robot
         Framework 4.1.2.
         """
-        if self._teardown is None and self:
-            self._teardown = create_fixture(None, self, self.TEARDOWN)
+        if self._teardown is None:
+            self._teardown = create_fixture(self.__class__, None, self, self.TEARDOWN)
         # Would be better to enhance `create_fixture` so that its return
         # type would match argument type.
-        return cast(Keyword, self._teardown)
+        return self._teardown
 
     @teardown.setter
     def teardown(self, teardown: 'Keyword|DataDict|None'):
-        self._teardown = create_fixture(teardown, self, self.TEARDOWN)
+        self._teardown = create_fixture(self.__class__, teardown, self, self.TEARDOWN)
 
     @property
     def has_teardown(self) -> bool:

--- a/src/robot/result/model.py
+++ b/src/robot/result/model.py
@@ -738,8 +738,6 @@ class Keyword(model.Keyword, StatusMixin):
         """
         if self._teardown is None:
             self._teardown = create_fixture(self.__class__, None, self, self.TEARDOWN)
-        # Would be better to enhance `create_fixture` so that its return
-        # type would match argument type.
         return self._teardown
 
     @teardown.setter

--- a/src/robot/running/model.py
+++ b/src/robot/running/model.py
@@ -755,14 +755,14 @@ class UserKeyword(ModelObject):
     @property
     def teardown(self) -> Keyword:
         if self._teardown is None:
-            self._teardown = create_fixture(None, self, Keyword.TEARDOWN)
+            self._teardown = create_fixture(self.fixture_class, None, self, Keyword.TEARDOWN)
         # Would be better to enhance `create_fixture` so that its return
         # type would match argument type.
-        return cast(Keyword, self._teardown)
+        return self._teardown
 
     @teardown.setter
     def teardown(self, teardown: 'Keyword|DataDict|None'):
-        self._teardown = create_fixture(teardown, self, Keyword.TEARDOWN)
+        self._teardown = create_fixture(self.fixture_class, teardown, self, Keyword.TEARDOWN)
 
     @property
     def has_teardown(self) -> bool:

--- a/src/robot/running/model.py
+++ b/src/robot/running/model.py
@@ -756,8 +756,6 @@ class UserKeyword(ModelObject):
     def teardown(self) -> Keyword:
         if self._teardown is None:
             self._teardown = create_fixture(self.fixture_class, None, self, Keyword.TEARDOWN)
-        # Would be better to enhance `create_fixture` so that its return
-        # type would match argument type.
         return self._teardown
 
     @teardown.setter

--- a/utest/model/test_fixture.py
+++ b/utest/model/test_fixture.py
@@ -9,13 +9,13 @@ class TestCreateFixture(unittest.TestCase):
 
     def test_creates_default_fixture_when_given_none(self):
         suite = TestSuite()
-        fixture = create_fixture(None, suite, Keyword.SETUP)
+        fixture = create_fixture(suite.fixture_class, None, suite, Keyword.SETUP)
         self._assert_fixture(fixture, suite, Keyword.SETUP)
 
     def test_sets_parent_and_type_correctly(self):
         suite = TestSuite()
         kw = Keyword('KW Name')
-        fixture = create_fixture(kw, suite, Keyword.TEARDOWN)
+        fixture = create_fixture(suite.fixture_class, kw, suite, Keyword.TEARDOWN)
         self._assert_fixture(fixture, suite, Keyword.TEARDOWN)
 
     def test_raises_type_error_when_wrong_fixture_type(self):
@@ -23,7 +23,7 @@ class TestCreateFixture(unittest.TestCase):
         wrong_kw = object()
         assert_raises_with_msg(
             TypeError, "Invalid fixture type 'object'.",
-            create_fixture, wrong_kw, suite, Keyword.TEARDOWN
+            create_fixture, suite.fixture_class, wrong_kw, suite, Keyword.TEARDOWN
         )
 
     def _assert_fixture(self, fixture, exp_parent, exp_type,


### PR DESCRIPTION
`create_fixture` takes a fixture class parameter, making the function generic. 
 
Unit tests have also been updated to reflect this