### PR TITLE
#4751 reimport same lib with different arguments

### DIFF
--- a/atest/robot/test_libraries/with_name.robot
+++ b/atest/robot/test_libraries/with_name.robot
@@ -6,7 +6,7 @@ Resource          atest_resource.robot
 Import Library Normally Before Importing With Name In Another Suite
     ${tc} =    Check Test Case    ${TEST NAME}
     Check Keyword Data    ${tc.kws[0]}    OperatingSystem.Should Exist    args=.
-    Check Keyword Data    ${tc.kws[1]}    ParameterLibrary.Parameters Should Be    args=before1, before2
+    Check Keyword Data    ${tc.kws[1]}    ParameterLibrary.Parameters Should Be    args=\${1}, 2
     Syslog Should Contain    Imported library 'OperatingSystem' with arguments [ ] (version ${ROBOT VERSION}, class type, GLOBAL scope,
     Syslog Should Contain    Imported library 'ParameterLibrary' with arguments [ before1 | before2 ] (version <unknown>, class type, TEST scope,
 

--- a/atest/testdata/test_libraries/with_name_1.robot
+++ b/atest/testdata/test_libraries/with_name_1.robot
@@ -10,7 +10,7 @@ Library           ParameterLibrary    ${1}    2
 *** Test Cases ***
 Import Library Normally Before Importing With Name In Another Suite
     OperatingSystem.Should Exist    .
-    ParameterLibrary.Parameters Should Be    before1    before2
+    ParameterLibrary.Parameters Should Be    ${1}    2
 
 Import Library With Name Before Importing With Name In Another Suite
     Params.Parameters Should Be    before1with    before2with

--- a/src/robot/running/namespace.py
+++ b/src/robot/running/namespace.py
@@ -130,7 +130,6 @@ class Namespace:
         if lib.name in self._kw_store.libraries:
             LOGGER.info(f"Library '{lib.name}' already imported by suite "
                         f"'{self._suite_name}'.")
-            return
         if notify:
             LOGGER.imported("Library", lib.name,
                             args=list(import_setting.args),


### PR DESCRIPTION
If that's still the case or reasonable to reimport the same library with different arguments then I've made a small change that does that (too simple to believe that it's enough - maybe I'm missing something/some bigger picture of it). IMHO it should allow me to use the "latest" version of an imported library. Anyway - it turns out that the Importer object [`robotframework/src/robot/running/importer.py:49`](https://github.com/robotframework/robotframework/blob/6a266bf852ad0525c350ea7412f7b33f81455e96/src/robot/running/importer.py#LL49C22-L49C22) returns a new instance of the same library with different arguments, but later the `Namespace` object checks if that library is imported (only via `name` attribute)  [`robotframework/src/robot/running/namespace.py:130`](https://github.com/robotframework/robotframework/blob/6a266bf852ad0525c350ea7412f7b33f81455e96/src/robot/running/namespace.py#LL130C11-L130C11) and if the names are the same - it does nothing.

If this case sounds like a bug/feature then I'd be glad if maintainers could verify this.
Thanks in advance

