### PR TITLE
if execution cannot continue, cancel task and its children

### DIFF
--- a/atest/robot/running/stopping_with_signal.robot
+++ b/atest/robot/running/stopping_with_signal.robot
@@ -69,6 +69,32 @@ Skip Teardowns After Stopping Gracefully
     Teardown Should Not Be Defined    ${tc}
     Teardown Should Not Be Defined    ${SUITE}
 
+SIGINT Signal Should Stop Async Test Execution Gracefully
+    Start And Send Signal    async_stop.robot    One SIGINT    5
+    Check Test Cases Have Failed Correctly
+    ${tc} =    Get Test Case    Test
+    Evaluate    len(${tc.kws[1].msgs}) == 1
+    Check Log Message    ${tc.kws[1].msgs[0]}    Start Sleep
+    Evaluate    len(${SUITE.teardown.msgs}) == 0
+
+Two SIGINT Signals Should Stop Async Test Execution Forcefully
+    Start And Send Signal    async_stop.robot    Two SIGINTs    5
+    Check Tests Have Been Forced To Shutdown
+
+SIGTERM Signal Should Stop Async Test Execution Gracefully
+    [Tags]    no-windows
+    Start And Send Signal    async_stop.robot    One SIGTERM    5
+    Check Test Cases Have Failed Correctly
+    ${tc} =    Get Test Case    Test
+    Evaluate    len(${tc.kws[1].msgs}) == 1
+    Check Log Message    ${tc.kws[1].msgs[0]}    Start Sleep
+    Evaluate    len(${SUITE.teardown.msgs}) == 0
+
+Two SIGTERM Signals Should Stop Async Test Execution Forcefully
+    [Tags]    no-windows
+    Start And Send Signal    async_stop.robot    Two SIGTERMs    5
+    Check Tests Have Been Forced To Shutdown
+
 *** Keywords ***
 Start And Send Signal
     [Arguments]    ${datasource}    ${signals}    ${sleep}=0s    @{extra options}

--- a/atest/testdata/running/stopping_with_signal/AsyncStop.py
+++ b/atest/testdata/running/stopping_with_signal/AsyncStop.py
@@ -1,0 +1,14 @@
+import asyncio
+
+from robot.api import logger
+
+
+class AsyncStop:
+
+    async def async_test(self):
+        logger.info("Start Sleep", also_console=True)
+        await asyncio.sleep(2)
+        logger.info("End Sleep", also_console=True)
+
+    async def async_sleep(self, time: int):
+        await asyncio.sleep(time)

--- a/atest/testdata/running/stopping_with_signal/async_stop.robot
+++ b/atest/testdata/running/stopping_with_signal/async_stop.robot
@@ -1,0 +1,16 @@
+*** Settings ***
+Suite Teardown    Async Sleep    ${TEARDOWN SLEEP}
+Library           OperatingSystem
+Library           Library.py
+Library           AsyncStop.py
+
+*** Test Case ***
+Test
+    [Documentation]    FAIL Execution terminated by signal
+    Create File    ${TESTSIGNALFILE}
+    Async Test
+    Fail    Should not be executed
+
+Test 2
+    [Documentation]    FAIL Test execution stopped due to a fatal error.
+    Fail    Should not be executed

--- a/doc/userguide/src/ExtendingRobotFramework/CreatingTestLibraries.rst
+++ b/doc/userguide/src/ExtendingRobotFramework/CreatingTestLibraries.rst
@@ -1996,6 +1996,10 @@ More examples of functionality:
           manage the task and save a reference to avoid it being garbage collected. If the event loop
           closes and a task is still pending, a message will be printed to the console.
 
+.. note:: If execution of keyword cannot continue for some reason, for example a signal stop,
+          Robot Framework will cancel the async task and any of its children. Other async tasks will
+          continue running normally.
+
 Communicating with Robot Framework
 ----------------------------------
 

--- a/src/robot/running/context.py
+++ b/src/robot/running/context.py
@@ -18,7 +18,7 @@ import inspect
 import asyncio
 from contextlib import contextmanager
 
-from robot.errors import DataError
+from robot.errors import DataError, ExecutionFailed
 
 
 class Asynchronous:
@@ -37,7 +37,15 @@ class Asynchronous:
             self._loop_ref.close()
 
     def run_until_complete(self, coroutine):
-        return self.event_loop.run_until_complete(coroutine)
+        task = self.event_loop.create_task(coroutine)
+        try:
+            return self.event_loop.run_until_complete(task)
+        except ExecutionFailed as e:
+            if e.dont_continue:
+                task.cancel()
+                # wait for task and its children to cancel
+                self.event_loop.run_until_complete(asyncio.gather(task, return_exceptions=True))
+            raise e
 
     def is_loop_required(self, obj):
         return inspect.iscoroutine(obj) and not self._is_loop_running()


### PR DESCRIPTION
This will only cancel the task that got the error. Other coroutines will still run normally.

We can try to clean up coroutines when closing the loop, but i think showing the logs of open tasks help developers manage the coroutines better, so i didn't include any clean up for that. Open to suggestions on this.

Adressing issue #4808