### PR TITLE
Improvement for Robot "Get Length" with len() Function own

### DIFF
--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -1409,9 +1409,10 @@ class _Verify(_BuiltInBase):
         self.log(f'Length is {length}.')
         return length
 
+
     def _get_length(self, item):
         try:
-            return len(item)
+            return self._robot_len(item)
         except RERAISED_EXCEPTIONS:
             raise
         except:
@@ -1431,6 +1432,19 @@ class _Verify(_BuiltInBase):
                         raise
                     except:
                         raise RuntimeError(f"Could not get length of '{item}'.")
+
+
+    def _robot_len(self, item):
+        for_check = item
+        count = 0
+        if type(for_check) == int:
+            while for_check > 0:
+                count += 1
+                for_check //= 10
+        else:
+            count = len(str(for_check))
+        return count
+
 
     def length_should_be(self, item, length, msg=None):
         """Verifies that the length of the given item is correct.


### PR DESCRIPTION
During my work on API endpoint validation, I needed know the length of an integer variable. It was then that I realized that the "Get Length" function couldn't count the characters in variables of types int, bool, and float. In discussions with my team, we noticed this need in several projects. Sometimes, it's necessary to validate the number of digits in an integer variable to ensure it doesn't exceed the limit of a system's business rule.

I'm submitting a Pull Request with this potential improvement. Now, when using "Get Length," it will return the number of digits in variables of types str, int, bool, and float and will no longer display the message "Could not get length of."