### PR TITLE
libraries: BuiltIn: _accepts_embedded_arguments: do not recommend on …

### DIFF
--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -1877,7 +1877,7 @@ class _RunKeyword(_BuiltInBase):
 
     def _accepts_embedded_arguments(self, name, ctx):
         if '{' in name:
-            runner = ctx.get_runner(name)
+            runner = ctx.get_runner(name, recommend_on_failure=False)
             return runner and hasattr(runner, 'embedded_args')
         return False
 

--- a/src/robot/running/context.py
+++ b/src/robot/running/context.py
@@ -304,8 +304,8 @@ class _ExecutionContext:
         method(data, result)
         self.steps.pop()
 
-    def get_runner(self, name):
-        return self.namespace.get_runner(name)
+    def get_runner(self, name, recommend_on_failure=True):
+        return self.namespace.get_runner(name, recommend_on_failure)
 
     def trace(self, message):
         self.output.trace(message)


### PR DESCRIPTION
…failure

We are not using this runner for anything here, so let's not gather recommendations on failure.

This is a pretty big performance hit for no apparent benefit.

We have to introduce `recommend_on_failure` variable to _ExecutionContext's get_runner(), but we can keep the default behaviour the same.


This might be fix for #4659 I found this for very similar performance issue. This came in 5.1b2 when the decoration for `run_keyword()` in BuiltIn was changed.