### PR TITLE
Robot console plugin system

### DIFF
--- a/src/robot/output/console/__init__.py
+++ b/src/robot/output/console/__init__.py
@@ -35,21 +35,16 @@ def ConsoleOutput(type='verbose', width=78, colors='AUTO', markers='AUTO',
         return QuietOutput(colors, stderr)
     if upper == 'NONE':
         return NoOutput()
-
     discoveries = entry_points(group=ENTRY_POINT_GROUP, name=type)
-
     if discoveries:
         if len(discoveries) > 1:
             warnings.warn("Multiple console outputs with name '%s' found. "
                           "Using first entry (%s)."
                           % (type, discoveries[0].value))
-
         constructor = discoveries[0].load()
         return constructor(width, colors, markers, stdout, stderr)
-
     values = ["VERBOSE", "DOTTED", "QUIET", "NONE"]
     discoveries = entry_points(group=ENTRY_POINT_GROUP)
     values.extend(discovery.name for discovery in discoveries)
-
     raise DataError("Invalid console output type '%s'. Available: %s."
                     % (type, ', '.join(values)))


### PR DESCRIPTION
I recently made a code contribution to the Robot Framework, which I think will improve usability and flexibility.

I have extended the existing "ConsoleOutput" feature in the Robot Framework to further extend its functionality. This modification allows more easily to select console output types that are determined with the --console argument.

The code that I added discover and load entry points based on the provided group and name. If multiple entries are found, it issues a warning and proceeds with the first discovery. This eliminates the need for manual updates when new/custom output types are added.

I made these changes to the Robot Framework because they provide practical solutions to streamline the selection of console output types. This improvement would help us hard in developing the project we are currently working on. The project is intended to allow users to easily track their test status, but we would also like to be able to easily call the project as a --console option. The modification also has a contribution in the project for other developers using the Robot Framework, provided others also want to pass their own values to the --console argument.