### PR TITLE
Linting with ruff

### DIFF
--- a/src/robot/errors.py
+++ b/src/robot/errors.py
@@ -201,7 +201,7 @@ class ExecutionFailures(ExecutionFailed):
         else:
             html_prefix = ''
         if any(e.skip for e in errors):
-            skip_idx = errors.index([e for e in errors if e.skip][0])
+            skip_idx = errors.index(next(e for e in errors if e.skip))
             skip_msg = messages[skip_idx]
             messages = messages[:skip_idx] + messages[skip_idx+1:]
             if len(messages) == 1:

--- a/src/robot/libdocpkg/datatypes.py
+++ b/src/robot/libdocpkg/datatypes.py
@@ -55,14 +55,13 @@ class TypeDoc(Sortable):
         converter = TypeConverter.converter_for(type_info, converters)
         if not converter:
             return None
-        elif not converter.type:
+        if not converter.type:
             return cls(cls.CUSTOM, converter.type_name, converter.doc,
                        converter.value_types)
-        else:
-            # Get `type_name` from class, not from instance, to get the original
-            # name with generics like `list[int]` that override it in instance.
-            return cls(cls.STANDARD, type(converter).type_name,
-                       STANDARD_TYPE_DOCS[converter.type], converter.value_types)
+        # Get `type_name` from class, not from instance, to get the original
+        # name with generics like `list[int]` that override it in instance.
+        return cls(cls.STANDARD, type(converter).type_name,
+                    STANDARD_TYPE_DOCS[converter.type], converter.value_types)
 
     @classmethod
     def for_enum(cls, enum):

--- a/src/robot/libdocpkg/htmlutils.py
+++ b/src/robot/libdocpkg/htmlutils.py
@@ -77,7 +77,7 @@ class DocFormatter:
         types = self._type_info_targets
         if name in targets:
             return f'<a href="#{targets[name]}" class="name">{name}</a>'
-        elif name in types:
+        if name in types:
             return f'<a href="#type-{types[name]}" class="name">{name}</a>'
         return f'<span class="name">{name}</span>'
 

--- a/src/robot/libdocpkg/htmlutils.py
+++ b/src/robot/libdocpkg/htmlutils.py
@@ -134,8 +134,7 @@ class HtmlToText:
         match = re.search(r'<p.*?>(.*?)</?p>', doc, re.DOTALL)
         if match:
             doc = match.group(1)
-        doc = self.html_to_plain_text(doc)
-        return doc
+        return self.html_to_plain_text(doc)
 
     def html_to_plain_text(self, doc):
         for tag, repl in self.html_tags.items():

--- a/src/robot/libdocpkg/jsonbuilder.py
+++ b/src/robot/libdocpkg/jsonbuilder.py
@@ -51,8 +51,7 @@ class JsonDocBuilder:
         if not os.path.isfile(path):
             raise DataError(f"Spec file '{path}' does not exist.")
         with open(path) as json_source:
-            libdoc_dict = json.load(json_source)
-        return libdoc_dict
+            return json.load(json_source)
 
     def _create_keyword(self, data):
         kw = KeywordDoc(name=data.get('name'),

--- a/src/robot/libdocpkg/output.py
+++ b/src/robot/libdocpkg/output.py
@@ -16,6 +16,7 @@
 import datetime
 import os
 import time
+from contextlib import suppress
 
 from robot.utils import file_writer
 
@@ -38,10 +39,8 @@ class LibdocOutput:
         if self._output_file:
             self._output_file.close()
         if any(exc_info):
-            try:
+            with suppress(OSError):
                 os.remove(self._output_path)
-            except OSError:
-                pass
 
 
 def get_generation_time():

--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -152,7 +152,7 @@ class _Converter(_BuiltInBase):
             if base:
                 return int(item, self._convert_to_integer(base))
             return int(item)
-        except:
+        except Exception:
             raise RuntimeError(f"'{orig}' cannot be converted to an integer: "
                                f"{get_error_message()}")
 
@@ -295,7 +295,7 @@ class _Converter(_BuiltInBase):
     def _convert_to_number_without_precision(self, item):
         try:
             return float(item)
-        except:
+        except Exception:
             error = get_error_message()
             try:
                 return float(self._convert_to_integer(item))
@@ -384,7 +384,7 @@ class _Converter(_BuiltInBase):
             except AttributeError:
                 raise RuntimeError(f"Invalid input type '{input_type}'.")
             return bytes(bytearray(o for o in ordinals(input)))
-        except:
+        except Exception:
             raise RuntimeError("Creating bytes failed: " + get_error_message())
 
     def _get_ordinals_from_text(self, input):
@@ -1282,7 +1282,7 @@ class _Verify(_BuiltInBase):
         if not hasattr(container, 'count'):
             try:
                 container = list(container)
-            except:
+            except Exception:
                 raise RuntimeError(f"Converting '{container}' to list failed: "
                                    f"{get_error_message()}")
         count = container.count(item)
@@ -1414,22 +1414,22 @@ class _Verify(_BuiltInBase):
             return len(item)
         except RERAISED_EXCEPTIONS:
             raise
-        except:
+        except Exception:
             try:
                 return item.length()
             except RERAISED_EXCEPTIONS:
                 raise
-            except:
+            except Exception:
                 try:
                     return item.size()
                 except RERAISED_EXCEPTIONS:
                     raise
-                except:
+                except Exception:
                     try:
                         return item.length
                     except RERAISED_EXCEPTIONS:
                         raise
-                    except:
+                    except Exception:
                         raise RuntimeError(f"Could not get length of '{item}'.")
 
     def length_should_be(self, item, length, msg=None):
@@ -1546,7 +1546,7 @@ class _Variables(_BuiltInBase):
                 value = OrderedDict(value)
         except RERAISED_EXCEPTIONS:
             raise
-        except:
+        except Exception:
             name = '$' + name[1:]
         return name, value
 
@@ -3099,15 +3099,14 @@ class _Misc(_BuiltInBase):
     def _yield_logged_messages(self, messages):
         for msg in messages:
             match = search_variable(msg)
-            value = self._variables.replace_scalar(msg)
+            msg_value = self._variables.replace_scalar(msg)
             if match.is_list_variable():
-                for item in value:
-                    yield item
+                yield from msg_value
             elif match.is_dict_variable():
-                for name, value in value.items():
+                for name, value in msg_value.items():
                     yield f'{name}={value}'
             else:
-                yield value
+                yield msg_value
 
     def log_to_console(self, message, stream='STDOUT', no_newline=False, format=''):
         """Logs the given message to the console.
@@ -3651,7 +3650,7 @@ class _Misc(_BuiltInBase):
             ctx.suite.set_tags(tags, persist=True)
         else:
             raise RuntimeError("'Set Tags' cannot be used in suite teardown.")
-        self.log(f'Set tag{s(tags)} {seq2str((tags))}.')
+        self.log(f'Set tag{s(tags)} {seq2str(tags)}.')
 
     def remove_tags(self, *tags):
         """Removes given ``tags`` from the current test or all tests in a suite.
@@ -3679,7 +3678,7 @@ class _Misc(_BuiltInBase):
             ctx.suite.set_tags(remove=tags, persist=True)
         else:
             raise RuntimeError("'Remove Tags' cannot be used in suite teardown.")
-        self.log(f'Removed tag{s(tags)} {seq2str((tags))}.')
+        self.log(f'Removed tag{s(tags)} {seq2str(tags)}.')
 
     def get_library_instance(self, name=None, all=False):
         """Returns the currently active instance of the specified library.

--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -1021,19 +1021,19 @@ class _Verify(_BuiltInBase):
             if is_string(container):
                 container = container.casefold()
             elif is_list_like(container):
-                container = set(x.casefold() if is_string(x) else x for x in container)
+                container = {x.casefold() if is_string(x) else x for x in container}
         if strip_spaces and is_string(item):
             item = self._strip_spaces(item, strip_spaces)
             if is_string(container):
                 container = self._strip_spaces(container, strip_spaces)
             elif is_list_like(container):
-                container = set(self._strip_spaces(x, strip_spaces) for x in container)
+                container = {self._strip_spaces(x, strip_spaces) for x in container}
         if collapse_spaces and is_string(item):
             item = self._collapse_spaces(item)
             if is_string(container):
                 container = self._collapse_spaces(container)
             elif is_list_like(container):
-                container = set(self._collapse_spaces(x) for x in container)
+                container = {self._collapse_spaces(x) for x in container}
         if item in container:
             raise AssertionError(self._get_string_msg(orig_container, item, msg,
                                                       values, 'contains'))
@@ -1077,19 +1077,19 @@ class _Verify(_BuiltInBase):
             if is_string(container):
                 container = container.casefold()
             elif is_list_like(container):
-                container = set(x.casefold() if is_string(x) else x for x in container)
+                container = {x.casefold() if is_string(x) else x for x in container}
         if strip_spaces and is_string(item):
             item = self._strip_spaces(item, strip_spaces)
             if is_string(container):
                 container = self._strip_spaces(container, strip_spaces)
             elif is_list_like(container):
-                container = set(self._strip_spaces(x, strip_spaces) for x in container)
+                container = {self._strip_spaces(x, strip_spaces) for x in container}
         if collapse_spaces and is_string(item):
             item = self._collapse_spaces(item)
             if is_string(container):
                 container = self._collapse_spaces(container)
             elif is_list_like(container):
-                container = set(self._collapse_spaces(x) for x in container)
+                container = {self._collapse_spaces(x) for x in container}
         if item not in container:
             raise AssertionError(self._get_string_msg(orig_container, item, msg,
                                                       values, 'does not contain'))
@@ -1132,19 +1132,19 @@ class _Verify(_BuiltInBase):
             if is_string(container):
                 container = container.casefold()
             elif is_list_like(container):
-                container = set(x.casefold() if is_string(x) else x for x in container)
+                container = {x.casefold() if is_string(x) else x for x in container}
         if strip_spaces:
             items = [self._strip_spaces(x, strip_spaces) for x in items]
             if is_string(container):
                 container = self._strip_spaces(container, strip_spaces)
             elif is_list_like(container):
-                container = set(self._strip_spaces(x, strip_spaces) for x in container)
+                container = {self._strip_spaces(x, strip_spaces) for x in container}
         if collapse_spaces:
             items = [self._collapse_spaces(x) for x in items]
             if is_string(container):
                 container = self._collapse_spaces(container)
             elif is_list_like(container):
-                container = set(self._collapse_spaces(x) for x in container)
+                container = {self._collapse_spaces(x) for x in container}
         if not any(item in container for item in items):
             msg = self._get_string_msg(orig_container,
                                        seq2str(items, lastsep=' or '),
@@ -1190,19 +1190,19 @@ class _Verify(_BuiltInBase):
             if is_string(container):
                 container = container.casefold()
             elif is_list_like(container):
-                container = set(x.casefold() if is_string(x) else x for x in container)
+                container = {x.casefold() if is_string(x) else x for x in container}
         if strip_spaces:
             items = [self._strip_spaces(x, strip_spaces) for x in items]
             if is_string(container):
                 container = self._strip_spaces(container, strip_spaces)
             elif is_list_like(container):
-                container = set(self._strip_spaces(x, strip_spaces) for x in container)
+                container = {self._strip_spaces(x, strip_spaces) for x in container}
         if collapse_spaces:
             items = [self._collapse_spaces(x) for x in items]
             if is_string(container):
                 container = self._collapse_spaces(container)
             elif is_list_like(container):
-                container = set(self._collapse_spaces(x) for x in container)
+                container = {self._collapse_spaces(x) for x in container}
         if any(item in container for item in items):
             msg = self._get_string_msg(orig_container,
                                        seq2str(items, lastsep=' or '),
@@ -3150,7 +3150,6 @@ class _Misc(_BuiltInBase):
         contain non-existing variables. If you are interested about variable
         values, you can use the `Log` or `Log Many` keywords.
         """
-        pass
 
     def set_log_level(self, level):
         """Sets the log threshold to the specified level and returns the old level.
@@ -4000,7 +3999,6 @@ class RobotNotRunningError(AttributeError):
     May later be based directly on Exception, so new code should except
     this exception explicitly.
     """
-    pass
 
 
 def register_run_keyword(library, keyword, args_to_process=0, deprecation_warning=True):

--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -1640,10 +1640,9 @@ class _Variables(_BuiltInBase):
         """
         if len(values) == 0:
             return ''
-        elif len(values) == 1:
+        if len(values) == 1:
             return values[0]
-        else:
-            return list(values)
+        return list(values)
 
     @run_keyword_variant(resolve=0)
     def set_local_variable(self, name, *values):

--- a/src/robot/libraries/Collections.py
+++ b/src/robot/libraries/Collections.py
@@ -45,8 +45,7 @@ class _List:
         | ${L2} = ['a', 'b', 'x', 'y', 'z']
         """
         self._validate_list(list_)
-        for value in values:
-            list_.append(value)
+        list_.extend(values)
 
     def insert_into_list(self, list_, index, value):
         """Inserts ``value`` into ``list`` to the position specified with ``index``.
@@ -159,10 +158,7 @@ class _List:
         duplicates. Number of the removed duplicates is logged.
         """
         self._validate_list(list_)
-        ret = []
-        for item in list_:
-            if item not in ret:
-                ret.append(item)
+        ret = list(dict.fromkeys(list_))
         removed = len(list_) - len(ret)
         logger.info(f'{removed} duplicate{s(removed)} removed.')
         return ret

--- a/src/robot/libraries/Collections.py
+++ b/src/robot/libraries/Collections.py
@@ -833,7 +833,7 @@ class _Dictionary:
             except AssertionError as err:
                 errors.append(str(err))
         if errors:
-            error = '\n'.join([f'Following keys have different values:', *errors])
+            error = '\n'.join(['Following keys have different values:', *errors])
             _report_error(error, message, values)
 
     def dictionary_should_contain_sub_dictionary(self, dict1, dict2, msg=None,

--- a/src/robot/libraries/DateTime.py
+++ b/src/robot/libraries/DateTime.py
@@ -334,12 +334,10 @@ def get_current_date(time_zone='local', increment=0,
     | Should Be Equal | ${date.month}    | ${6}                    |
     """
     upper = time_zone.upper()
-    if upper == 'LOCAL':
-        dt = datetime.now()
     # Epoch time is same regardless the timezone. We convert `dt` to epoch time
     # using `time.mktime()` afterwards, and it expects time in local time.
     # For details: https://github.com/robotframework/robotframework/issues/3306
-    elif upper == 'UTC' and result_format.upper() == 'EPOCH':
+    if upper == 'LOCAL' or upper == 'UTC' and result_format.upper() == 'EPOCH':
         dt = datetime.now()
     elif upper == 'UTC':
         dt = datetime.utcnow()

--- a/src/robot/libraries/Process.py
+++ b/src/robot/libraries/Process.py
@@ -511,11 +511,10 @@ class Process:
     def _manage_process_timeout(self, handle, on_timeout):
         if on_timeout == 'terminate':
             return self.terminate_process(handle)
-        elif on_timeout == 'kill':
+        if on_timeout == 'kill':
             return self.terminate_process(handle, kill=True)
-        else:
-            logger.info('Leaving process intact.')
-            return None
+        logger.info('Leaving process intact.')
+        return None
 
     def _wait(self, process):
         result = self._results[process]
@@ -730,7 +729,7 @@ class Process:
                                                  stdout_path, stderr_path)
         if not attributes:
             return result
-        elif len(attributes) == 1:
+        if len(attributes) == 1:
             return attributes[0]
         return attributes
 

--- a/src/robot/libraries/Process.py
+++ b/src/robot/libraries/Process.py
@@ -755,7 +755,8 @@ class Process:
         self._processes.switch(handle)
 
     def _process_is_stopped(self, process, timeout):
-        stopped = lambda: process.poll() is not None
+        def stopped():
+            return process.poll() is not None
         max_time = time.time() + timeout
         while time.time() <= max_time and not stopped():
             time.sleep(min(0.1, timeout))

--- a/src/robot/libraries/Process.py
+++ b/src/robot/libraries/Process.py
@@ -498,10 +498,9 @@ class Process:
         process = self._processes[handle]
         logger.info('Waiting for process to complete.')
         timeout = self._get_timeout(timeout)
-        if timeout > 0:
-            if not self._process_is_stopped(process, timeout):
-                logger.info(f'Process did not complete in {secs_to_timestr(timeout)}.')
-                return self._manage_process_timeout(handle, on_timeout.lower())
+        if timeout > 0 and not self._process_is_stopped(process, timeout):
+            logger.info(f'Process did not complete in {secs_to_timestr(timeout)}.')
+            return self._manage_process_timeout(handle, on_timeout.lower())
         return self._wait(process)
 
     def _get_timeout(self, timeout):
@@ -932,12 +931,12 @@ class ProcessConfiguration:
             env = NormalizedDict(env, spaceless=False)
         self._add_to_env(env, extra)
         if WINDOWS:
-            env = dict((key.upper(), env[key]) for key in env)
+            env = {key.upper(): env[key] for key in env}
         return env
 
     def _get_initial_env(self, env, extra):
         if env:
-            return dict((system_encode(k), system_encode(env[k])) for k in env)
+            return {system_encode(k): system_encode(env[k]) for k in env}
         if extra:
             return os.environ.copy()
         return None

--- a/src/robot/libraries/Remote.py
+++ b/src/robot/libraries/Remote.py
@@ -13,7 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 
 import http.client
 import re
@@ -65,10 +65,8 @@ class Remote:
 
     def _is_lib_info_available(self):
         if not self._lib_info_initialized:
-            try:
+            with suppress(TypeError):
                 self._lib_info = self._client.get_library_information()
-            except TypeError:
-                pass
             self._lib_info_initialized = True
         return self._lib_info is not None
 

--- a/src/robot/libraries/Screenshot.py
+++ b/src/robot/libraries/Screenshot.py
@@ -194,7 +194,7 @@ class Screenshot:
                      % self._screenshot_taker.module)
         try:
             self._screenshot_taker(path)
-        except:
+        except Exception:
             logger.warn('Taking screenshot failed: %s\n'
                         'Make sure tests are run with a physical or virtual '
                         'display.' % get_error_message())
@@ -252,7 +252,7 @@ class ScreenshotTaker:
         print("Taking test screenshot to '%s'." % path)
         try:
             self(path)
-        except:
+        except Exception:
             print("Failed: %s" % get_error_message())
             return False
         else:

--- a/src/robot/libraries/Screenshot.py
+++ b/src/robot/libraries/Screenshot.py
@@ -110,10 +110,7 @@ class Screenshot:
     def _norm_path(self, path):
         if not path:
             return path
-        elif isinstance(path, os.PathLike):
-            path = str(path)
-        else:
-            path = path.replace('/', os.sep)
+        path = str(path) if isinstance(path, os.PathLike) else path.replace('/', os.sep)
         return os.path.normpath(path)
 
     @property

--- a/src/robot/libraries/String.py
+++ b/src/robot/libraries/String.py
@@ -475,7 +475,7 @@ class String:
         # re.sub handles 0 and negative counts differently than string.replace
         if count == 0:
             return string
-        return re.sub(pattern, replace_with, string, max(count, 0), flags=parse_re_flags(flags))
+        return re.sub(pattern, replace_with, string, count=max(count, 0), flags=parse_re_flags(flags))
 
     def remove_string(self, string, *removables):
         """Removes all ``removables`` from the given ``string``.

--- a/src/robot/libraries/String.py
+++ b/src/robot/libraries/String.py
@@ -292,9 +292,11 @@ class String:
             ignore_case = case_insensitive
         if ignore_case:
             pattern = pattern.casefold()
-            contains = lambda line: pattern in line.casefold()
+            def contains(line):
+                return pattern in line.casefold()
         else:
-            contains = lambda line: pattern in line
+            def contains(line):
+                return pattern in line
         return self._get_matching_lines(string, contains)
 
     def get_lines_matching_pattern(self, string: str, pattern: str,
@@ -331,9 +333,11 @@ class String:
             ignore_case = case_insensitive
         if ignore_case:
             pattern = pattern.casefold()
-            matches = lambda line: fnmatchcase(line.casefold(), pattern)
+            def matches(line):
+                return fnmatchcase(line.casefold(), pattern)
         else:
-            matches = lambda line: fnmatchcase(line, pattern)
+            def matches(line):
+                return fnmatchcase(line, pattern)
         return self._get_matching_lines(string, matches)
 
     def get_lines_matching_regexp(self, string, pattern, partial_match=False, flags=None):

--- a/src/robot/libraries/Telnet.py
+++ b/src/robot/libraries/Telnet.py
@@ -1095,8 +1095,7 @@ class TelnetConnection(telnetlib.Telnet):
         if cmd in (telnetlib.DO, telnetlib.DONT, telnetlib.WILL, telnetlib.WONT):
             if (cmd, opt) in self._opt_responses:
                 return
-            else:
-                self._opt_responses.append((cmd, opt))
+            self._opt_responses.append((cmd, opt))
 
         # This is supposed to turn server side echoing on and turn other options off.
         if opt == telnetlib.ECHO and cmd in (telnetlib.WILL, telnetlib.WONT):

--- a/src/robot/libraries/Telnet.py
+++ b/src/robot/libraries/Telnet.py
@@ -509,7 +509,7 @@ class TelnetConnection(telnetlib.Telnet):
         self._terminal_type = self._encode(terminal_type) if terminal_type else None
         self.set_option_negotiation_callback(self._negotiate_options)
         self._set_telnetlib_log_level(telnetlib_log_level)
-        self._opt_responses = list()
+        self._opt_responses = []
 
     def set_timeout(self, timeout):
         """Sets the timeout used for waiting output in the current connection.

--- a/src/robot/libraries/XML.py
+++ b/src/robot/libraries/XML.py
@@ -520,7 +520,7 @@ class XML:
             tree = self.etree.parse(source)
         if self.lxml_etree:
             strip = (lxml_etree.Comment, lxml_etree.ProcessingInstruction)
-            lxml_etree.strip_elements(tree, *strip, **dict(with_tail=False))
+            lxml_etree.strip_elements(tree, *strip, with_tail=False)
         root = tree.getroot()
         if not is_truthy(keep_clark_notation):
             self._ns_stripper.strip(root, preserve=is_falsy(strip_namespaces))
@@ -692,8 +692,7 @@ class XML:
         if element.text:
             yield element.text
         for child in element:
-            for text in self._yield_texts(child, top=False):
-                yield text
+            yield from self._yield_texts(child, top=False)
         if element.tail and not top:
             yield element.tail
 

--- a/src/robot/libraries/dialogs_py.py
+++ b/src/robot/libraries/dialogs_py.py
@@ -179,8 +179,7 @@ class MultipleSelectionDialog(TkDialog):
         return widget
 
     def _get_value(self) -> list:
-        selected_values = [self.widget.get(i) for i in self.widget.curselection()]
-        return selected_values
+        return [self.widget.get(i) for i in self.widget.curselection()]
 
 
 class PassFailDialog(TkDialog):

--- a/src/robot/model/body.py
+++ b/src/robot/model/body.py
@@ -281,12 +281,10 @@ class Body(BaseBody['Keyword', 'For', 'While', 'If', 'Try', 'Var', 'Return',
 
     Body contains the keywords and other structures such as FOR loops.
     """
-    pass
 
 
 class BranchType(Generic[IT]):
     """Class that wrapps `Generic` as python doesn't allow multple generic inheritance"""
-    pass
 
 
 class BaseBranches(BaseBody[KW, F, W, I, T, V, R, C, B, M, E], BranchType[IT]):

--- a/src/robot/model/control.py
+++ b/src/robot/model/control.py
@@ -221,7 +221,7 @@ class If(BodyItem):
     @property
     def id(self) -> None:
         """Root IF/ELSE id is always ``None``."""
-        return None
+        return
 
     def visit(self, visitor: SuiteVisitor):
         visitor.visit_if(self)
@@ -348,7 +348,7 @@ class Try(BodyItem):
     @property
     def id(self) -> None:
         """Root TRY/EXCEPT id is always ``None``."""
-        return None
+        return
 
     def visit(self, visitor: SuiteVisitor):
         visitor.visit_try(self)

--- a/src/robot/model/modelobject.py
+++ b/src/robot/model/modelobject.py
@@ -230,7 +230,7 @@ class JsonDumper:
     def dump(self, data: DataDict, output: 'None|TextIO|Path|str' = None) -> 'None|str':
         if not output:
             return json.dumps(data, **self.config)
-        elif isinstance(output, (str, Path)):
+        if isinstance(output, (str, Path)):
             with open(output, 'w', encoding='UTF-8') as file:
                 json.dump(data, file, **self.config)
         elif hasattr(output, 'write'):

--- a/src/robot/model/stats.py
+++ b/src/robot/model/stats.py
@@ -49,12 +49,12 @@ class Stat(Sortable):
         if include_elapsed:
             attrs['elapsed'] = elapsed_time_to_string(self.elapsed, include_millis=False)
         if exclude_empty:
-            attrs = dict((k, v) for k, v in attrs.items() if v not in ('', None))
+            attrs = {k: v for k, v in attrs.items() if v not in ('', None)}
         if values_as_strings:
-            attrs = dict((k, str(v) if v is not None else '')
-                         for k, v in attrs.items())
+            attrs = {k: str(v) if v is not None else ''
+                         for k, v in attrs.items()}
         if html_escape:
-            attrs = dict((k, self._html_escape(v)) for k, v in attrs.items())
+            attrs = {k: self._html_escape(v) for k, v in attrs.items()}
         return attrs
 
     def _get_custom_attrs(self):

--- a/src/robot/model/suitestatistics.py
+++ b/src/robot/model/suitestatistics.py
@@ -31,8 +31,7 @@ class SuiteStatistics:
     def __iter__(self):
         yield self.stat
         for child in self.suites:
-            for stat in child:
-                yield stat
+            yield from child
 
 
 class SuiteStatisticsBuilder:

--- a/src/robot/model/visitor.py
+++ b/src/robot/model/visitor.py
@@ -139,11 +139,9 @@ class SuiteVisitor:
 
         Can return explicit ``False`` to stop visiting.
         """
-        pass
 
     def end_suite(self, suite: 'TestSuite'):
         """Called when a suite ends. Default implementation does nothing."""
-        pass
 
     def visit_test(self, test: 'TestCase'):
         """Implements traversing through tests.
@@ -164,11 +162,9 @@ class SuiteVisitor:
 
         Can return explicit ``False`` to stop visiting.
         """
-        pass
 
     def end_test(self, test: 'TestCase'):
         """Called when a test ends. Default implementation does nothing."""
-        pass
 
     def visit_keyword(self, keyword: 'Keyword'):
         """Implements traversing through keywords.
@@ -576,7 +572,6 @@ class SuiteVisitor:
         Can return explicit ``False`` to stop visiting. Default implementation does
         nothing.
         """
-        pass
 
     def end_body_item(self, item: 'BodyItem'):
         """Called, by default, when keywords, messages or control structures end.
@@ -587,4 +582,3 @@ class SuiteVisitor:
 
         Default implementation does nothing.
         """
-        pass

--- a/src/robot/output/listeners.py
+++ b/src/robot/output/listeners.py
@@ -504,11 +504,10 @@ class ListenerV2Facade(ListenerFacade):
     def _message_attributes(self, msg):
         # Timestamp in our legacy format.
         timestamp = msg.timestamp.isoformat(' ', timespec='milliseconds').replace('-', '')
-        attrs = {'timestamp': timestamp,
+        return {'timestamp': timestamp,
                  'message': msg.message,
                  'level': msg.level,
                  'html': 'yes' if msg.html else 'no'}
-        return attrs
 
 
 def import_listener(listener):

--- a/src/robot/output/pyloggingconf.py
+++ b/src/robot/output/pyloggingconf.py
@@ -70,7 +70,7 @@ class RobotHandler(logging.Handler):
     def _get_message(self, record):
         try:
             return self.format(record), None
-        except:
+        except Exception:
             message = 'Failed to log following message properly: %s' \
                         % safe_str(record.msg)
             error = '\n'.join(get_error_details())

--- a/src/robot/parsing/lexer/lexer.py
+++ b/src/robot/parsing/lexer/lexer.py
@@ -127,10 +127,7 @@ class Lexer:
         return tokens
 
     def _get_tokens(self, statements: 'Iterable[list[Token]]') -> 'Iterator[Token]':
-        if self.data_only:
-            ignored_types = {None, Token.COMMENT}
-        else:
-            ignored_types = {None}
+        ignored_types = {None, Token.COMMENT} if self.data_only else {None}
         inline_if_type = Token.INLINE_IF
         for statement in statements:
             last = None

--- a/src/robot/parsing/suitestructure.py
+++ b/src/robot/parsing/suitestructure.py
@@ -184,10 +184,7 @@ class ValidExtensions:
                 self.extensions.add(ext.lstrip('.').lower())
 
     def match(self, path: Path) -> bool:
-        for ext in self._extensions_from(path):
-            if ext in self.extensions:
-                return True
-        return False
+        return any(ext in self.extensions for ext in self._extensions_from(path))
 
     def get_extension(self, path: Path) -> str:
         for ext in self._extensions_from(path):

--- a/src/robot/reporting/jsexecutionresult.py
+++ b/src/robot/reporting/jsexecutionresult.py
@@ -73,8 +73,7 @@ class _KeywordRemover:
             if isinstance(item, StringIndex):
                 yield item
             elif isinstance(item, tuple):
-                for i in self._get_used_indices(item):
-                    yield i
+                yield from self._get_used_indices(item)
 
     def _get_used_strings(self, strings, used_indices, remap):
         offset = 0

--- a/src/robot/result/flattenkeywordmatcher.py
+++ b/src/robot/result/flattenkeywordmatcher.py
@@ -24,9 +24,7 @@ def validate_flatten_keyword(options):
         # TODO: Deprecate 'foritem' in RF 6.1!
         if low == 'foritem':
             low = 'iteration'
-        if not (low in ('for', 'while', 'iteration') or
-                low.startswith('name:') or
-                low.startswith('tag:')):
+        if not (low in ('for', 'while', 'iteration') or low.startswith(('name:', 'tag:'))):
             raise DataError(f"Expected 'FOR', 'WHILE', 'ITERATION', 'TAG:<pattern>' or "
                             f"'NAME:<pattern>', got '{opt}'.")
 

--- a/src/robot/result/model.py
+++ b/src/robot/result/model.py
@@ -71,7 +71,6 @@ class Branches(model.BaseBranches['Keyword', 'For', 'While', 'If', 'Try', 'Var',
 
 class IterationType(Generic[FW]):
     """Class that wrapps `Generic` as python doesn't allow multple generic inheritance"""
-    pass
 
 
 class Iterations(model.BaseBody['Keyword', 'For', 'While', 'If', 'Try', 'Var', 'Return',

--- a/src/robot/run.py
+++ b/src/robot/run.py
@@ -473,8 +473,9 @@ class RobotFramework(Application):
         return self._filter_options_without_value(options), arguments
 
     def _filter_options_without_value(self, options):
-        return dict((name, value) for name, value in options.items()
-                    if value not in (None, []))
+        return {
+            name: value for name, value in options.items() if value not in (None, [])
+        }
 
 
 def run_cli(arguments=None, exit=True):

--- a/src/robot/running/arguments/argumentconverter.py
+++ b/src/robot/running/arguments/argumentconverter.py
@@ -85,9 +85,9 @@ class ArgumentConverter:
         # https://github.com/robotframework/robotframework/issues/4881
         if name in spec.defaults:
             typ = type(spec.defaults[name])
-            if typ == str:      # Don't convert arguments to strings.
+            if typ is str:      # Don't convert arguments to strings.
                 info = TypeInfo()
-            elif typ == int:    # Try also conversion to float.
+            elif typ is int:    # Try also conversion to float.
                 info = TypeInfo.from_sequence([int, float])
             else:
                 info = TypeInfo.from_type(typ)

--- a/src/robot/running/arguments/argumentmapper.py
+++ b/src/robot/running/arguments/argumentmapper.py
@@ -64,7 +64,8 @@ class KeywordCallTemplate:
                 self.kwargs.append((name, value))
 
     def replace_defaults(self):
-        is_default = lambda arg: isinstance(arg, DefaultValue)
+        def is_default(arg):
+            return isinstance(arg, DefaultValue)
         while self.args and is_default(self.args[-1]):
             self.args.pop()
         self.args = [a if not is_default(a) else a.value for a in self.args]

--- a/src/robot/running/arguments/argumentvalidator.py
+++ b/src/robot/running/arguments/argumentvalidator.py
@@ -29,7 +29,7 @@ class ArgumentValidator:
         self.arg_spec = arg_spec
 
     def validate(self, positional, named, dryrun=False):
-        named = set(name for name, value in named)
+        named = {name for name, value in named}
         if dryrun and (any(is_list_variable(arg) for arg in positional) or
                        any(is_dict_variable(arg) for arg in named)):
             return

--- a/src/robot/running/arguments/typeconverters.py
+++ b/src/robot/running/arguments/typeconverters.py
@@ -15,7 +15,8 @@
 
 from ast import literal_eval
 from collections import OrderedDict
-from collections.abc import ByteString, Container, Mapping, Sequence, Set
+from collections.abc import ByteString, Container, Mapping, Sequence
+from collections.abc import Set as AbstractSet
 from datetime import datetime, date, timedelta
 from decimal import InvalidOperation, Decimal
 from enum import Enum
@@ -401,7 +402,7 @@ class NoneConverter(TypeConverter):
 
     def _convert(self, value):
         if value.upper() == 'NONE':
-            return None
+            return
         raise ValueError
 
 
@@ -603,7 +604,7 @@ class DictionaryConverter(TypeConverter):
 @TypeConverter.register
 class SetConverter(TypeConverter):
     type = set
-    abc = Set
+    abc = AbstractSet
     type_name = 'set'
     value_types = (str, Container)
 

--- a/src/robot/running/arguments/typeinfo.py
+++ b/src/robot/running/arguments/typeinfo.py
@@ -13,7 +13,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from collections.abc import Mapping, Sequence, Set
+from collections.abc import Mapping, Sequence
+from collections.abc import Set as AbstractSet
 from datetime import date, datetime, timedelta
 from decimal import Decimal
 from pathlib import Path
@@ -106,10 +107,11 @@ class TypeInfo(metaclass=SetterAwareType):
         elif issubclass(typ, tuple):
             if nested[-1].type is Ellipsis and len(nested) != 2:
                 self._report_nested_error(nested, 1, 'Homogenous tuple', offset=-1)
-        elif issubclass(typ, Sequence) and not issubclass(typ, (str, bytes, bytearray)):
-            if len(nested) != 1:
-                self._report_nested_error(nested, 1)
-        elif issubclass(typ, Set):
+        elif (
+            issubclass(typ, AbstractSet)
+            or issubclass(typ, Sequence)
+            and not issubclass(typ, (str, bytes, bytearray))
+        ):
             if len(nested) != 1:
                 self._report_nested_error(nested, 1)
         elif issubclass(typ, Mapping):

--- a/src/robot/running/bodyrunner.py
+++ b/src/robot/running/bodyrunner.py
@@ -705,12 +705,11 @@ class WhileLimit:
         on_limit_pass = self.on_limit == 'PASS'
         if self.on_limit_message:
             raise LimitExceeded(on_limit_pass, self.on_limit_message)
-        else:
-            raise LimitExceeded(
-                on_limit_pass,
-                f"WHILE loop was aborted because it did not finish within the limit of {self}. "
-                f"Use the 'limit' argument to increase or remove the limit if needed."
-            )
+        raise LimitExceeded(
+            on_limit_pass,
+            f"WHILE loop was aborted because it did not finish within the limit of {self}. "
+            f"Use the 'limit' argument to increase or remove the limit if needed."
+        )
 
     def __enter__(self):
         raise NotImplementedError

--- a/src/robot/running/builder/parsers.py
+++ b/src/robot/running/builder/parsers.py
@@ -81,8 +81,7 @@ class RobotParser(Parser):
         model = get_resource_model(self._get_source(source), data_only=True,
                                    curdir=self._get_curdir(source), lang=self.lang)
         model.source = source
-        resource = self.parse_resource_model(model)
-        return resource
+        return self.parse_resource_model(model)
 
     def parse_resource_model(self, model: File) -> ResourceFile:
         resource = ResourceFile(source=model.source)

--- a/src/robot/running/builder/transformers.py
+++ b/src/robot/running/builder/transformers.py
@@ -485,8 +485,7 @@ class ErrorReporter(ModelVisitor):
         if token.type == Token.INVALID_HEADER:
             if self.raise_on_invalid_header:
                 raise DataError(message)
-            else:
-                LOGGER.error(message)
+            LOGGER.error(message)
         else:
             # Errors, other than totally invalid headers, can occur only with
             # deprecated singular headers, and we want to report them as warnings.

--- a/src/robot/running/dynamicmethods.py
+++ b/src/robot/running/dynamicmethods.py
@@ -53,7 +53,7 @@ class _DynamicMethod:
             if ctx and ctx.asynchronous.is_loop_required(result):
                 result = ctx.asynchronous.run_until_complete(result)
             return self._handle_return_value(result)
-        except:
+        except Exception:
             raise DataError("Calling dynamic method '%s' failed: %s"
                             % (self.name, get_error_message()))
 

--- a/src/robot/running/handlers.py
+++ b/src/robot/running/handlers.py
@@ -237,8 +237,7 @@ class _DynamicHandler(_RunnableHandler):
         def handler(*positional, **kwargs):
             if self._supports_kwargs:
                 return runner(name, positional, kwargs)
-            else:
-                return runner(name, positional)
+            return runner(name, positional)
         return handler
 
 

--- a/src/robot/running/namespace.py
+++ b/src/robot/running/namespace.py
@@ -451,8 +451,9 @@ class KeywordStore:
         for owner_name, kw_name in self._get_owner_and_kw_names(name):
             for owner in chain(self.libraries.values(), self.resources.values()):
                 if eq(owner.name, owner_name) and kw_name in owner.handlers:
-                    for handler in owner.handlers.get_handlers(kw_name):
-                        handlers_and_names.append((handler, kw_name))
+                    handlers_and_names.extend(
+                        [(handler, kw_name) for handler in owner.handlers.get_handlers(kw_name)]
+                    )
         if not handlers_and_names:
             return None
         if len(handlers_and_names) == 1:

--- a/src/robot/running/testlibraries.py
+++ b/src/robot/running/testlibraries.py
@@ -52,8 +52,7 @@ def _get_lib_class(libcode):
     if GetKeywordNames(libcode):
         if RunKeyword(libcode):
             return _DynamicLibrary
-        else:
-            return _HybridLibrary
+        return _HybridLibrary
     return _ClassLibrary
 
 

--- a/src/robot/running/testlibraries.py
+++ b/src/robot/running/testlibraries.py
@@ -34,10 +34,7 @@ from .outputcapture import OutputCapturer
 
 
 def TestLibrary(name, args=None, variables=None, create_handlers=True, logger=LOGGER):
-    if name in STDLIBS:
-        import_name = 'robot.libraries.' + name
-    else:
-        import_name = name
+    import_name = 'robot.libraries.' + name if name in STDLIBS else name
     with OutputCapturer(library_import=True):
         importer = Importer('library', logger=LOGGER)
         libcode, source = importer.import_class_or_module(import_name,
@@ -187,7 +184,7 @@ class _BaseTestLibrary:
         with OutputCapturer(library_import=True):
             try:
                 return libcode(*self.positional_args, **dict(self.named_args))
-            except:
+            except Exception:
                 self._raise_creating_instance_failed()
 
     def get_listeners(self, libinst=None):
@@ -319,8 +316,8 @@ class _BaseTestLibrary:
         embedded = EmbeddedArguments.from_name(handler.name)
         if embedded:
             if len(embedded.args) > handler.arguments.maxargs:
-                raise DataError(f'Keyword must accept at least as many positional '
-                                f'arguments as it has embedded arguments.')
+                raise DataError('Keyword must accept at least as many positional '
+                                'arguments as it has embedded arguments.')
             handler.arguments.embedded = embedded.args
             return EmbeddedArgumentsHandler(embedded, handler), True
         return handler, False

--- a/src/robot/running/testlibraries.py
+++ b/src/robot/running/testlibraries.py
@@ -260,7 +260,8 @@ class _BaseTestLibrary:
 
         auto_keywords = getattr(libcode, 'ROBOT_AUTO_KEYWORDS', True)
         if auto_keywords:
-            predicate = lambda name: name[:1] != '_' or has_robot_name(name)
+            def predicate(name):
+                return name[:1] != '_' or has_robot_name(name)
         else:
             predicate = has_robot_name
         return [name for name in dir(libcode) if predicate(name)]
@@ -411,5 +412,6 @@ class _DynamicLibrary(_BaseTestLibrary):
         return DynamicHandler(self, name, method, doc, argspec, tags)
 
     def _create_init_handler(self, libcode):
-        docgetter = lambda: self._get_kw_doc('__init__')
+        def docgetter():
+            return self._get_kw_doc('__init__')
         return InitHandler(self, self._resolve_init_method(libcode), docgetter)

--- a/src/robot/running/timeouts/__init__.py
+++ b/src/robot/running/timeouts/__init__.py
@@ -74,7 +74,8 @@ class _Timeout(Sortable):
                              test_timeout=isinstance(self, TestTimeout))
         if timeout <= 0:
             raise error
-        executable = lambda: runnable(*(args or ()), **(kwargs or {}))
+        def executable():
+            return runnable(*(args or ()), **(kwargs or {}))
         return Timeout(timeout, error).execute(executable)
 
     def get_message(self):

--- a/src/robot/utils/application.py
+++ b/src/robot/utils/application.py
@@ -84,7 +84,7 @@ class Application:
         except (KeyboardInterrupt, SystemExit):
             return self._report_error('Execution stopped by user.',
                                       rc=STOPPED_BY_USER)
-        except:
+        except Exception:
             error, details = get_error_details(exclude_robot_traces=False)
             return self._report_error('Unexpected error: %s' % error,
                                       details, rc=FRAMEWORK_ERROR)

--- a/src/robot/utils/asserts.py
+++ b/src/robot/utils/asserts.py
@@ -177,7 +177,7 @@ def assert_raises_with_msg(exc_class, expected_msg, callable_obj, *args,
 
 def assert_equal(first, second, msg=None, values=True, formatter=safe_str):
     """Fail if given objects are unequal as determined by the '==' operator."""
-    if not first == second:
+    if first != second:
         _report_inequality(first, second, '!=', msg, values, formatter)
 
 

--- a/src/robot/utils/error.py
+++ b/src/robot/utils/error.py
@@ -105,11 +105,10 @@ class ErrorDetails:
                 return traceback.format_exception(etype, value, tb)
             else:
                 return empty_tb + traceback.format_exception_only(etype, value)
+        elif tb:
+            return [prefix] + traceback.format_tb(tb)
         else:
-            if tb:
-                return [prefix] + traceback.format_tb(tb)
-            else:
-                return empty_tb
+            return empty_tb
 
     def _format_message(self, error):
         name = type(error).__name__.split('.')[-1]  # Use only the last part

--- a/src/robot/utils/error.py
+++ b/src/robot/utils/error.py
@@ -103,12 +103,10 @@ class ErrorDetails:
         if self._full_traceback:
             if tb or value.__context__ or value.__cause__:
                 return traceback.format_exception(etype, value, tb)
-            else:
-                return empty_tb + traceback.format_exception_only(etype, value)
-        elif tb:
+            return empty_tb + traceback.format_exception_only(etype, value)
+        if tb:
             return [prefix] + traceback.format_tb(tb)
-        else:
-            return empty_tb
+        return empty_tb
 
     def _format_message(self, error):
         name = type(error).__name__.split('.')[-1]  # Use only the last part

--- a/src/robot/utils/etreewrapper.py
+++ b/src/robot/utils/etreewrapper.py
@@ -49,7 +49,7 @@ class ETSource:
     def _is_path(self, source):
         if is_pathlike(source):
             return True
-        elif is_string(source):
+        if is_string(source):
             prefix = '<'
         elif is_bytes(source):
             prefix = b'<'

--- a/src/robot/utils/htmlformatters.py
+++ b/src/robot/utils/htmlformatters.py
@@ -73,7 +73,8 @@ class LinkFormatter:
 
 
 class LineFormatter:
-    handles = lambda self, line: True
+    def handles(self, line):
+        return True
     newline = '\n'
     _bold = re.compile(r'''
 (                         # prefix (group 1)

--- a/src/robot/utils/htmlformatters.py
+++ b/src/robot/utils/htmlformatters.py
@@ -59,7 +59,7 @@ class LinkFormatter:
         return ''.join(f(t) for f, t in zip(formatters, tokens))
 
     def _format_link(self, text):
-        link, content = [t.strip() for t in text.split('|', 1)]
+        link, content = (t.strip() for t in text.split('|', 1))
         if self._is_image(content):
             content = self._get_image(content, link)
         elif self._is_image(link):

--- a/src/robot/utils/importer.py
+++ b/src/robot/utils/importer.py
@@ -189,7 +189,7 @@ class Importer:
             raise DataError(err.args[0])
         try:
             return imported(*positional, **dict(named))
-        except:
+        except Exception:
             raise DataError('Creating instance failed: %s\n%s' % get_error_details())
 
     def _get_arg_spec(self, imported):
@@ -215,7 +215,7 @@ class _Importer:
         importlib.invalidate_caches()
         try:
             return __import__(name, fromlist=fromlist)
-        except:
+        except Exception:
             message, traceback = get_error_details(full_traceback=False)
             path = '\n'.join(f'  {p}' for p in sys.path)
             raise DataError(f'{message}\n{traceback}\nPYTHONPATH:\n{path}')
@@ -256,7 +256,7 @@ class ByPathImporter(_Importer):
             raise DataError('File or directory does not exist.')
         if not os.path.isabs(path):
             raise DataError('Import path must be absolute.')
-        if not os.path.splitext(path)[1] in self._valid_import_extensions:
+        if os.path.splitext(path)[1] not in self._valid_import_extensions:
             raise DataError('Not a valid file or directory to import.')
 
     def _remove_wrong_module_from_sys_modules(self, path):

--- a/src/robot/utils/normalizing.py
+++ b/src/robot/utils/normalizing.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 
 import re
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from typing import Any, MutableMapping, TypeVar
 
 

--- a/src/robot/utils/restreader.py
+++ b/src/robot/utils/restreader.py
@@ -68,7 +68,8 @@ def directive(*args, **kwargs):
     directive_class, messages = directive.__wrapped__(*args, **kwargs)
     if directive_class not in relevant_directives:
         # Skipping unknown or non-relevant directive entirely
-        directive_class = (lambda *args, **kwargs: [])
+        def directive_class(*args, **kwargs):
+            return []
     return directive_class, messages
 
 

--- a/src/robot/utils/robotenv.py
+++ b/src/robot/utils/robotenv.py
@@ -40,5 +40,7 @@ def del_env_var(name):
 
 def get_env_vars(upper=os.sep != '/'):
     # by default, name is upper-cased on Windows regardless interpreter
-    return dict((name if not upper else name.upper(), get_env_var(name))
-                for name in (decode(name) for name in os.environ))
+    return {
+        name if not upper else name.upper(): get_env_var(name)
+        for name in (decode(name) for name in os.environ)
+    }

--- a/src/robot/utils/robotio.py
+++ b/src/robot/utils/robotio.py
@@ -29,7 +29,7 @@ def file_writer(path=None, encoding='UTF-8', newline=None, usage=None):
         path = str(path)
     create_destination_directory(path, usage)
     try:
-        return io.open(path, 'w', encoding=encoding, newline=newline)
+        return open(path, 'w', encoding=encoding, newline=newline)
     except EnvironmentError:
         usage = '%s file' % usage if usage else 'file'
         raise DataError("Opening %s '%s' failed: %s"
@@ -40,7 +40,7 @@ def binary_file_writer(path=None):
     if path:
         if is_pathlike(path):
             path = str(path)
-        return io.open(path, 'wb')
+        return open(path, 'wb')
     f = io.BytesIO()
     getvalue = f.getvalue
     f.getvalue = lambda encoding='UTF-8': getvalue().decode(encoding)

--- a/src/robot/utils/robottime.py
+++ b/src/robot/utils/robottime.py
@@ -235,10 +235,9 @@ def get_time(format='timestamp', time_=None):
     if not parts:
         return dt.isoformat(' ', timespec='seconds')
     # Return requested parts of the time
-    elif len(parts) == 1:
+    if len(parts) == 1:
         return parts[0]
-    else:
-        return parts
+    return parts
 
 
 def parse_timestamp(timestamp: 'str|datetime') -> datetime:

--- a/src/robot/utils/setter.py
+++ b/src/robot/utils/setter.py
@@ -87,8 +87,6 @@ class SetterAwareType(type):
     def __new__(cls, name, bases, dct):
         if '__slots__' in dct:
             slots = list(dct['__slots__'])
-            for item in dct.values():
-                if isinstance(item, setter):
-                    slots.append(item.attr_name)
+            slots.extend([item.attr_name for item in dct.values() if isinstance(item, setter)])
             dct['__slots__'] = slots
         return type.__new__(cls, name, bases, dct)

--- a/src/robot/utils/unic.py
+++ b/src/robot/utils/unic.py
@@ -32,7 +32,7 @@ def _safe_str(item):
             return ''.join(chr(b) if b < 128 else '\\x%x' % b for b in item)
     try:
         return str(item)
-    except:
+    except Exception:
         return _unrepresentable_object(item)
 
 
@@ -45,7 +45,7 @@ class PrettyRepr(PrettyPrinter):
     def format(self, object, context, maxlevels, level):
         try:
             return PrettyPrinter.format(self, object, context, maxlevels, level)
-        except:
+        except Exception:
             return _unrepresentable_object(object), True, False
 
     # Don't split strings: https://stackoverflow.com/questions/31485402

--- a/src/robot/variables/assigner.py
+++ b/src/robot/variables/assigner.py
@@ -15,6 +15,7 @@
 
 import re
 from collections.abc import MutableSequence
+from contextlib import suppress
 
 from robot.errors import (DataError, ExecutionStatus, HandlerExecutionFailed,
                           VariableError)
@@ -180,10 +181,8 @@ class VariableAssigner:
                 )
         selector = variables.replace_scalar(item)
         if isinstance(var, MutableSequence):
-            try:
+            with suppress(ValueError):
                 selector = self._parse_sequence_index(selector)
-            except ValueError:
-                pass
         try:
             value = self._validate_item_assign(name, value)
             var[selector] = value

--- a/src/robot/variables/assigner.py
+++ b/src/robot/variables/assigner.py
@@ -119,7 +119,7 @@ class VariableAssigner:
     def _extended_assign(self, name, value, variables):
         if name[0] != '$' or '.' not in name or name in variables:
             return False
-        base, attr = [token.strip() for token in name[2:-1].rsplit('.', 1)]
+        base, attr = (token.strip() for token in name[2:-1].rsplit('.', 1))
         try:
             var = variables.replace_scalar(f'${{{base}}}')
         except VariableError:

--- a/src/robot/variables/filesetter.py
+++ b/src/robot/variables/filesetter.py
@@ -128,7 +128,7 @@ class JsonImporter:
         return [(name, self._dot_dict(value)) for name, value in variables]
 
     def _import(self, path):
-        with io.open(path, encoding='UTF-8') as stream:
+        with open(path, encoding='UTF-8') as stream:
             variables = json.load(stream)
         if not is_dict_like(variables):
             raise DataError(f'JSON variable file must be a mapping, '
@@ -152,7 +152,7 @@ class YamlImporter:
         return [(name, self._dot_dict(value)) for name, value in variables]
 
     def _import(self, path):
-        with io.open(path, encoding='UTF-8') as stream:
+        with open(path, encoding='UTF-8') as stream:
             variables = self._load_yaml(stream)
         if not is_dict_like(variables):
             raise DataError(f'YAML variable file must be a mapping, '

--- a/src/robot/variables/finders.py
+++ b/src/robot/variables/finders.py
@@ -132,7 +132,7 @@ class ExtendedFinder:
                                 % (name, err.message))
         try:
             return eval('_BASE_VAR_' + extended, {'_BASE_VAR_': variable})
-        except:
+        except Exception:
             raise VariableError("Resolving variable '%s' failed: %s"
                                 % (name, get_error_message()))
 

--- a/src/robot/variables/scopes.py
+++ b/src/robot/variables/scopes.py
@@ -175,7 +175,7 @@ class GlobalVariables(Variables):
                 if name.lower().endswith(self._import_by_path_ends):
                     name = find_file(name, file_type='Variable file')
                 self.set_from_file(name, args)
-            except:
+            except Exception:
                 msg, details = get_error_details()
                 LOGGER.error(msg)
                 LOGGER.info(details)

--- a/src/robot/variables/store.py
+++ b/src/robot/variables/store.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from contextlib import suppress
 from robot.errors import DataError, VariableError
 from robot.utils import (DotDict, is_dict_like, is_list_like, NormalizedDict, NOT_SET,
                          type_name)
@@ -32,10 +33,8 @@ class VariableStore:
         if item:
             return self._resolve_delayed(*item)
         for name, value in list(self.data.items()):
-            try:
+            with suppress(DataError):
                 self._resolve_delayed(name, value)
-            except DataError:
-                pass
 
     def _resolve_delayed(self, name, value):
         if not self._is_resolvable(value):

--- a/src/robot/variables/tablesetter.py
+++ b/src/robot/variables/tablesetter.py
@@ -114,10 +114,7 @@ class ScalarVariableResolver(VariableResolver):
         value, separator = self.value, self.separator
         if self._is_single_value(value, separator):
             return variables.replace_scalar(value[0])
-        if separator is None:
-            separator = ' '
-        else:
-            separator = variables.replace_string(separator)
+        separator = ' ' if separator is None else variables.replace_string(separator)
         value = variables.replace_list(value)
         return separator.join(str(item) for item in value)
 


### PR DESCRIPTION
Hi @pekkaklarck 

I have taken ruff and let it run over the Robot Framework code (src folder)
It had found a huge amount, of things, but not all of them are relevant, because they are more naming decisions.
Others may be real issues.
Others just New vs Old technique. (like `pathlib.Path `vs `os.path`)
Others are considered better style...

I have applied some of the rules and excluded others.
I have a pack of rules i would consider worth fixing, but want to talk to you first.
- PTH100 `os.path.abspath()` should be replaced by `Path.resolve()`  (*And their siblings*)
- B904 Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
- UP031 Use format specifiers instead of percent format
- DTZ001 The use of `datetime.datetime()` without `tzinfo` argument is not allowed

Maybe you can find this valuable. 