### PR TITLE
implemented dark_light theme toggle button

### DIFF
--- a/src/robot/htmldata/rebot/common.css
+++ b/src/robot/htmldata/rebot/common.css
@@ -15,23 +15,20 @@
     --ascending-icon: url(data:image/gif;base64,R0lGODlhCwAJAKEAAAAAAH9/fwAAAAAAACH5BAEAAAIALAAAAAALAAkAAAIUlBWnFr3cnIr0WQOyBmvzp13CpxQAOw==);
     --descending-icon: url(data:image/gif;base64,R0lGODlhCwAJAKEAAAAAAH9/fwAAAAAAACH5BAEAAAIALAAAAAALAAkAAAIUlAWnBr3cnIr0WROyDmvzp13CpxQAOw==);
 }
-
-@media (prefers-color-scheme: dark) {
-    :root {
-        color-scheme: dark;
-        --text-color: white;
-        --background-color: #1c2227;
-        --primary-color: #26373b;
-        --secondary-color: #424f5a;
-        --link-color: #8cc4ff;
-        --link-hover-color: #bb86fc;
-        --highlight-color: #002b36;
-        --pass-link-color: #97bd61;
-        --warn-link-color: #fed84f;
-        --fail-link-color: #ff9b8f;
-        --ascending-icon: url(data:image/gif;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAJAgMAAACZCj6+AAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAlQTFRFAAAAfn5+////f/cqYgAAAAN0Uk5TAP//RFDWIQAAACdJREFUeJxjYHBgYGAMYGBgDWFgEA1lAAOtVQwMXCsYGJgWADkNDAA78QP9oKr7vwAAAABJRU5ErkJggg==);
-        --descending-icon: url(data:image/gif;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAJAgMAAACZCj6+AAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAlQTFRFAAAA////fn5+K6jOaAAAAAN0Uk5TAP//RFDWIQAAACdJREFUeJxjYHBgYGAMYGBgDWFgEA1lAAOtVQwMXCsYGJgWADkNDAA78QP9oKr7vwAAAABJRU5ErkJggg==);
-    }
+[data-theme="dark"] {
+    color-scheme: dark;
+    --text-color: white;
+    --background-color: #1c2227;
+    --primary-color: #26373b;
+    --secondary-color: #424f5a;
+    --link-color: #8cc4ff;
+    --link-hover-color: #bb86fc;
+    --highlight-color: #002b36;
+    --pass-link-color: #97bd61;
+    --warn-link-color: #fed84f;
+    --fail-link-color: #ff9b8f;
+    --ascending-icon: url(data:image/gif;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAJAgMAAACZCj6+AAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAlQTFRFAAAAfn5+////f/cqYgAAAAN0Uk5TAP//RFDWIQAAACdJREFUeJxjYHBgYGAMYGBgDWFgEA1lAAOtVQwMXCsYGJgWADkNDAA78QP9oKr7vwAAAABJRU5ErkJggg==);
+    --descending-icon: url(data:image/gif;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAJAgMAAACZCj6+AAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAlQTFRFAAAA////fn5+K6jOaAAAAAN0Uk5TAP//RFDWIQAAACdJREFUeJxjYHBgYGAMYGBgDWFgEA1lAAOtVQwMXCsYGJgWADkNDAA78QP9oKr7vwAAAABJRU5ErkJggg==);
 }
 /* Generic and misc styles */
 body {
@@ -100,7 +97,7 @@ select {
 #header {
     width: 65em;
     height: 3em;
-    margin: 6px 0;
+    margin: 20px 0 6px 0;
 }
 h1 {
     float: left;
@@ -317,4 +314,25 @@ th.stats-col-graph:hover {
 .sorter-false:hover {
     background-color: #ddd; /* Fallback value */
     background-color: var(--primary-color);
+}
+#theme-toggle {
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 28px;
+    height: 28px;
+    border: none;
+    padding: 4px;
+    z-index: 1000;
+    border-bottom-left-radius: 3px;
+    border-bottom-right-radius: 3px;
+    background: var(--highlight-color);
+}
+[data-theme="dark"] .dark-mode-icon,
+[data-theme="light"] .light-mode-icon {
+    display: block;
+}
+[data-theme="dark"] .light-mode-icon,
+[data-theme="light"] .dark-mode-icon {
+    display: none;
 }

--- a/src/robot/htmldata/rebot/log.css
+++ b/src/robot/htmldata/rebot/log.css
@@ -6,13 +6,14 @@
     --elapsed-color: #666;
 }
 
-@media (prefers-color-scheme: dark) {
-    :root {
-        --icon-filter: invert(1); /* Invert colors for the icons */
-        --icon-highlight: #a39990; /* Dark mode secondary color inverted (--icon-filter will invert it back) */
-        --elapsed-color: #999;
-    }
+/* @media (prefers-color-scheme: dark) { */
+
+[data-theme="dark"] {
+    --icon-filter: invert(1);
+    --icon-highlight: #a39990;
+    --elapsed-color: #999;
 }
+
 /* Containers */
 .suite, .test, #errors {
     border-color: #ccc; /* Fallback value */

--- a/src/robot/htmldata/rebot/log.html
+++ b/src/robot/htmldata/rebot/log.html
@@ -102,16 +102,16 @@ function highlightLinkTarget() {
 }
 
 function highlight(element, color) {
-    var darkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    var darkMode = getThemePreference() === 'dark';
     var startingColor = darkMode ? 52 : 242;
     var endingColor = darkMode ? 39 : 255;
 
     if (color === undefined)
         color = startingColor;
 
-    if (color != endingColor) {
+    if (color > endingColor) {
         element.css({'background-color': 'rgb('+color+','+color+','+color+')'});
-        color = darkMode ? color - 1 : color + 1;
+        color = darkMode ? color - 2 : color + 2;
         setTimeout(function () { highlight(element, color); }, 300);
     } else {
         element.css({'background-color': ''});

--- a/src/robot/htmldata/rebot/log.html
+++ b/src/robot/htmldata/rebot/log.html
@@ -25,7 +25,7 @@
 <!-- JS MODEL --><script type="text/javascript" src="../testdata/data.js"></script>
 <title></title>
 </head>
-<body>
+<body data-theme="dark">
 <div id="javascript-disabled">
   <h1>Opening Robot Framework log failed</h1>
   <ul>
@@ -35,7 +35,9 @@
   </ul>
 </div>
 <script type="text/javascript">removeJavaScriptDisabledWarning();</script>
-
+<script type="text/javascript">
+    document.body.setAttribute('data-theme', getThemePreference());
+</script>
 <div id="header"></div>
 <div id="statistics-container"></div>
 

--- a/src/robot/htmldata/rebot/report.html
+++ b/src/robot/htmldata/rebot/report.html
@@ -25,7 +25,7 @@
 <!-- JS MODEL --><script type="text/javascript" src="../testdata/data.js"></script>
 <title></title>
 </head>
-<body>
+<body data-theme="dark">
 <div id="javascript-disabled">
   <h1>Opening Robot Framework report failed</h1>
   <ul>
@@ -35,7 +35,9 @@
   </ul>
 </div>
 <script type="text/javascript">removeJavaScriptDisabledWarning();</script>
-
+<script type="text/javascript">
+    document.body.setAttribute('data-theme', getThemePreference());
+</script>
 <div id="status-bar"></div>
 <div id="header"></div>
 <div id="statistics-container"></div>
@@ -50,17 +52,16 @@ $(document).ready(function () {
         return;
     }
     window.prevLocationHash = '';
-    setStatusColor(topsuite);
     initLayout(topsuite.name, 'Report');
+    setStatusColor(topsuite);
     storage.init('report');
     addSummary(topsuite);
     addStatistics();
     addDetails();
     window.onhashchange = showDetailsByHash;
-    window.matchMedia('(prefers-color-scheme: dark)')
-        .addEventListener('change', ({matches:isDark}) => {
+    document.addEventListener("theme-change", () => {
         setStatusColor(topsuite);
-  })
+    });
 });
 
 function setStatusColor(topsuite) {
@@ -68,7 +69,7 @@ function setStatusColor(topsuite) {
     let fail = Boolean(topsuite.fail);
     let pass = Boolean(!topsuite.fail && topsuite.pass);
     let skip = Boolean(!topsuite.fail && !topsuite.pass);
-    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    if (getThemePreference() === 'dark') {
         $('#status-bar').toggleClass("fail-bar", fail);
         $('#status-bar').toggleClass("pass-bar", pass);
         $('#status-bar').toggleClass("skip-bar", skip);

--- a/src/robot/htmldata/rebot/view.js
+++ b/src/robot/htmldata/rebot/view.js
@@ -1,3 +1,20 @@
+const lightModeIcon = `
+<svg class="light-mode-icon" xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24"
+    viewBox="0 0 24 24" fill="#000000">
+    <rect fill="none" height="24" width="24" />
+    <path
+        d="M12,7c-2.76,0-5,2.24-5,5s2.24,5,5,5s5-2.24,5-5S14.76,7,12,7L12,7z M2,13l2,0c0.55,0,1-0.45,1-1s-0.45-1-1-1l-2,0 c-0.55,0-1,0.45-1,1S1.45,13,2,13z M20,13l2,0c0.55,0,1-0.45,1-1s-0.45-1-1-1l-2,0c-0.55,0-1,0.45-1,1S19.45,13,20,13z M11,2v2 c0,0.55,0.45,1,1,1s1-0.45,1-1V2c0-0.55-0.45-1-1-1S11,1.45,11,2z M11,20v2c0,0.55,0.45,1,1,1s1-0.45,1-1v-2c0-0.55-0.45-1-1-1 C11.45,19,11,19.45,11,20z M5.99,4.58c-0.39-0.39-1.03-0.39-1.41,0c-0.39,0.39-0.39,1.03,0,1.41l1.06,1.06 c0.39,0.39,1.03,0.39,1.41,0s0.39-1.03,0-1.41L5.99,4.58z M18.36,16.95c-0.39-0.39-1.03-0.39-1.41,0c-0.39,0.39-0.39,1.03,0,1.41 l1.06,1.06c0.39,0.39,1.03,0.39,1.41,0c0.39-0.39,0.39-1.03,0-1.41L18.36,16.95z M19.42,5.99c0.39-0.39,0.39-1.03,0-1.41 c-0.39-0.39-1.03-0.39-1.41,0l-1.06,1.06c-0.39,0.39-0.39,1.03,0,1.41s1.03,0.39,1.41,0L19.42,5.99z M7.05,18.36 c0.39-0.39,0.39-1.03,0-1.41c-0.39-0.39-1.03-0.39-1.41,0l-1.06,1.06c-0.39,0.39-0.39,1.03,0,1.41s1.03,0.39,1.41,0L7.05,18.36z" />
+</svg>`
+
+const darkModeIcon = `
+<svg class="dark-mode-icon" xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24"
+    viewBox="0 0 24 24" fill="#FFFFFF">
+    <rect fill="none" height="24" width="24" />
+    <path
+        d="M11.01,3.05C6.51,3.54,3,7.36,3,12c0,4.97,4.03,9,9,9c4.63,0,8.45-3.5,8.95-8c0.09-0.79-0.78-1.42-1.54-0.95 c-0.84,0.54-1.84,0.85-2.91,0.85c-2.98,0-5.4-2.42-5.4-5.4c0-1.06,0.31-2.06,0.84-2.89C12.39,3.94,11.9,2.98,11.01,3.05z" />
+</svg>`
+
+
 function removeJavaScriptDisabledWarning() {
     // Not using jQuery here for maximum speed
     document.getElementById('javascript-disabled').style.display = 'none';
@@ -39,6 +56,10 @@ function setTitle(suiteName, type) {
 function addHeader() {
     var generated = util.timestamp(window.output.generated);
     $.tmpl('<h1>${title}</h1>' +
+           '<button id=theme-toggle>' +
+             lightModeIcon +
+             darkModeIcon +
+           '</button>' +
            '<div id="generated">' +
              '<span>Generated<br>${generated}</span><br>' +
              '<span id="generated-ago">${ago} ago</span>' +
@@ -50,6 +71,8 @@ function addHeader() {
         ago: util.createGeneratedAgoString(generated),
         title: document.title
     }).appendTo($('#header'));
+    document.getElementById('theme-toggle')?.addEventListener('click', onClick);
+    reflectThemePreference();
 }
 
 function addReportOrLogLink(myType) {
@@ -188,3 +211,50 @@ function stopPropagation(event) {
     if (event.stopPropagation)
         event.stopPropagation();
 }
+
+const storageKey = 'theme-preference';
+const urlParams = new URLSearchParams(window.location.search);
+const theme = { value: getThemePreference() };
+
+window.matchMedia('(prefers-color-scheme: dark)')
+    .addEventListener('change', ({matches:isDark}) => {
+        theme.value = isDark ? 'dark' : 'light';
+        setThemePreference();
+    });
+
+window.addEventListener('storage', ({key, newValue}) => {
+    if (key === storageKey) {
+        theme.value = newValue === 'dark' ? 'dark' : 'light';
+        setThemePreference();
+    }
+})
+
+function getThemePreference() {
+    if (urlParams.has('theme')) {
+        const urlTheme = urlParams.get('theme') === 'dark' ? 'dark' : 'light';
+        localStorage.setItem(storageKey, urlTheme);
+        urlParams.delete('theme');
+        return urlTheme;
+    }
+    if (localStorage.getItem(storageKey))
+        return localStorage.getItem(storageKey) === 'dark' ? 'dark' : 'light';
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+    
+function setThemePreference() {
+    localStorage.setItem(storageKey, theme.value);
+    reflectThemePreference();
+}
+
+function reflectThemePreference() {
+    document.body.setAttribute('data-theme', theme.value);
+    document.querySelector('#theme-toggle')?.setAttribute('aria-label', theme.value);
+    const event = new Event('theme-change', {value: theme.value});
+    document.dispatchEvent(event);
+}
+    
+function onClick() {
+    theme.value = theme.value === 'light' ? 'dark' : 'light';
+    setThemePreference();
+}
+


### PR DESCRIPTION
@pekkaklarck This implements a theme toggle butten at top left of log and report.

By default the system setting is used.
If toggle is clicked, it is stored in localStorage.

Additionally it is possible to add `?theme=dark` or `?theme=light` to the url and you directly get the requested theme.

maybe this can still be tried out in RC1 ?

![2023-12-21_03-28-06 (2)](https://github.com/robotframework/robotframework/assets/41592183/bd5b6491-88f3-4237-9c5d-702fd7b1a4a5)
