### PR TITLE
Miscellaneous type hint fixes

### DIFF
--- a/src/robot/model/body.py
+++ b/src/robot/model/body.py
@@ -23,8 +23,7 @@ from .itemlist import ItemList
 from .modelobject import DataDict, full_name, ModelObject
 
 if TYPE_CHECKING:
-    from robot.result.model import ForIteration, WhileIteration
-    from robot.running.model import UserKeyword, ResourceFile
+    from robot.running.model import ResourceFile, UserKeyword
     from .control import (Break, Continue, Error, For, ForIteration, If, IfBranch,
                           Return, Try, TryBranch, Var, While, WhileIteration)
     from .keyword import Keyword

--- a/src/robot/model/control.py
+++ b/src/robot/model/control.py
@@ -15,7 +15,7 @@
 
 import warnings
 from collections import OrderedDict
-from typing import Any, cast, Literal, Sequence, TypeVar, TYPE_CHECKING
+from typing import Any, cast, Mapping, Literal, Sequence, TypeVar, TYPE_CHECKING
 
 from robot.utils import setter
 

--- a/src/robot/model/testcase.py
+++ b/src/robot/model/testcase.py
@@ -51,7 +51,7 @@ class TestCase(ModelObject, Generic[KW]):
                  tags: 'Tags|Sequence[str]' = (),
                  timeout: 'str|None' = None,
                  lineno: 'int|None' = None,
-                 parent: 'TestSuite|None' = None):
+                 parent: 'TestSuite[KW, TestCase[KW]]|None' = None):
         self.name = name
         self.doc = doc
         self.tags = tags

--- a/src/robot/model/testsuite.py
+++ b/src/robot/model/testsuite.py
@@ -57,7 +57,7 @@ class TestSuite(ModelObject, Generic[KW, TC]):
                  metadata: 'Mapping[str, str]|None' = None,
                  source: 'Path|str|None' = None,
                  rpa: 'bool|None' = False,
-                 parent: 'TestSuite|None' = None):
+                 parent: 'TestSuite[KW, TC]|None' = None):
         self._name = name
         self.doc = doc
         self.metadata = metadata

--- a/src/robot/running/model.py
+++ b/src/robot/running/model.py
@@ -53,7 +53,7 @@ from .statusreporter import StatusReporter
 if TYPE_CHECKING:
     from robot.parsing import File
     from .builder import TestDefaults
-    from .resourcemodel import ResourceFile
+    from .resourcemodel import ResourceFile, UserKeyword
 
 
 IT = TypeVar('IT', bound='IfBranch|TryBranch')
@@ -67,7 +67,7 @@ class Body(model.BaseBody['Keyword', 'For', 'While', 'If', 'Try', 'Var', 'Return
 
 
 class Branches(model.BaseBranches['Keyword', 'For', 'While', 'If', 'Try', 'Var', 'Return',
-                                  'Continue', 'Break', 'Message', 'Error', IT]):
+                                  'Continue', 'Break', 'model.Message', 'Error', IT]):
     __slots__ = ()
 
 


### PR DESCRIPTION
I was checking my contributions to the previous version of robotFramework were still functional in the RF 7.0 beta. I noticed some small issues.  

- Fixed a couple of instances of overzealous find-and-replace
- Fixed some missing imports
- Added some missing type arguments to Generic classes