### PR TITLE
improved and fixed broken link target highlighting

### DIFF
--- a/src/robot/htmldata/rebot/common.css
+++ b/src/robot/htmldata/rebot/common.css
@@ -6,6 +6,7 @@
     --link-color: #15c;
     --link-hover-color: #61c;
     --highlight-color: #eee;
+    --target-color: #f9f9f9;
     --pass-color: #97bd61;
     --fail-color: #ce3e01;
     --warn-color: #fed84f;
@@ -28,6 +29,7 @@
     --link-color: #8cc4ff;
     --link-hover-color: #bb86fc;
     --highlight-color: #002b36;
+    --target-color: #1a252e;
     --pass-link-color: #97bd61;
     --warn-link-color: #fed84f;
     --fail-link-color: #ff9b8f;
@@ -342,4 +344,19 @@ th.stats-col-graph:hover {
 [data-theme="dark"] .light-mode-icon,
 [data-theme="light"] .dark-mode-icon {
     display: block;
+}
+
+@keyframes highlight {
+    0% {
+        background: var(--primary-color)
+    }
+    100% {
+        background: var(--target-color);
+    }
+}
+
+:target {
+    background: var(--target-color);
+    transition: background 0.3s;
+    animation: highlight 4s;
 }

--- a/src/robot/htmldata/rebot/log.html
+++ b/src/robot/htmldata/rebot/log.html
@@ -91,31 +91,6 @@ function drawErrorsRecursively(errors, target) {
         // Errors may have moved scroll position. Resetting location re-scrolls.
         if (window.location.hash)
             window.location.replace(window.location.hash);
-        highlightLinkTarget();
-    }
-}
-
-function highlightLinkTarget() {
-    if (window.location.hash) {
-        var target = $(window.location.hash);
-        highlight(target);
-    }
-}
-
-function highlight(element, color) {
-    var darkMode = theme.getPreference() === 'dark';
-    var startingColor = darkMode ? 52 : 242;
-    var endingColor = darkMode ? 39 : 255;
-
-    if (color === undefined)
-        color = startingColor;
-
-    if (color > endingColor) {
-        element.css({'background-color': 'rgb('+color+','+color+','+color+')'});
-        color = darkMode ? color - 2 : color + 2;
-        setTimeout(function () { highlight(element, color); }, 300);
-    } else {
-        element.css({'background-color': ''});
     }
 }
 
@@ -133,7 +108,6 @@ function makeElementVisible(id) {
             expandFailed(window.testdata.findLoaded(util.last(ids)));
             window.location.hash = id;
             document.getElementById(id).scrollIntoView();
-            highlightLinkTarget();
         }
     });
 }


### PR DESCRIPTION
This fixes the broken highlighting of the taget test element.
(The one jumped to with #s1-s1-t1 etc.)

It now uses standard css for this.

See [Slack Discussion](https://robotframework.slack.com/archives/C0K0240NL/p1704455170871919?thread_ts=1704392651.216979&cid=C0K0240NL) as well.