### PR TITLE
log.html | expand collapse for test-execution-errors

### DIFF
--- a/src/robot/htmldata/rebot/log.html
+++ b/src/robot/htmldata/rebot/log.html
@@ -80,7 +80,7 @@ function addErrors() {
         $.tmpl('errorHeaderTemplate').appendTo($('body'));
         drawErrorsRecursively(errors, $('#errors'));
     }
-    toggleErrors('errorSection');
+    toggleSymbols('errorSection');
 }
 
 function drawErrorsRecursively(errors, target) {
@@ -161,7 +161,7 @@ function addExecutionLog(main) {
 <script type="text/x-jquery-tmpl" id="errorHeaderTemplate">
   <h2>{{= testOrTask('{Test}')}} Execution Errors</h2>
   <div id="errorSection" class="suite">
-        <div class="element-header closed" onclick="toggleErrors('errorSection')">
+        <div class="element-header closed" onclick="toggleSymbols('errorSection')">
             <div class="element-header-left">
                 <span class="label error">ERRORS</span>
                 <span class="name">Execution Errors</span>

--- a/src/robot/htmldata/rebot/log.html
+++ b/src/robot/htmldata/rebot/log.html
@@ -80,6 +80,7 @@ function addErrors() {
         $.tmpl('errorHeaderTemplate').appendTo($('body'));
         drawErrorsRecursively(errors, $('#errors'));
     }
+    toggleErrors('errorSection');
 }
 
 function drawErrorsRecursively(errors, target) {
@@ -159,7 +160,18 @@ function addExecutionLog(main) {
 
 <script type="text/x-jquery-tmpl" id="errorHeaderTemplate">
   <h2>{{= testOrTask('{Test}')}} Execution Errors</h2>
-  <table id="errors"></table>
+  <div id="errorSection" class="suite">
+        <div class="element-header closed" onclick="toggleErrors('errorSection')">
+            <div class="element-header-left">
+                <span class="label error">ERRORS</span>
+                <span class="name">Execution Errors</span>
+            </div>
+            <div class="element-header-toggle" title="Toggle visibility"></div>
+        </div>
+        <div class="children">
+          <table id="errors"></table>
+        </div>
+    </div>
 </script>
 
 <script type="text/x-jquery-tmpl" id="errorTemplate">

--- a/src/robot/htmldata/rebot/log.js
+++ b/src/robot/htmldata/rebot/log.js
@@ -15,7 +15,7 @@ function toggleKeyword(kwId) {
     toggleElement(kwId, ['keyword']);
 }
 
-function toggleErrors(elementId) {
+function toggleSymbols(elementId) {
     var element = $('#' + elementId);
     var children = element.children('.children');
     children.toggle(100, '', function () {
@@ -24,7 +24,7 @@ function toggleErrors(elementId) {
 }
 
 function toggleElement(elementId, childrenNames) {
-    toggleErrors(elementId);
+    toggleSymbols(elementId);
     populateChildren(elementId, children, childrenNames);
 }
 

--- a/src/robot/htmldata/rebot/log.js
+++ b/src/robot/htmldata/rebot/log.js
@@ -15,12 +15,16 @@ function toggleKeyword(kwId) {
     toggleElement(kwId, ['keyword']);
 }
 
-function toggleElement(elementId, childrenNames) {
+function toggleErrors(elementId) {
     var element = $('#' + elementId);
     var children = element.children('.children');
     children.toggle(100, '', function () {
         element.children('.element-header').toggleClass('closed');
     });
+}
+
+function toggleElement(elementId, childrenNames) {
+    toggleErrors(elementId);
     populateChildren(elementId, children, childrenNames);
 }
 


### PR DESCRIPTION
log.js and log.html updated to get below result:
![image](https://github.com/robotframework/robotframework/assets/61159866/46dd5a8e-8e6e-41ce-9cb2-a796aff806d5)

- existing code utilized
- toggleElement function separated one more level inside new function toggleSymbol in log.js
- errors table kept inside suite element and treated as suite in log.html
- toggleSymbol function added in addErrors function to expand errors after the page has loaded