### PR TITLE
run event loop in background thread when possible

### DIFF
--- a/atest/robot/running/stopping_with_signal.robot
+++ b/atest/robot/running/stopping_with_signal.robot
@@ -73,9 +73,9 @@ SIGINT Signal Should Stop Async Test Execution Gracefully
     Start And Send Signal    async_stop.robot    One SIGINT    5
     Check Test Cases Have Failed Correctly
     ${tc} =    Get Test Case    Test
-    Evaluate    len(${tc.kws[1].msgs}) == 1
+    Should Be True    len(${tc.kws[1].msgs}) == 1
     Check Log Message    ${tc.kws[1].msgs[0]}    Start Sleep
-    Evaluate    len(${SUITE.teardown.msgs}) == 0
+    Should Be True    len(${SUITE.teardown.msgs}) == 0
 
 Two SIGINT Signals Should Stop Async Test Execution Forcefully
     Start And Send Signal    async_stop.robot    Two SIGINTs    5
@@ -86,9 +86,9 @@ SIGTERM Signal Should Stop Async Test Execution Gracefully
     Start And Send Signal    async_stop.robot    One SIGTERM    5
     Check Test Cases Have Failed Correctly
     ${tc} =    Get Test Case    Test
-    Evaluate    len(${tc.kws[1].msgs}) == 1
+    Should Be True    len(${tc.kws[1].msgs}) == 1
     Check Log Message    ${tc.kws[1].msgs[0]}    Start Sleep
-    Evaluate    len(${SUITE.teardown.msgs}) == 0
+    Should Be True    len(${SUITE.teardown.msgs}) == 0
 
 Two SIGTERM Signals Should Stop Async Test Execution Forcefully
     [Tags]    no-windows

--- a/atest/testdata/keywords/async_keywords.robot
+++ b/atest/testdata/keywords/async_keywords.robot
@@ -17,10 +17,10 @@ Works Using Gather
 Long Async Tasks Run In Background
     [Tags]    require-py3.7
     ${hanger} =     Create Hanger
-    Basic Async Test
+    Sleep    1s
     Stop task From Hanger   ${hanger}
     ${size} =    Evaluate    len($hanger.ticks)
-    Should Be True    ${size} > 1
+    Should Be True    ${size} > 2
 
 Builtin Call From Library Works
     ${result} =    Run Keyword Using Builtin

--- a/atest/testdata/running/stopping_with_signal/async_stop.robot
+++ b/atest/testdata/running/stopping_with_signal/async_stop.robot
@@ -4,7 +4,7 @@ Library           OperatingSystem
 Library           Library.py
 Library           AsyncStop.py
 
-*** Test Case ***
+*** Test Cases ***
 Test
     [Documentation]    FAIL Execution terminated by signal
     Create File    ${TESTSIGNALFILE}


### PR DESCRIPTION
I tested and looks like behaviour was maintained. There were many tests that failed, but they also failed without my modifications, so maybe my environment is misconfigured.

I was also thinking of when coroutines that run in the background log something in the terminal. I'm not so sure about the behaviour from that and couldn't observe this scenario in the tests, but could be worth investigating further.

I'm open to suggestions as always :)