### PR TITLE
Use 'sphinx_rtd_theme' as theme

### DIFF
--- a/doc/api/conf.py
+++ b/doc/api/conf.py
@@ -27,7 +27,7 @@ needs_sphinx = '1.3'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx_rtd_theme']
 autoclass_content = 'both'
 autodoc_default_flags = ['members', 'undoc-members', 'inherited-members']
 autodoc_member_order = 'bysource'
@@ -100,7 +100,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#html_theme = 'classic'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Since end of 2023, the default theme at ReadTheDocs has been changed to Alabaster.
This change will make sure the classic ReadTheDocs theme is used again.

If you want to check the document creation locally, you can do that my running
`TZ=UTC make html`
(`TZ=UTC` was needed on my system due to a timezone error)

When building locally, make sure to install the packages `sphinx_rtd_theme`.
via `pip install sphinx_rtd_theme`.
When building via ReadTheDocs, this is not needed as their standard image for building includes that package
