### PR TITLE
utest: Improve filtering of output sugar for Python 3.13+

### DIFF
--- a/utest/utils/test_error.py
+++ b/utest/utils/test_error.py
@@ -127,8 +127,8 @@ Traceback \(most recent call last\):
             tb = ErrorDetails(error).traceback
         else:
             raise AssertionError
-        # Remove lines indicating error location with `^^^^` used by Python 3.11+.
-        tb = '\n'.join(line for line in tb.splitlines() if line.strip('^ '))
+        # Remove lines indicating error location with `^^^^` used by Python 3.11+ and `~~~~^` variants in Python 3.13+.
+        tb = '\n'.join(line for line in tb.splitlines() if line.strip('^~ '))
         if not re.match(expected, tb):
             raise AssertionError('\nExpected:\n%s\n\nActual:\n%s' % (expected, tb))
 


### PR DESCRIPTION
Python 3.13+ introduces some additional characters to exception descriptions containing the `~` character. Filter them out as well like the `^` previously handled.

Closes #5035 