### PR TITLE
Add requirements.txt with sphinx dependencies for readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,6 +20,6 @@ sphinx:
 #    - pdf
 
 # Optionally declare the Python requirements required to build your docs
-#python:
-#   install:
-#   - requirements: docs/requirements.txt
+python:
+  install:
+  - requirements: docs/requirements.txt

--- a/doc/api/conf.py
+++ b/doc/api/conf.py
@@ -27,7 +27,7 @@ needs_sphinx = '1.3'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx_rtd_theme']
 autoclass_content = 'both'
 autodoc_default_flags = ['members', 'undoc-members', 'inherited-members']
 autodoc_member_order = 'bysource'
@@ -100,7 +100,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#html_theme = 'classic'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/doc/api/requirements.txt
+++ b/doc/api/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx-rtd-theme


### PR DESCRIPTION
`requirements.txt` has been added with sphinx dependencies-
`.readthedocs.yaml` has been adjusted to use requirements.txt during docs built on readthedocs