### PR TITLE
Fixed Tcl_AsyncDelete crash after closing dialog (#4993)

### DIFF
--- a/atest/robot/standard_libraries/dialogs/dialogs.robot
+++ b/atest/robot/standard_libraries/dialogs/dialogs.robot
@@ -66,3 +66,6 @@ Get Selections From User Exited
 
 Multiple dialogs in a row
     Check Test Case    ${TESTNAME}
+
+Garbage Collection In Thread Should Not Cause Problems
+    Check Test Case    ${TESTNAME}

--- a/atest/testdata/standard_libraries/dialogs/dialogs.robot
+++ b/atest/testdata/standard_libraries/dialogs/dialogs.robot
@@ -117,3 +117,9 @@ Multiple dialogs in a row
     [Documentation]  FAIL No value provided by user.
     Pause Execution    Verify that dialog is closed immediately.\n\nAfter pressing OK or <Enter>.
     Get Value From User    Verify that dialog is closed immediately.\n\nAfter pressing Cancel or <Esc>.
+
+Garbage Collection In Thread Should Not Cause Problems
+    Pause Execution    Verify that the software does not crash after pressing OK or <Enter>.
+    ${thread}=    Evaluate    threading.Thread(target=gc.collect)    modules=gc,threading
+    Call Method    ${thread}    start
+    Call Method    ${thread}    join

--- a/atest/testdata/standard_libraries/dialogs/dialogs.robot
+++ b/atest/testdata/standard_libraries/dialogs/dialogs.robot
@@ -119,7 +119,7 @@ Multiple dialogs in a row
     Get Value From User    Verify that dialog is closed immediately.\n\nAfter pressing Cancel or <Esc>.
 
 Garbage Collection In Thread Should Not Cause Problems
-    Pause Execution    Verify that the software does not crash after pressing OK or <Enter>.
     ${thread}=    Evaluate    threading.Thread(target=gc.collect)    modules=gc,threading
+    Pause Execution    Verify that the execution does not crash after pressing OK or <Enter>.
     Call Method    ${thread}    start
     Call Method    ${thread}    join

--- a/src/robot/libraries/dialogs_py.py
+++ b/src/robot/libraries/dialogs_py.py
@@ -26,9 +26,8 @@ class TkDialog(Toplevel):
 
     def __init__(self, message, value=None, **config):
         self._prevent_execution_with_timeouts()
-        self.root = self._get_root()
         self._button_bindings = {}
-        super().__init__(self.root)
+        super().__init__(self._get_root())
         self._initialize_dialog()
         self.widget = self._create_body(message, value, **config)
         self._create_buttons()
@@ -109,8 +108,8 @@ class TkDialog(Toplevel):
         return None
 
     def _close(self, event=None):
-        # self.destroy() is not enough on Linux
-        self.root.destroy()
+        self.destroy()
+        self.update() # Needed on linux to close the window (Issue #1466)
 
     def _right_button_clicked(self, event=None):
         self._result = self._get_right_button_value()


### PR DESCRIPTION
Closes #4993

Reverting the change introduced in the fix for #1466 and fixing it in a different way without the side effect of #4993.