### PR TITLE
fix argument name in docstring

### DIFF
--- a/src/robot/running/model.py
+++ b/src/robot/running/model.py
@@ -663,7 +663,7 @@ class TestSuite(model.TestSuite[Keyword, TestCase]):
 
         Example::
 
-            suite.configure(included_tags=['smoke'],
+            suite.configure(include_tags=['smoke'],
                             doc='Smoke test results.')
 
         Not to be confused with :meth:`config` method that suites, tests,


### PR DESCRIPTION
changes 'included_tags' to 'include_tags' in TestSuite.configure() docstring