### PR TITLE
5102: Asynchronous should use existing eventloop if one exists

### DIFF
--- a/src/robot/running/context.py
+++ b/src/robot/running/context.py
@@ -28,7 +28,13 @@ class Asynchronous:
     @property
     def event_loop(self):
         if self._loop_ref is None:
-            self._loop_ref = asyncio.new_event_loop()
+            try:
+                self._loop_ref = asyncio.get_event_loop()
+                if self._loop_ref.is_closed():
+                    raise RuntimeError()
+            except RuntimeError:
+                self._loop_ref = asyncio.new_event_loop()
+                asyncio.set_event_loop(self._loop_ref)
         return self._loop_ref
 
     def close_loop(self):


### PR DESCRIPTION
closes #5102 