### PR TITLE
Screenshot changes to support more image types

### DIFF
--- a/atest/robot/standard_libraries/screenshot/take_screenshot.robot
+++ b/atest/robot/standard_libraries/screenshot/take_screenshot.robot
@@ -15,6 +15,14 @@ Basename May Be Defined
     ${tc}=  Check Test Case  ${TESTNAME}
     Check Embedding In Log  ${tc.kws[0].kws[0].msgs[1]}  foo_1.jpg
 
+Basename May Be Defined With Screenshot Format Of PNG
+    ${tc} =    Check Test Case    ${TESTNAME}
+    Check Embedding In Log    ${tc.kws[0].kws[0].msgs[1]}    foo_1.png
+
+Basename May Be Defined With Screenshot Format Of TIFF
+    ${tc} =    Check Test Case    ${TESTNAME}
+    Check Embedding In Log    ${tc.kws[0].kws[0].msgs[1]}    foo_1.tiff
+
 Basename With Extension Turns Off Index Generation
     ${tc}=  Check Test Case  ${TESTNAME}
     Check Embedding In Log  ${tc.kws[0].kws[0].msgs[1]}  xxx.jpg

--- a/atest/testdata/standard_libraries/screenshot/screenshot_resource.robot
+++ b/atest/testdata/standard_libraries/screenshot/screenshot_resource.robot
@@ -17,6 +17,7 @@ Save Start Time
     Set Test Variable  \${START TIME}
 
 Screenshots Should Exist
-    [Arguments]  ${directory}  @{files}
-    @{actual files}=  List Directory  ${directory}  *.jp*g
+    [Arguments]  ${directory}  @{files}    ${format}=jpg
+    ${file_ext_re} =    Set Variable If    "${format.lower()}" == "jpg"    *.jp*g    *.${format}
+    @{actual files}=  List Directory  ${directory}  ${file_ext_re}
     Lists Should Be Equal  ${actual files}  ${files}

--- a/atest/testdata/standard_libraries/screenshot/take_screenshot.robot
+++ b/atest/testdata/standard_libraries/screenshot/take_screenshot.robot
@@ -1,7 +1,7 @@
 *** Settings ***
-Suite Setup     Remove Files  ${OUTPUTDIR}/*.jp*g
+Suite Setup     Remove Files  ${OUTPUTDIR}/*.jp*g    ${OUTPUTDIR}/*.png    ${OUTPUTDIR}/*.tiff    ${OUTPUTDIR}/*.bmp
 Test Setup      Save Start Time
-Test Teardown   Remove Files  ${OUTPUTDIR}/*.jp*g
+Test Teardown   Remove Files  ${OUTPUTDIR}/*.jp*g    ${OUTPUTDIR}/*.png    ${OUTPUTDIR}/*.tiff    ${OUTPUTDIR}/*.bmp
 Resource        screenshot_resource.robot
 
 *** Variables ***
@@ -21,25 +21,59 @@ Basename May Be Defined
     Repeat Keyword    2    Take Screenshot    foo
     Screenshots Should Exist    ${OUTPUTDIR}    foo_1.jpg    foo_2.jpg
 
+Basename May Be Defined With Screenshot Format Of PNG
+    Repeat Keyword    2    Take Screenshot    foo    img_format=png
+    Screenshots Should Exist    ${OUTPUTDIR}    foo_1.png    foo_2.png    format=png
+
+Basename May Be Defined With Screenshot Format Of TIFF
+    Repeat Keyword    2    Take Screenshot    foo    img_format=tiff
+    Screenshots Should Exist    ${OUTPUTDIR}    foo_1.tiff    foo_2.tiff    format=tiff
+
 Basename With Extension Turns Off Index Generation
-    Repeat Keyword    3    Take Screenshot    xxx.jpg
-    Repeat Keyword    2    Take Screenshot    yyy.jpeg
-    Screenshots Should Exist  ${OUTPUTDIR}    xxx.jpg    yyy.jpeg
+    Repeat Keyword    3    Take Screenshot    xxx.jpg    img_format=jpg
+    Repeat Keyword    2    Take Screenshot    yyy.jpeg    img_format=jpg
+    Screenshots Should Exist  ${OUTPUTDIR}    xxx.jpg    yyy.jpeg    format=jpg
+    Repeat Keyword    3    Take Screenshot    xxx.png    img_format=png
+    Screenshots Should Exist  ${OUTPUTDIR}    xxx.png    format=png
+    Repeat Keyword    3    Take Screenshot    xxx.bmp    img_format=bmp
+    Screenshots Should Exist  ${OUTPUTDIR}    xxx.bmp    format=bmp
 
 Name as `pathlib.Path`
     Take Screenshot    ${{pathlib.Path('name.jpg')}}
     Screenshots Should Exist    ${OUTPUTDIR}    name.jpg
 
+Name as `pathlib.Path` - Format PNG
+    Take Screenshot    ${{pathlib.Path('name.png')}}    img_format=png
+    Screenshots Should Exist    ${OUTPUTDIR}    name.png    format=png
+
+Name as `pathlib.Path` - Format TIFF
+    Take Screenshot    ${{pathlib.Path('name.tiff')}}    img_format=tiff
+    Screenshots Should Exist    ${OUTPUTDIR}    name.tiff    format=tiff
+
 Screenshot Width Can Be Given
     Take Screenshot    width=300px
     Screenshots Should Exist    ${OUTPUTDIR}    ${FIRST_SCREENSHOT}
 
+Screenshot Width Can Be Given For PNG
+    Take Screenshot    foo.png    width=300px    img_format=png
+    Screenshots Should Exist    ${OUTPUTDIR}    foo.png    format=png
+
+Screenshot Width Can Be Given For BMP
+    Take Screenshot    foo.bmp    width=300px    img_format=bmp
+    Screenshots Should Exist    ${OUTPUTDIR}    foo.bmp    format=bmp
+
 Basename With Non-existing Directories Fails
-    [Documentation]  FAIL Directory '${OUTPUTDIR}${/}non-existing' where to save the screenshot does not exist
-    Take Screenshot    ${OUTPUTDIR}${/}non-existing${/}foo
+    [Documentation]  FAIL Directory '${/}non-existing' where to save the screenshot does not exist
+    Take Screenshot    ${/}non-existing${/}foo
 
 Without Embedding
     Take Screenshot Without Embedding    no_embed.jpeg
+
+Take Screenshot Without Embedding For PNG
+    Take Screenshot Without Embedding    no_embed.png    img_format=png
+
+Take Screenshot Without Embedding for TIFF
+    Take Screenshot Without Embedding    no_embed.tiff    img_format=tiff
 
 *** Keywords ***
 Take Screenshot And Verify

--- a/src/robot/libraries/Screenshot.py
+++ b/src/robot/libraries/Screenshot.py
@@ -168,7 +168,6 @@ class Screenshot:
         return old
 
     def take_screenshot(self, name="screenshot", width="800px", img_format="jpg"):
-        # TODO: update the docs below once this actually works
         """Takes a screenshot in JPEG format and embeds it into the log file.
 
         Name of the file where the screenshot is stored is derived from the


### PR DESCRIPTION
Modification of the Screenshot/Taker classes to support other image formats than just "jpg"
Implemented support for: jpg, png, tiff, and bmp; although other formats can be supported by extending Screenshot.IMAGE_FORMATS;
Extended test cases to prove out the support for non-jpg types; 