### PR TITLE
feat: Add support for "week" as a valid unit of time in time strings

### DIFF
--- a/atest/testdata/standard_libraries/datetime/convert_time_input_format.robot
+++ b/atest/testdata/standard_libraries/datetime/convert_time_input_format.robot
@@ -17,6 +17,12 @@ Time string           10 s                                  10
                       0.123456789 ms                        0.000123456789
                       123 μs                                0.000123
                       1 ns                                  1E-9
+                      1 week                                604800
+                      2 weeks                               1209600
+                      1 week 1 day 1 hour 1 min 1 sec 1 ms  694861.001
+                      2 weeks 1 day 1 hour 1 min 1 sec      1299661
+                      1w 1d 1h 1m 1s 1ms                    694861.001
+                      2w 1d 1h 1m 1s 1ms                    1299661.001
 
 Number as string      10                                    10
                       0.5                                   0.5

--- a/doc/userguide/src/Appendices/TimeFormat.rst
+++ b/doc/userguide/src/Appendices/TimeFormat.rst
@@ -54,7 +54,9 @@ Examples::
    1.5 minutes
    90 s
    1 day 2 hours 3 minutes 4 seconds 5 milliseconds 6 microseconds 7 nanoseconds
+   8 weeks 7 days 6 hours 5 minutes 4 seconds 3 milliseconds 2 microseconds 1 nanosecond
    1d 2h 3m 4s 5ms 6μs 7 ns
+   8w 7d 6h 5m 4s 3ms 2μs 1ns
    - 10 seconds
 
 .. note:: Support for micro and nanoseconds is new in Robot Framework 6.0.

--- a/doc/userguide/src/Appendices/TimeFormat.rst
+++ b/doc/userguide/src/Appendices/TimeFormat.rst
@@ -39,6 +39,7 @@ integers or floating point numbers, the whole format is case and space
 insensitive, and it is possible to add `-` prefix to specify negative
 times. The available time specifiers are:
 
+* weeks, week, w
 * days, day, d
 * hours, hour, h
 * minutes, minute, mins, min, m
@@ -57,6 +58,7 @@ Examples::
    - 10 seconds
 
 .. note:: Support for micro and nanoseconds is new in Robot Framework 6.0.
+          Support for weeks is new in Robot Framework 7.1.
 
 Time as "timer" string
 ----------------------

--- a/src/robot/libraries/DateTime.py
+++ b/src/robot/libraries/DateTime.py
@@ -191,7 +191,7 @@ integers or floating point numbers, the whole format is case and space
 insensitive, and it is possible to add a minus prefix to specify negative
 times. The available time specifiers are:
 
-- ``weeks``, ``week``, ``w``
+- ``weeks``, ``week``, ``w`` (new in RF 7.1)
 - ``days``, ``day``, ``d``
 - ``hours``, ``hour``, ``h``
 - ``minutes``, ``minute``, ``mins``, ``min``, ``m``

--- a/src/robot/libraries/DateTime.py
+++ b/src/robot/libraries/DateTime.py
@@ -191,6 +191,7 @@ integers or floating point numbers, the whole format is case and space
 insensitive, and it is possible to add a minus prefix to specify negative
 times. The available time specifiers are:
 
+- ``weeks``, ``week``, ``w``
 - ``days``, ``day``, ``d``
 - ``hours``, ``hour``, ``h``
 - ``minutes``, ``minute``, ``mins``, ``min``, ``m``
@@ -201,9 +202,9 @@ times. The available time specifiers are:
 
 When returning a time string, it is possible to select between ``verbose``
 and ``compact`` representations using ``result_format`` argument. The verbose
-format uses long specifiers ``day``, ``hour``, ``minute``, ``second`` and
+format uses long specifiers ``week``, ``day``, ``hour``, ``minute``, ``second`` and
 ``millisecond``, and adds ``s`` at the end when needed. The compact format uses
-shorter specifiers ``d``, ``h``, ``min``, ``s`` and ``ms``, and even drops
+shorter specifiers ``w``, ``d``, ``h``, ``min``, ``s`` and ``ms``, and even drops
 the space between the number and the specifier.
 
 Examples:

--- a/src/robot/utils/robottime.py
+++ b/src/robot/utils/robottime.py
@@ -86,7 +86,7 @@ def _time_string_to_secs(timestr):
     timestr = _normalize_timestr(timestr)
     if not timestr:
         return None
-    nanos = micros = millis = secs = mins = hours = days = 0
+    nanos = micros = millis = secs = mins = hours = days = weeks = 0
     if timestr[0] == '-':
         sign = -1
         timestr = timestr[1:]
@@ -102,13 +102,14 @@ def _time_string_to_secs(timestr):
             elif c == 'm': mins   = float(''.join(temp)); temp = []
             elif c == 'h': hours  = float(''.join(temp)); temp = []
             elif c == 'd': days   = float(''.join(temp)); temp = []
+            elif c == 'w': weeks  = float(''.join(temp)); temp = []
             else: temp.append(c)
         except ValueError:
             return None
     if temp:
         return None
     return sign * (nanos/1E9 + micros/1E6 + millis/1000 + secs +
-                   mins*60 + hours*60*60 + days*60*60*24)
+                   mins*60 + hours*60*60 + days*60*60*24 + weeks*60*60*24*7)
 
 
 def _normalize_timestr(timestr):
@@ -120,7 +121,8 @@ def _normalize_timestr(timestr):
                                ('s', ['second', 'sec']),
                                ('m', ['minute', 'min']),
                                ('h', ['hour']),
-                               ('d', ['day'])]:
+                               ('d', ['day']),
+                               ('w', ['week'])]:
         plural_aliases = [a+'s' for a in aliases if not a.endswith('s')]
         for alias in plural_aliases + aliases:
             if alias in timestr:

--- a/utest/utils/test_robottime.py
+++ b/utest/utils/test_robottime.py
@@ -99,7 +99,17 @@ class TestTime(unittest.TestCase):
                          ('- 1 min 2 s', -62),
                          ('0.1millis', 0),
                          ('0.5ms', 0.001),
-                         ('0day 0hour 0minute 0seconds 0millisecond', 0)]:
+                         ('0day 0hour 0minute 0seconds 0millisecond', 0),
+                         ('0w 0d 0h 0m 0s 0ms', 0),
+                         ('1 week', 60*60*24*7),
+                         ('2 weeks', 2*60*60*24*7),
+                         ('1 w', 60*60*24*7),
+                         ('2 w', 2*60*60*24*7),
+                         ('1w 0d 0h 0m 0s 0ms', 60*60*24*7),
+                         ('2w 0d 0h 0m 0s 0ms', 2*60*60*24*7),
+                         ('1week 1day 1hour 1minute 1second', 60*60*24*8 + 3661),
+                         ('11 weeks 5 days 3 hours 7 minutes', 11*60*60*24*7 + 5*60*60*24 + 3*60*60 + 7*60),
+            ]:
             assert_equal(timestr_to_secs(inp), exp, inp)
 
     def test_timestr_to_secs_with_time_string_ns_accuracy(self):
@@ -173,7 +183,7 @@ class TestTime(unittest.TestCase):
         assert_equal(timestr_to_secs(str(secs), round_to=None), secs)
 
     def test_timestr_to_secs_with_invalid(self):
-        for inv in ['', 'foo', 'foo days', '1sec 42 millis 3', '1min 2w', '1x',
+        for inv in ['', 'foo', 'foo days', '1sec 42 millis 3', '1min 2y', '1x',
                     '01:02:03:04', '01:02:03foo', 'foo01:02:03', None]:
             assert_raises_with_msg(ValueError, f"Invalid time string '{inv}'.",
                                    timestr_to_secs, inv)


### PR DESCRIPTION
This PR fixes #5135 and stands as a potential implementation for a "week" as a valid unit of time in a time string.

Documentation was updated to indicate that a "week" is now a valid unit of time. Furthermore, unit tests were also added to ensure backwards compatibility. I should call out that one of the unit tests ensuring invalid formats raise an exception needed to be modified from `w` to `y` in order to pass. I *think* the intent of this unit test was to ensure that units of time must be sorted (e.g. days, then hours, then minutes, etc.) and not reversed/arbitrary (minutes, then weeks, then days, etc.). However, if I misinterpreted that and need to modify the unit tests somehow, let me know!