### PR TITLE
chore: Allow listeners to remove log messages altogether

### DIFF
--- a/src/robot/api/logger.py
+++ b/src/robot/api/logger.py
@@ -89,6 +89,8 @@ def write(msg: str, level: LOGLEVEL = 'INFO', html: bool = False):
     specific methods such as ``info`` and ``debug`` that have separate
     ``html`` argument to control the message format.
     """
+    if len(msg) == 0:
+        return
     if EXECUTION_CONTEXTS.current is not None:
         librarylogger.write(msg, level, html)
     else:

--- a/utest/api/test_logging_api.py
+++ b/utest/api/test_logging_api.py
@@ -79,6 +79,13 @@ class TestRedirectToPythonLogging(unittest.TestCase):
         logger.write("Doo", 'INFO')
         assert_equal(self.handler.messages, ['Foo', 'Boo', 'Goo', 'Doo'])
 
+    def test_empty_string_not_looged_to_python(self):
+        logger.info("")
+        logger.debug("")
+        logger.trace("")
+        logger.write("", 'INFO')
+        assert_equal(self.handler.messages, [])
+
     def test_logger_to_python_with_html(self):
         logger.info("Foo", html=True)
         logger.write("Doo", 'INFO', html=True)
@@ -88,6 +95,7 @@ class TestRedirectToPythonLogging(unittest.TestCase):
     def test_logger_to_python_with_console(self):
         logger.write("Foo", 'CONSOLE')
         assert_equal(self.handler.messages, ['Foo'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/utest/api/test_logging_api.py
+++ b/utest/api/test_logging_api.py
@@ -79,7 +79,7 @@ class TestRedirectToPythonLogging(unittest.TestCase):
         logger.write("Doo", 'INFO')
         assert_equal(self.handler.messages, ['Foo', 'Boo', 'Goo', 'Doo'])
 
-    def test_empty_string_not_looged_to_python(self):
+    def test_empty_string_not_logged_to_python(self):
         logger.info("")
         logger.debug("")
         logger.trace("")


### PR DESCRIPTION
# Description

- This implements a check for an empty string as `msg` argument at `robots/api/loggers.py`. If the string is empty, it returns the function, thus no log is added.

# Test

- The test case for the same is also written in `utest/api/test_logging_api.py`. The test case passes an empty string as a message and asserts if any message is logged.