### PR TITLE
Enable disabling of ANSI Terminal Hyperlinks via environment variable and improve URI generation using `pathlib.Path.as_uri`

### DIFF
--- a/src/robot/output/console/highlighting.py
+++ b/src/robot/output/console/highlighting.py
@@ -152,7 +152,7 @@ class AnsiHighlighter:
         self._set_color(self.RESET)
 
     def link(self, path):
-        if os.getenv("ROBOT_DISABLE_ANSI_LINKS", "").lower() == "1":
+        if os.getenv("ROBOT_DISABLE_ANSI_LINKS", "") == "1":
             return path
         return f'\033]8;;{path.as_uri()}\033\\{path}\033]8;;\033\\'
 

--- a/src/robot/output/console/highlighting.py
+++ b/src/robot/output/console/highlighting.py
@@ -152,6 +152,8 @@ class AnsiHighlighter:
         self._set_color(self.RESET)
 
     def link(self, path):
+        if os.getenv("ROBOT_DISABLE_ANSI_LINKS", "").lower() == "1":
+            return path
         return f'\033]8;;file:///{path}\033\\{path}\033]8;;\033\\'
 
     def _set_color(self, color):

--- a/src/robot/output/console/highlighting.py
+++ b/src/robot/output/console/highlighting.py
@@ -154,7 +154,7 @@ class AnsiHighlighter:
     def link(self, path):
         if os.getenv("ROBOT_DISABLE_ANSI_LINKS", "").lower() == "1":
             return path
-        return f'\033]8;;file:///{path}\033\\{path}\033]8;;\033\\'
+        return f'\033]8;;{path.as_uri()}\033\\{path}\033]8;;\033\\'
 
     def _set_color(self, color):
         self._stream.write(color)


### PR DESCRIPTION
**Description:**  
Currently, VSCode/RobotCode struggles with the new ANSI Terminal Hyperlinks in console output. These hyperlinks take precedence over the `TerminalLinkProvider` registered by RobotCode in VSCode. However, the `TerminalLinkProvider` is crucial for correctly opening reports in different environments, particularly when using DevContainers or developing on a remote machine via SSH/WSL. In these cases, it's not straightforward to open local links since the client machine does not have access to the remote system via `file:` URI.

The `TerminalLinkProvider` in RobotCode allows local links to be adjusted so they work correctly in such scenarios. To restore this functionality, I propose making the generation of ANSI Terminal Links disableable via an environment variable. RobotCode can then inject this environment variable into the terminal session in VSCode, allowing the `TerminalLinkProvider` to function as intended.

**Changes in this Pull Request:**

1. **First Commit:**  
   Adds an environment variable that allows the generation of ANSI Terminal Links to be disabled. This ensures that the `TerminalLinkProvider` in VSCode can work correctly, especially in more complex development environments like DevContainers or when using SSH/WSL.

2. **Second Commit:**  
   Improves the generation of URIs by using the `pathlib.Path.as_uri` method. This method ensures that correct URIs are generated regardless of the environment. This is particularly important on Windows, as URIs must not contain spaces and must be correctly masked with `%20`, which `as_uri` handles automatically.

**Additional Information:**  
These changes are backward-compatible and should not affect existing functionality.