### PR TITLE
use `as_uri` to build the link in AnsiHighlighter

### DIFF
--- a/src/robot/output/console/highlighting.py
+++ b/src/robot/output/console/highlighting.py
@@ -152,7 +152,7 @@ class AnsiHighlighter:
         self._set_color(self.RESET)
 
     def link(self, path):
-        return f'\033]8;;file:///{path}\033\\{path}\033]8;;\033\\'
+        return f'\033]8;;{path.as_uri()}\033\\{path}\033]8;;\033\\'
 
     def _set_color(self, color):
         self._stream.write(color)


### PR DESCRIPTION
In the `AnsiHighlighter` class, the method for creating file URLs has been improved. Instead of manually constructing the URL via string formatting, `Path.as_uri()` is now used.

**Why `Path.as_uri()`?**

- **Robustness**: Ensures correct and OS-independent URL formatting.
- **UNC Paths**: Properly handles UNC paths, avoiding common pitfalls.
- **Character Escaping**: Automatically escapes special characters to ensure a valid URL.
- **Local Files**: Omits unnecessary hostname for local files
- **Error Prevention**: Reduces potential errors and inconsistencies in URL construction.
