### PR TITLE
fix  sys.__stderr__.write

### DIFF
--- a/src/robot/running/outputcapture.py
+++ b/src/robot/running/outputcapture.py
@@ -52,7 +52,8 @@ class OutputCapturer:
             LOGGER.log_output(stdout)
         if stderr:
             LOGGER.log_output(stderr)
-            sys.__stderr__.write(console_encode(stderr, stream=sys.__stderr__))
+            if sys.__stderr__:
+                sys.__stderr__.write(console_encode(stderr, stream=sys.__stderr__))
 
     def _release(self):
         stdout = self.stdout.release()


### PR DESCRIPTION
Using pyinstaller packaging, an error is reported when the parameter console configures False

 sys.__stderr__.write(console_encode(stderr, stream=sys.__stderr__))
AttributeError: 'NoneType' object has no attribute 'write'