### PR TITLE
Added separator argument in `Set Test Message`, `Set Test Documentation`, `Set Suite Documentation` and `Set Suite Metadata` keywords.

### DIFF
--- a/atest/robot/standard_libraries/builtin/set_documentation.robot
+++ b/atest/robot/standard_libraries/builtin/set_documentation.robot
@@ -12,9 +12,12 @@ Replace test documentation
     Check Log Message    ${tc.kws[0].msgs[0]}    Set test documentation to:\nNew doc
 
 Append to test documentation
-    ${tc} =    Check Test Doc    ${TESTNAME}     Original doc is continued \n\ntwice!
+    ${tc} =    Check Test Doc    ${TESTNAME}     Original doc is continued \n\ntwice! thrice!!
     Check Log Message    ${tc.kws[0].msgs[0]}    Set test documentation to:\nOriginal doc is continued
     Check Log Message    ${tc.kws[2].msgs[0]}    Set test documentation to:\nOriginal doc is continued \n\ntwice!
+    Check Log Message    ${tc.kws[4].msgs[0]}    Set test documentation to:\nOriginal doc is continued \n\ntwice! thrice
+    Check Log Message    ${tc.kws[6].msgs[0]}    Set test documentation to:\nOriginal doc is continued \n\ntwice! thrice!
+    Check Log Message    ${tc.kws[8].msgs[0]}    Set test documentation to:\nOriginal doc is continued \n\ntwice! thrice!!
 
 Set suite documentation
     ${tc} =    Check Test Case    ${TESTNAME}
@@ -27,7 +30,9 @@ Append to suite documentation
     Check Log Message    ${tc.kws[0].msgs[0]}    Set suite documentation to:\nNew suite doc is continued
     ${tc} =    Check Test Case    ${TESTNAME} 2
     Check Log Message    ${tc.kws[1].msgs[0]}    Set suite documentation to:\nNew suite doc is continued \n\ntwice!
-    Should Be Equal    ${SUITE.suites[0].doc}    New suite doc is continued \n\ntwice!
+    Check Log Message    ${tc.kws[3].msgs[0]}    Set suite documentation to:\nNew suite doc is continued \n\ntwice!,thrice
+    Check Log Message    ${tc.kws[5].msgs[0]}    Set suite documentation to:\nNew suite doc is continued \n\ntwice!,thrice?1
+    Should Be Equal    ${SUITE.suites[0].doc}    New suite doc is continued \n\ntwice!,thrice?1
 
 Set init file suite docs
     Should Be Equal     ${SUITE.doc}    Init file doc. Concatenated in setup. Appended in test.

--- a/atest/robot/standard_libraries/builtin/set_suite_metadata.robot
+++ b/atest/robot/standard_libraries/builtin/set_suite_metadata.robot
@@ -30,6 +30,12 @@ Append to value
     ...    Set suite metadata 'toappend' to value 'Original is continued'.
     Check log message    ${tc.kws[4].msgs[0]}
     ...    Set suite metadata 'TOAPPEND' to value 'Original is continued \n\ntwice!'.
+    Check log message    ${tc.kws[6].msgs[0]}
+    ...    Set suite metadata 'Version' to value '1.0'.
+    Check log message    ${tc.kws[8].msgs[0]}
+    ...    Set suite metadata 'version' to value '1.0/2.0'.
+    Check log message    ${tc.kws[10].msgs[0]}
+    ...    Set suite metadata 'ver sion' to value '1.0/2.0/3.0'.
 
 Set top-level suite metadata
     Metadata should have value    New metadata    Metadata for top level suite    top=yes
@@ -38,6 +44,13 @@ Set top-level suite metadata
     ...    Set suite metadata 'New metadata' to value 'Metadata for'.
     Check log message    ${tc.kws[1].msgs[0]}
     ...    Set suite metadata 'newmetadata' to value 'Metadata for top level suite'.
+    Metadata should have value    Separator    2top**level    top=yes
+    Check log message    ${tc.kws[3].msgs[0]}
+    ...    Set suite metadata 'Separator' to value '2'.
+    Check log message    ${tc.kws[4].msgs[0]}
+    ...    Set suite metadata 'Separator' to value '2top'.
+    Check log message    ${tc.kws[5].msgs[0]}
+    ...    Set suite metadata 'Separator' to value '2top**level'.
 
 Non-ASCII and non-string names and values
     ${tc} =    Check test case    ${TESTNAME}

--- a/atest/robot/standard_libraries/builtin/set_test_message.robot
+++ b/atest/robot/standard_libraries/builtin/set_test_message.robot
@@ -15,6 +15,8 @@ Append To Message
     ${tc} =    Check Test Case    ${TEST NAME}
     Check Log Message    ${tc.kws[0].msgs[0]}    Set test message to:\nMy <message>
     Check Log Message    ${tc.kws[1].msgs[0]}    Set test message to:\nMy <message> & its continuation <>
+    Check Log Message    ${tc.kws[2].msgs[0]}    Set test message to:\nMy <message> & its continuation <>1
+    Check Log Message    ${tc.kws[3].msgs[0]}    Set test message to:\nMy <message> & its continuation <>1,\n2
 
 Set Non-ASCII Message
     ${tc} =    Check Test Case    ${TEST NAME}
@@ -87,3 +89,18 @@ Not Allowed In Suite Setup or Teardown
     ...    Also suite teardown failed:
     ...    'Set Test Message' keyword cannot be used in suite setup or teardown.
     Should Be Equal    ${SUITE.suites[1].message}    ${error}
+
+Append HTML to non-HTML with separator
+    ${tc} =    Check Test Case    ${TEST NAME}
+    Check Log Message    ${tc.kws[0].msgs[0]}    Set test message to:\nA non HTML <message>    html=False
+    Check Log Message    ${tc.kws[1].msgs[0]}    Set test message to:\nA non HTML &lt;message&gt;&amp;its <b>HTML</b> continuation    html=True
+
+Append non-HTML to HTML with separator
+    ${tc} =    Check Test Case    ${TEST NAME}
+    Check Log Message    ${tc.kws[0].msgs[0]}    Set test message to:\nA <b>HTML</b> message    html=True
+    Check Log Message    ${tc.kws[1].msgs[0]}    Set test message to:\nA <b>HTML</b> message&lt;\br&gt;its non-HTML &lt;continuation&gt;    html=True
+
+Append HTML to HTML with separator
+    ${tc} =    Check Test Case    ${TEST NAME}
+    Check Log Message    ${tc.kws[0].msgs[0]}    Set test message to:\nA <b>HTML</b> message    html=True
+    Check Log Message    ${tc.kws[1].msgs[0]}    Set test message to:\nA <b>HTML</b> message &amp;&amp; its <b>HTML</b> continuation    html=True

--- a/atest/testdata/standard_libraries/builtin/documentation/set_documentation.robot
+++ b/atest/testdata/standard_libraries/builtin/documentation/set_documentation.robot
@@ -17,6 +17,12 @@ Append to test documentation
    Should be equal        ${TEST DOCUMENTATION}      Original doc is continued
    Set test documentation      \n\ntwice!    append=yep
    Should be equal        ${TEST DOCUMENTATION}      Original doc is continued \n\ntwice!
+   Set test documentation      thrice    append=yes    separator=${SPACE}
+   Should be equal        ${TEST DOCUMENTATION}      Original doc is continued \n\ntwice! thrice
+   Set test documentation      ${EMPTY}    append=yes    separator=!
+   Should be equal        ${TEST DOCUMENTATION}      Original doc is continued \n\ntwice! thrice!
+   Set test documentation      !    append=yes    separator=${EMPTY}
+   Should be equal        ${TEST DOCUMENTATION}      Original doc is continued \n\ntwice! thrice!!
 
 Set suite documentation
    Set suite documentation     New suite doc
@@ -33,7 +39,11 @@ Append to suite documentation 2
    Should be equal        ${SUITE DOCUMENTATION}      New suite doc is continued
    Set suite documentation      \n\ntwice!    append=yep
    Should be equal        ${SUITE DOCUMENTATION}      New suite doc is continued \n\ntwice!
+   Set suite documentation      thrice    append=yep    separator=,
+   Should be equal        ${SUITE DOCUMENTATION}      New suite doc is continued \n\ntwice!,thrice
+   Set suite documentation      ${1}    append=yes    separator=?
+   Should be equal        ${SUITE DOCUMENTATION}      New suite doc is continued \n\ntwice!,thrice?1
 
 Set top level suite documentation
    Set suite documentation    Appended in test.    append=yes    top=please
-   Should be equal        ${SUITE DOCUMENTATION}      New suite doc is continued \n\ntwice!
+   Should be equal        ${SUITE DOCUMENTATION}      New suite doc is continued \n\ntwice!,thrice?1

--- a/atest/testdata/standard_libraries/builtin/set_suite_metadata.robot
+++ b/atest/testdata/standard_libraries/builtin/set_suite_metadata.robot
@@ -25,11 +25,20 @@ Append to value
     Metadata variable should have value    To Append    Original is continued
     Set Suite Metadata    TOAPPEND    \n\ntwice!    append=please
     Metadata variable should have value    To Append    Original is continued \n\ntwice!
+    Set Suite Metadata    Version    1.0    append please    separator=,
+    Metadata variable should have value    Version    1.0
+    Set Suite Metadata    version    2.0    append please    separator=/
+    Metadata variable should have value    Version    1.0/2.0
+    Set Suite Metadata    ver sion    3.0    append please    separator=/
+    Metadata variable should have value    Version    1.0/2.0/3.0
 
 Set top-level suite metadata
     Set Suite Metadata    New metadata    Metadata for    top=yes
     Set Suite Metadata    newmetadata    top level suite    append    top
     Metadata variable should have value    New metadata    Set in test
+    Set Suite Metadata    Separator    ${2}    append=yes    top=yes     separator=/
+    Set Suite Metadata    Separator    top    append    top    separator=
+    Set Suite Metadata    Separator    level    append    top    separator=**
 
 Non-ASCII and non-string names and values
     Set Suite Metadata    ${42}    ${1}

--- a/atest/testdata/standard_libraries/builtin/set_test_message.robot
+++ b/atest/testdata/standard_libraries/builtin/set_test_message.robot
@@ -11,10 +11,12 @@ Reset Message
     [Teardown]    Should Be Equal    ${TEST MESSAGE}    My Real Test Message
 
 Append To Message
-    [Documentation]    PASS My <message> & its continuation <>
+    [Documentation]    PASS My <message> & its continuation <>1,\n2
     Set Test Message    My <message>    append please
     Set Test Message    & its continuation <>    append=please
-    [Teardown]    Should Be Equal    ${TEST MESSAGE}    My <message> & its continuation <>
+    Set Test Message    1    append=yes    separator=
+    Set Test Message    \n2    append=yup  separator=,
+    [Teardown]    Should Be Equal    ${TEST MESSAGE}    My <message> & its continuation <>1,\n2
 
 Set Non-ASCII Message
     [Documentation]    PASS Hyvää yötä & huomenta!
@@ -109,6 +111,21 @@ Test Message Variable Reacts On Set Test Message
     [Documentation]    PASS Other Second
     Pass_Execution    Initial Test Message
     [Teardown]    Check Test Message Variable Behavior Is Correct
+
+Append HTML to non-HTML with separator
+    [Documentation]    PASS *HTML* A non HTML &lt;message&gt;&amp;its <b>HTML</b> continuation
+    Set Test Message    A non HTML <message>
+    Set Test Message    *HTML* its <b>HTML</b> continuation    append=true    separator=&
+
+Append non-HTML to HTML with separator
+    [Documentation]    PASS *HTML* A <b>HTML</b> message&lt;\br&gt;its non-HTML &lt;continuation&gt;
+    Set Test Message    *HTML* A <b>HTML</b> message
+    Set Test Message    its non-HTML <continuation>    append=True    separator=<\br>
+
+Append HTML to HTML with separator
+    [Documentation]    PASS *HTML* A <b>HTML</b> message &amp;&amp; its <b>HTML</b> continuation
+    Set Test Message    *HTML* A <b>HTML</b> message
+    Set Test Message    *HTML* &amp; its <b>HTML</b> continuation    append=yeah    separator=${SPACE}&
 
 *** Keywords ***
 Set Message In Teardown And Fail Afterwards

--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -3550,12 +3550,16 @@ class _Misc(_BuiltInBase):
             return re.escape(patterns[0])
         return [re.escape(p) for p in patterns]
 
-    def set_test_message(self, message, append=False):
+    def set_test_message(self, message, append=False, separator=' '):
         """Sets message for the current test case.
 
         If the optional ``append`` argument is given a true value (see `Boolean
         arguments`), the given ``message`` is added after the possible earlier
         message by joining the messages with a space.
+        
+        An optional ``separator`` argument can be used to provide custom separator
+        string when appending to old text. By default a single space is used 
+        as separator.
 
         In test teardown this keyword can alter the possible failure message,
         but otherwise failures override messages set by this keyword. Notice
@@ -3572,19 +3576,20 @@ class _Misc(_BuiltInBase):
         | Set Test Message | `*`HTML`*` <b>Hello!</b> |                      |
 
         This keyword can not be used in suite setup or suite teardown.
+        ``separator`` argument is new in Robot Framework 7.2.
         """
         test = self._context.test
         if not test:
             raise RuntimeError("'Set Test Message' keyword cannot be used in "
                                "suite setup or teardown.")
-        test.message = self._get_new_text(test.message, message,
-                                          append, handle_html=True)
+        test.message = self._get_new_text(
+            test.message, message, append, handle_html=True, separator=separator)
         if self._context.in_test_teardown:
             self._variables.set_test("${TEST_MESSAGE}", test.message)
         message, level = self._get_logged_test_message_and_level(test.message)
         self.log(f'Set test message to:\n{message}', level)
 
-    def _get_new_text(self, old, new, append, handle_html=False):
+    def _get_new_text(self, old, new, append, handle_html=False, separator=' '):
         if not is_string(new):
             new = str(new)
         if not (is_truthy(append) and old):
@@ -3594,35 +3599,43 @@ class _Misc(_BuiltInBase):
                 new = new[6:].lstrip()
                 if not old.startswith('*HTML*'):
                     old = f'*HTML* {html_escape(old)}'
+                separator = html_escape(separator)
             elif old.startswith('*HTML*'):
                 new = html_escape(new)
-        return f'{old} {new}'
+                separator = html_escape(separator)
+        return f'{old}{separator}{new}'
 
     def _get_logged_test_message_and_level(self, message):
         if message.startswith('*HTML*'):
             return message[6:].lstrip(), 'HTML'
         return message, 'INFO'
 
-    def set_test_documentation(self, doc, append=False):
+    def set_test_documentation(self, doc, append=False, separator=' '):
         """Sets documentation for the current test case.
 
         By default the possible existing documentation is overwritten, but
         this can be changed using the optional ``append`` argument similarly
         as with `Set Test Message` keyword.
+        
+        An optional ``separator`` argument can be used to provide custom separator
+        string when appending to old text. By default a single space is used 
+        as separator.
 
         The current test documentation is available as a built-in variable
         ``${TEST DOCUMENTATION}``. This keyword can not be used in suite
         setup or suite teardown.
+        
+        ``separator`` argument is new in Robot Framework 7.2.
         """
         test = self._context.test
         if not test:
             raise RuntimeError("'Set Test Documentation' keyword cannot be "
                                "used in suite setup or teardown.")
-        test.doc = self._get_new_text(test.doc, doc, append)
+        test.doc = self._get_new_text(test.doc, doc, append, separator=separator)
         self._variables.set_test('${TEST_DOCUMENTATION}', test.doc)
         self.log(f'Set test documentation to:\n{test.doc}')
 
-    def set_suite_documentation(self, doc, append=False, top=False):
+    def set_suite_documentation(self, doc, append=False, top=False, separator=' '):
         """Sets documentation for the current test suite.
 
         By default, the possible existing documentation is overwritten, but
@@ -3633,16 +3646,22 @@ class _Misc(_BuiltInBase):
         If the optional ``top`` argument is given a true value (see `Boolean
         arguments`), the documentation of the top level suite is altered
         instead.
+        
+        An optional ``separator`` argument can be used to provide custom separator
+        string when appending to old text. By default a single space is used 
+        as separator.
 
         The documentation of the current suite is available as a built-in
         variable ``${SUITE DOCUMENTATION}``.
+        
+        ``separator`` argument is new in Robot Framework 7.2.
         """
         suite = self._get_context(top).suite
-        suite.doc = self._get_new_text(suite.doc, doc, append)
+        suite.doc = self._get_new_text(suite.doc, doc, append, separator=separator)
         self._variables.set_suite('${SUITE_DOCUMENTATION}', suite.doc, top)
         self.log(f'Set suite documentation to:\n{suite.doc}')
 
-    def set_suite_metadata(self, name, value, append=False, top=False):
+    def set_suite_metadata(self, name, value, append=False, top=False, separator=' '):
         """Sets metadata for the current test suite.
 
         By default, possible existing metadata values are overwritten, but
@@ -3652,16 +3671,23 @@ class _Misc(_BuiltInBase):
         This keyword sets the metadata of the current suite by default.
         If the optional ``top`` argument is given a true value (see `Boolean
         arguments`), the metadata of the top level suite is altered instead.
+        
+        An optional ``separator`` argument can be used to provide custom separator
+        string when appending to old text. By default a single space is used 
+        as separator.
 
         The metadata of the current suite is available as a built-in variable
         ``${SUITE METADATA}`` in a Python dictionary. Notice that modifying this
         variable directly has no effect on the actual metadata the suite has.
+        
+        ``separator`` argument is new in Robot Framework 7.2.
         """
         if not is_string(name):
             name = str(name)
         metadata = self._get_context(top).suite.metadata
         original = metadata.get(name, '')
-        metadata[name] = self._get_new_text(original, value, append)
+        metadata[name] = self._get_new_text(original, value, append, 
+                                            separator=separator)
         self._variables.set_suite('${SUITE_METADATA}', metadata.copy(), top)
         self.log(f"Set suite metadata '{name}' to value '{metadata[name]}'.")
 


### PR DESCRIPTION
Added an argument `separator` in `Set Test Message`, `Set Test Documentation`, `Set Suite Documentation` and `Set Suite Metadata` keywords. This allows passing in custom separators when appending the data.
Added steps in existing acceptance tests. Added new acceptance tests where required.
Closes #5215 