### PR TITLE
Add rflogs integration for improved test failure tracking

### DIFF
--- a/.github/workflows/acceptance_tests_cpython.yml
+++ b/.github/workflows/acceptance_tests_cpython.yml
@@ -140,18 +140,3 @@ jobs:
           else:
               print("No directory containing log.html found")
               exit(1)
-
-      - uses: octokit/request-action@872c5c97b3c85c23516a572f02b31401ef82415d
-        name: Update status with Github Status API
-        id: update_status
-        with:
-          route: POST /repos/:repository/statuses/:sha
-          repository: ${{ github.repository }}
-          sha: ${{ github.sha }}
-          state: "${{env.JOB_STATUS}}"
-          target_url: "${{env.REPORT_URL}}"
-          description: "Link to test report."
-          context: at-results-${{ matrix.python-version }}-${{ matrix.os }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.STATUS_UPLOAD_TOKEN }}
-        if: always() && job.status == 'failure'

--- a/.github/workflows/acceptance_tests_cpython.yml
+++ b/.github/workflows/acceptance_tests_cpython.yml
@@ -110,9 +110,36 @@ jobs:
         env:
           RFLOGS_API_KEY: ${{ secrets.RFLOGS_API_KEY }}
         working-directory: atest/results
+        shell: python
         run: |
-          pip install rflogs
-          rflogs upload --tag "os:${{ runner.os }}" --tag "python-version:${{ matrix.python-version }}" --tag "branch:${{ github.head_ref }}"
+          import os
+          import glob
+          import subprocess
+
+          # Install rflogs
+          subprocess.check_call(["pip", "install", "rflogs"])
+
+          # Find the first directory containing log.html
+          log_files = glob.glob("**/log.html", recursive=True)
+          if log_files:
+              result_dir = os.path.dirname(log_files[0])
+              print(f"Result directory: {result_dir}")
+
+              # Construct the rflogs command
+              cmd = [
+                  "rflogs", "upload",
+                  "--tag", f"workflow:${{ github.workflow }}",
+                  "--tag", f"os:${{ runner.os }}",
+                  "--tag", f"python-version:${{ matrix.python-version }}",
+                  "--tag", f"branch:${{ github.head_ref || github.ref_name }}",
+                  result_dir
+              ]
+
+              # Run rflogs upload
+              subprocess.check_call(cmd)
+          else:
+              print("No directory containing log.html found")
+              exit(1)
 
       - uses: octokit/request-action@872c5c97b3c85c23516a572f02b31401ef82415d
         name: Update status with Github Status API

--- a/.github/workflows/acceptance_tests_cpython.yml
+++ b/.github/workflows/acceptance_tests_cpython.yml
@@ -105,23 +105,14 @@ jobs:
           path: atest/results
         if: always() && job.status == 'failure'
 
-      - name: Upload results on *nix
+      - name: Install and run rflogs
+        if: failure()
+        env:
+          RFLOGS_API_KEY: ${{ secrets.RFLOGS_API_KEY }}
+        working-directory: atest/results
         run: |
-          echo '<html><head><meta http-equiv = "refresh" content =" 0 ; url = /report.html"></head></html>' > atest/results/index.html
-          zip -r -j site.zip atest/results > no_output 2>&1
-          curl -s -H "Content-Type: application/zip" -H "Authorization: Bearer ${{ secrets.NETLIFY_TOKEN }}" --data-binary "@site.zip" https://api.netlify.com/api/v1/sites > response.json
-          echo "REPORT_URL=$(cat response.json|python -c "import sys, json; print('https://' + json.load(sys.stdin)['subdomain'] + '.netlify.com')")" >> $GITHUB_ENV
-          echo "JOB_STATUS=$(python -c "print('${{ job.status }}'.lower())")" >> $GITHUB_ENV
-        if: always() && job.status == 'failure' && runner.os != 'Windows'
-
-      - name: Upload results on Windows
-        run: |
-          echo '<html><head><meta http-equiv = "refresh" content =" 0 ; url = /report.html"></head></html>' > atest/results/index.html
-          zip -r -j site.zip atest/results > no_output 2>&1
-          curl -s -H "Content-Type: application/zip" -H "Authorization: Bearer ${{ secrets.NETLIFY_TOKEN }}" --data-binary "@site.zip" https://api.netlify.com/api/v1/sites > response.json
-          echo "REPORT_URL=$(cat response.json|python -c "import sys, json; print('https://' + json.load(sys.stdin)['subdomain'] + '.netlify.com')")" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "JOB_STATUS=$(python -c "print('${{ job.status }}'.lower())")" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        if: always() && job.status == 'failure' && runner.os == 'Windows'
+          pip install rflogs
+          rflogs upload --tag workflow:${{ github.workflow }} --tag os:${{ runner.os }} --tag python-version:${{ matrix.python-version }} --tag branch:${{ github.ref_name }}
 
       - uses: octokit/request-action@872c5c97b3c85c23516a572f02b31401ef82415d
         name: Update status with Github Status API

--- a/.github/workflows/acceptance_tests_cpython.yml
+++ b/.github/workflows/acceptance_tests_cpython.yml
@@ -112,7 +112,7 @@ jobs:
         working-directory: atest/results
         run: |
           pip install rflogs
-          rflogs upload --tag workflow:${{ github.workflow }} --tag os:${{ runner.os }} --tag python-version:${{ matrix.python-version }} --tag branch:${{ github.ref_name }}
+          rflogs upload --tag "workflow:${{ github.workflow }}" --tag "os:${{ runner.os }}" --tag "python-version:${{ matrix.python-version }}" --tag "branch:${{ github.head_ref }}"
 
       - uses: octokit/request-action@872c5c97b3c85c23516a572f02b31401ef82415d
         name: Update status with Github Status API

--- a/.github/workflows/acceptance_tests_cpython.yml
+++ b/.github/workflows/acceptance_tests_cpython.yml
@@ -112,7 +112,7 @@ jobs:
         working-directory: atest/results
         run: |
           pip install rflogs
-          rflogs upload --tag "workflow:${{ github.workflow }}" --tag "os:${{ runner.os }}" --tag "python-version:${{ matrix.python-version }}" --tag "branch:${{ github.head_ref }}"
+          rflogs upload --tag "os:${{ runner.os }}" --tag "python-version:${{ matrix.python-version }}" --tag "branch:${{ github.head_ref }}"
 
       - uses: octokit/request-action@872c5c97b3c85c23516a572f02b31401ef82415d
         name: Update status with Github Status API

--- a/.github/workflows/acceptance_tests_cpython_pr.yml
+++ b/.github/workflows/acceptance_tests_cpython_pr.yml
@@ -94,6 +94,7 @@ jobs:
         if: always() && job.status == 'failure'
 
       - name: Install and run rflogs
+        if: failure()
         env:
           RFLOGS_API_KEY: ${{ secrets.RFLOGS_API_KEY }}
         working-directory: atest/results

--- a/.github/workflows/acceptance_tests_cpython_pr.yml
+++ b/.github/workflows/acceptance_tests_cpython_pr.yml
@@ -99,7 +99,7 @@ jobs:
         working-directory: atest/results
         run: |
           pip install rflogs
-          rflogs upload --tag workflow:${{ github.workflow }} --tag os:${{ runner.os }} --tag python-version:${{ matrix.python-version }} --tag branch:${{ github.head_ref }}
+          rflogs upload --tag "workflow:${{ github.workflow }}" --tag "os:${{ runner.os }}" --tag "python-version:${{ matrix.python-version }}" --tag "branch:${{ github.head_ref }}"
 
       - uses: octokit/request-action@872c5c97b3c85c23516a572f02b31401ef82415d
         name: Update status with Github Status API

--- a/.github/workflows/acceptance_tests_cpython_pr.yml
+++ b/.github/workflows/acceptance_tests_cpython_pr.yml
@@ -128,18 +128,3 @@ jobs:
           else:
               print("No directory containing log.html found")
               exit(1)
-
-      - uses: octokit/request-action@872c5c97b3c85c23516a572f02b31401ef82415d
-        name: Update status with Github Status API
-        id: update_status
-        with:
-          route: POST /repos/:repository/statuses/:sha
-          repository: ${{ github.repository }}
-          sha: ${{ github.sha }}
-          state: "${{env.JOB_STATUS}}"
-          target_url: "${{env.REPORT_URL}}"
-          description: "Link to test report."
-          context: at-results-${{ matrix.python-version }}-${{ matrix.os }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.STATUS_UPLOAD_TOKEN }}
-        if: always() && job.status == 'failure'

--- a/.github/workflows/acceptance_tests_cpython_pr.yml
+++ b/.github/workflows/acceptance_tests_cpython_pr.yml
@@ -93,23 +93,14 @@ jobs:
           path: atest/results
         if: always() && job.status == 'failure'
 
-      - name: Upload results on *nix
+      - name: Install and run rflogs
+        if: failure()
+        env:
+          RFLOGS_API_KEY: ${{ secrets.RFLOGS_API_KEY }}
+        working-directory: atest/results
         run: |
-          echo '<html><head><meta http-equiv = "refresh" content =" 0 ; url = /report.html"></head></html>' > atest/results/index.html
-          zip -r -j site.zip atest/results > no_output 2>&1
-          curl -s -H "Content-Type: application/zip" -H "Authorization: Bearer ${{ secrets.NETLIFY_TOKEN }}" --data-binary "@site.zip" https://api.netlify.com/api/v1/sites > response.json
-          echo "REPORT_URL=$(cat response.json|python -c "import sys, json; print('https://' + json.load(sys.stdin)['subdomain'] + '.netlify.com')")" >> $GITHUB_ENV
-          echo "JOB_STATUS=$(python -c "print('${{ job.status }}'.lower())")" >> $GITHUB_ENV
-        if: always() && job.status == 'failure' && runner.os != 'Windows'
-
-      - name: Upload results on Windows
-        run: |
-          echo '<html><head><meta http-equiv = "refresh" content =" 0 ; url = /report.html"></head></html>' > atest/results/index.html
-          zip -r -j site.zip atest/results > no_output 2>&1
-          curl -s -H "Content-Type: application/zip" -H "Authorization: Bearer ${{ secrets.NETLIFY_TOKEN }}" --data-binary "@site.zip" https://api.netlify.com/api/v1/sites > response.json
-          echo "REPORT_URL=$(cat response.json|python -c "import sys, json; print('https://' + json.load(sys.stdin)['subdomain'] + '.netlify.com')")" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "JOB_STATUS=$(python -c "print('${{ job.status }}'.lower())")" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        if: always() && job.status == 'failure' && runner.os == 'Windows'
+          pip install rflogs
+          rflogs upload --tag workflow:${{ github.workflow }} --tag os:${{ runner.os }} --tag python-version:${{ matrix.python-version }} --tag branch:${{ github.head_ref }}
 
       - uses: octokit/request-action@872c5c97b3c85c23516a572f02b31401ef82415d
         name: Update status with Github Status API

--- a/.github/workflows/acceptance_tests_cpython_pr.yml
+++ b/.github/workflows/acceptance_tests_cpython_pr.yml
@@ -98,9 +98,36 @@ jobs:
         env:
           RFLOGS_API_KEY: ${{ secrets.RFLOGS_API_KEY }}
         working-directory: atest/results
+        shell: python
         run: |
-          pip install rflogs
-          rflogs upload --tag "os:${{ runner.os }}" --tag "python-version:${{ matrix.python-version }}" --tag "branch:${{ github.head_ref }}"
+          import os
+          import glob
+          import subprocess
+
+          # Install rflogs
+          subprocess.check_call(["pip", "install", "rflogs"])
+
+          # Find the first directory containing log.html
+          log_files = glob.glob("**/log.html", recursive=True)
+          if log_files:
+              result_dir = os.path.dirname(log_files[0])
+              print(f"Result directory: {result_dir}")
+
+              # Construct the rflogs command
+              cmd = [
+                  "rflogs", "upload",
+                  "--tag", f"workflow:${{ github.workflow }}",
+                  "--tag", f"os:${{ runner.os }}",
+                  "--tag", f"python-version:${{ matrix.python-version }}",
+                  "--tag", f"branch:${{ github.head_ref || github.ref_name }}",
+                  result_dir
+              ]
+
+              # Run rflogs upload
+              subprocess.check_call(cmd)
+          else:
+              print("No directory containing log.html found")
+              exit(1)
 
       - uses: octokit/request-action@872c5c97b3c85c23516a572f02b31401ef82415d
         name: Update status with Github Status API

--- a/.github/workflows/acceptance_tests_cpython_pr.yml
+++ b/.github/workflows/acceptance_tests_cpython_pr.yml
@@ -94,7 +94,6 @@ jobs:
         if: always() && job.status == 'failure'
 
       - name: Install and run rflogs
-        if: failure()
         env:
           RFLOGS_API_KEY: ${{ secrets.RFLOGS_API_KEY }}
         working-directory: atest/results

--- a/.github/workflows/acceptance_tests_cpython_pr.yml
+++ b/.github/workflows/acceptance_tests_cpython_pr.yml
@@ -99,7 +99,7 @@ jobs:
         working-directory: atest/results
         run: |
           pip install rflogs
-          rflogs upload --tag "workflow:${{ github.workflow }}" --tag "os:${{ runner.os }}" --tag "python-version:${{ matrix.python-version }}" --tag "branch:${{ github.head_ref }}"
+          rflogs upload --tag "os:${{ runner.os }}" --tag "python-version:${{ matrix.python-version }}" --tag "branch:${{ github.head_ref }}"
 
       - uses: octokit/request-action@872c5c97b3c85c23516a572f02b31401ef82415d
         name: Update status with Github Status API

--- a/atest/robot/cli/console/colors_and_width.robot
+++ b/atest/robot/cli/console/colors_and_width.robot
@@ -5,6 +5,7 @@ Resource          console_resource.robot
 
 *** Test Cases ***
 Console Colors Auto
+    Fail  Just FAIL
     Run Tests With Warnings    --consolecolors auto
     Outputs should not have ANSI codes
 

--- a/atest/robot/cli/console/colors_and_width.robot
+++ b/atest/robot/cli/console/colors_and_width.robot
@@ -5,7 +5,6 @@ Resource          console_resource.robot
 
 *** Test Cases ***
 Console Colors Auto
-    Fail  Just FAIL
     Run Tests With Warnings    --consolecolors auto
     Outputs should not have ANSI codes
 


### PR DESCRIPTION
# Integration of rflogs for Enhanced Test Failure Tracking

This PR introduces rflogs integration to GitHub Actions workflows, improving ability to track and analyze test failures across different environments.

## Changes

- Added rflogs upload step to acceptance test workflows (both push and PR)
- Made the result dir discovery platform independent by using python
- Removed deprecated result upload steps
- Configured rflogs to upload results only on test failures
- Included relevant tags for better context:
  - os
  - python-version
  - branch

## Notes

- RFLOGS_API_KEY is set in repository secrets ( I did it )
![rflogs_api_key](https://github.com/user-attachments/assets/939afd9d-bacc-42c9-9e1c-16c6f3d0b422)
- RFLOGS_API_KEY points to a project that I own in rflogs.io as the service is still WIP (this could be changed later).

## Example outputs

From https://github.com/robotframework/robotframework/actions/runs/11196642558
```
HTML Files:
  Report:    https://rflogs.io/files/YOx7vOwxRKS2Qapxo9l5RA/report.html
  Log:       https://rflogs.io/files/YOx7vOwxRKS2Qapxo9l5RA/log.html
  Run:       https://rflogs.io/run-details.html?runId=YOx7vOwxRKS2Qapxo9l5RA
```