### PR TITLE
thread capable logging to the debugfile (for now)

### DIFF
--- a/atest/robot/cli/runner/debugfile.robot
+++ b/atest/robot/cli/runner/debugfile.robot
@@ -13,13 +13,13 @@ Debugfile
     Debug file should contain    ${content}           + START SUITE: Normal
     Debug file should contain    ${content}           +- START TEST: First One
     Debug file should contain    ${content}
-    ...      ${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Test 1 ?
-    ...      ${TIMESTAMP} - INFO - Test 1
-    ...      ${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
+    ...      MainThread\t${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Test 1 ?
+    ...      MainThread\t${TIMESTAMP} - INFO - Test 1
+    ...      MainThread\t${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
     Debug file should contain    ${content}
-    ...      ${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Logging with debug level | DEBUG ?
-    ...      ${TIMESTAMP} - DEBUG - Logging with debug level
-    ...      ${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
+    ...      MainThread\t${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Logging with debug level | DEBUG ?
+    ...      MainThread\t${TIMESTAMP} - DEBUG - Logging with debug level
+    ...      MainThread\t${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
     Debug file should contain    ${content}    + END SUITE: Normal
     Syslog Should Contain  DebugFile: DeBug.TXT
     ${path} =  Set Variable  [:.\\w /\\\\~+-]*DeBug\\.TXT
@@ -31,13 +31,13 @@ Debugfile Log Level Should Always Be Debug
     Run Tests Without Processing Output  --outputdir ${CLI OUTDIR} -b debug.txt -o o.xml --loglevel WARN  ${TESTFILE}
     ${content}=     Get File     ${CLI OUTDIR}/debug.txt
     Debug file should contain    ${content}
-    ...    ${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Test 1 ?
-    ...    ${TIMESTAMP} - INFO - Test 1
-    ...    ${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
+    ...    MainThread\t${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Test 1 ?
+    ...    MainThread\t${TIMESTAMP} - INFO - Test 1
+    ...    MainThread\t${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
     Debug file should contain    ${content}
-    ...    ${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Logging with debug level | DEBUG ?
-    ...    ${TIMESTAMP} - DEBUG - Logging with debug level
-    ...    ${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
+    ...    MainThread\t${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Logging with debug level | DEBUG ?
+    ...    MainThread\t${TIMESTAMP} - DEBUG - Logging with debug level
+    ...    MainThread\t${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
 
 Debugfile timestamps are accurate
     Run Tests    --outputdir ${CLI OUTDIR} -b debug.txt -t LibraryAddsTimestampAsInteger
@@ -45,8 +45,8 @@ Debugfile timestamps are accurate
     ${tc} =    Check Test Case    LibraryAddsTimestampAsInteger
     ${content} =     Get file     ${CLI OUTDIR}/debug.txt
     Debug file should contain    ${content}
-    ...    ${tc[0, 0].timestamp} - INFO - Known timestamp
-    ...    ${tc[0, 1].timestamp} - INFO - <b>Current</b>
+    ...    MainThread\t${tc[0, 0].timestamp} - INFO - Known timestamp
+    ...    MainThread\t${tc[0, 1].timestamp} - INFO - <b>Current</b>
 
 Writing Non-ASCII To Debugfile
     [Documentation]    Tests also that '.txt' is appended if no extension given
@@ -54,8 +54,8 @@ Writing Non-ASCII To Debugfile
     Directory Should Contain    ${CLI OUTDIR}    debug.txt    o.xml
     Stderr Should Be Empty
     ${content} =    Get File    ${CLI OUTDIR}/debug.txt
-    Debugfile should contain    ${content}    ${TIMESTAMP} - FAIL - Circle is 360°, Hyvää üötä, উৄ ৰ ৺ ট ৫ ৪ হ
-    Debugfile should contain    ${content}    ${TIMESTAMP} - INFO - +- START TEST: Ñöñ-ÄŚÇÏÏ Tëśt äņd Këywörd Nämës, Спасибо
+    Debugfile should contain    MainThread\t${content}    ${TIMESTAMP} - FAIL - Circle is 360°, Hyvää üötä, উৄ ৰ ৺ ট ৫ ৪ হ
+    Debugfile should contain    MainThread\t${content}    ${TIMESTAMP} - INFO - +- START TEST: Ñöñ-ÄŚÇÏÏ Tëśt äņd Këywörd Nämës, Спасибо
 
 No Debugfile
     Run Tests Without Processing Output  --outputdir ${CLI OUTDIR} --debugfile NoNe -o o.xml  ${TESTFILE}

--- a/atest/robot/cli/runner/debugfile.robot
+++ b/atest/robot/cli/runner/debugfile.robot
@@ -13,13 +13,13 @@ Debugfile
     Debug file should contain    ${content}           + START SUITE: Normal
     Debug file should contain    ${content}           +- START TEST: First One
     Debug file should contain    ${content}
-    ...      MainThread\t${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Test 1 ?
-    ...      MainThread\t${TIMESTAMP} - INFO - Test 1
-    ...      MainThread\t${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
+    ...      MainThread\tregular\t${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Test 1 ?
+    ...      MainThread\tregular\t${TIMESTAMP} - INFO - Test 1
+    ...      MainThread\tregular\t${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
     Debug file should contain    ${content}
-    ...      MainThread\t${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Logging with debug level | DEBUG ?
-    ...      MainThread\t${TIMESTAMP} - DEBUG - Logging with debug level
-    ...      MainThread\t${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
+    ...      MainThread\tregular\t${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Logging with debug level | DEBUG ?
+    ...      MainThread\tregular\t${TIMESTAMP} - DEBUG - Logging with debug level
+    ...      MainThread\tregular\t${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
     Debug file should contain    ${content}    + END SUITE: Normal
     Syslog Should Contain  DebugFile: DeBug.TXT
     ${path} =  Set Variable  [:.\\w /\\\\~+-]*DeBug\\.TXT
@@ -31,13 +31,13 @@ Debugfile Log Level Should Always Be Debug
     Run Tests Without Processing Output  --outputdir ${CLI OUTDIR} -b debug.txt -o o.xml --loglevel WARN  ${TESTFILE}
     ${content}=     Get File     ${CLI OUTDIR}/debug.txt
     Debug file should contain    ${content}
-    ...    MainThread\t${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Test 1 ?
-    ...    MainThread\t${TIMESTAMP} - INFO - Test 1
-    ...    MainThread\t${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
+    ...    MainThread\tregular\t${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Test 1 ?
+    ...    MainThread\tregular\t${TIMESTAMP} - INFO - Test 1
+    ...    MainThread\tregular\t${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
     Debug file should contain    ${content}
-    ...    MainThread\t${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Logging with debug level | DEBUG ?
-    ...    MainThread\t${TIMESTAMP} - DEBUG - Logging with debug level
-    ...    MainThread\t${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
+    ...    MainThread\tregular\t${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Logging with debug level | DEBUG ?
+    ...    MainThread\tregular\t${TIMESTAMP} - DEBUG - Logging with debug level
+    ...    MainThread\tregular\t${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
 
 Debugfile timestamps are accurate
     Run Tests    --outputdir ${CLI OUTDIR} -b debug.txt -t LibraryAddsTimestampAsInteger
@@ -45,8 +45,8 @@ Debugfile timestamps are accurate
     ${tc} =    Check Test Case    LibraryAddsTimestampAsInteger
     ${content} =     Get file     ${CLI OUTDIR}/debug.txt
     Debug file should contain    ${content}
-    ...    MainThread\t${tc[0, 0].timestamp} - INFO - Known timestamp
-    ...    MainThread\t${tc[0, 1].timestamp} - INFO - <b>Current</b>
+    ...    MainThread\tregular\t${tc[0, 0].timestamp} - INFO - Known timestamp
+    ...    MainThread\tregular\t${tc[0, 1].timestamp} - INFO - <b>Current</b>
 
 Writing Non-ASCII To Debugfile
     [Documentation]    Tests also that '.txt' is appended if no extension given
@@ -54,8 +54,8 @@ Writing Non-ASCII To Debugfile
     Directory Should Contain    ${CLI OUTDIR}    debug.txt    o.xml
     Stderr Should Be Empty
     ${content} =    Get File    ${CLI OUTDIR}/debug.txt
-    Debugfile should contain    MainThread\t${content}    ${TIMESTAMP} - FAIL - Circle is 360°, Hyvää üötä, উৄ ৰ ৺ ট ৫ ৪ হ
-    Debugfile should contain    MainThread\t${content}    ${TIMESTAMP} - INFO - +- START TEST: Ñöñ-ÄŚÇÏÏ Tëśt äņd Këywörd Nämës, Спасибо
+    Debugfile should contain    MainThread\tregular\t${content}    ${TIMESTAMP} - FAIL - Circle is 360°, Hyvää üötä, উৄ ৰ ৺ ট ৫ ৪ হ
+    Debugfile should contain    MainThread\tregular\t${content}    ${TIMESTAMP} - INFO - +- START TEST: Ñöñ-ÄŚÇÏÏ Tëśt äņd Këywörd Nämës, Спасибо
 
 No Debugfile
     Run Tests Without Processing Output  --outputdir ${CLI OUTDIR} --debugfile NoNe -o o.xml  ${TESTFILE}

--- a/atest/robot/cli/runner/debugfile.robot
+++ b/atest/robot/cli/runner/debugfile.robot
@@ -13,13 +13,13 @@ Debugfile
     Debug file should contain    ${content}           + START SUITE: Normal
     Debug file should contain    ${content}           +- START TEST: First One
     Debug file should contain    ${content}
-    ...      MainThread\tregular\t${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Test 1 ?
-    ...      MainThread\tregular\t${TIMESTAMP} - INFO - Test 1
-    ...      MainThread\tregular\t${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
+    ...      *\tMainThread\tregular\t${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Test 1 ?
+    ...      *\tMainThread\tregular\t${TIMESTAMP} - INFO - Test 1
+    ...      *\tMainThread\tregular\t${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
     Debug file should contain    ${content}
-    ...      MainThread\tregular\t${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Logging with debug level | DEBUG ?
-    ...      MainThread\tregular\t${TIMESTAMP} - DEBUG - Logging with debug level
-    ...      MainThread\tregular\t${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
+    ...      *\tMainThread\tregular\t${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Logging with debug level | DEBUG ?
+    ...      *\tMainThread\tregular\t${TIMESTAMP} - DEBUG - Logging with debug level
+    ...      *\tMainThread\tregular\t${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
     Debug file should contain    ${content}    + END SUITE: Normal
     Syslog Should Contain  DebugFile: DeBug.TXT
     ${path} =  Set Variable  [:.\\w /\\\\~+-]*DeBug\\.TXT
@@ -31,13 +31,13 @@ Debugfile Log Level Should Always Be Debug
     Run Tests Without Processing Output  --outputdir ${CLI OUTDIR} -b debug.txt -o o.xml --loglevel WARN  ${TESTFILE}
     ${content}=     Get File     ${CLI OUTDIR}/debug.txt
     Debug file should contain    ${content}
-    ...    MainThread\tregular\t${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Test 1 ?
-    ...    MainThread\tregular\t${TIMESTAMP} - INFO - Test 1
-    ...    MainThread\tregular\t${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
+    ...    *\tMainThread\tregular\t${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Test 1 ?
+    ...    *\tMainThread\tregular\t${TIMESTAMP} - INFO - Test 1
+    ...    *\tMainThread\tregular\t${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
     Debug file should contain    ${content}
-    ...    MainThread\tregular\t${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Logging with debug level | DEBUG ?
-    ...    MainThread\tregular\t${TIMESTAMP} - DEBUG - Logging with debug level
-    ...    MainThread\tregular\t${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
+    ...    *\tMainThread\tregular\t${TIMESTAMP} - INFO - +-- START KEYWORD: BuiltIn.Log ? Logging with debug level | DEBUG ?
+    ...    *\tMainThread\tregular\t${TIMESTAMP} - DEBUG - Logging with debug level
+    ...    *\tMainThread\tregular\t${TIMESTAMP} - INFO - +-- END KEYWORD: BuiltIn.Log
 
 Debugfile timestamps are accurate
     Run Tests    --outputdir ${CLI OUTDIR} -b debug.txt -t LibraryAddsTimestampAsInteger
@@ -45,8 +45,8 @@ Debugfile timestamps are accurate
     ${tc} =    Check Test Case    LibraryAddsTimestampAsInteger
     ${content} =     Get file     ${CLI OUTDIR}/debug.txt
     Debug file should contain    ${content}
-    ...    MainThread\tregular\t${tc[0, 0].timestamp} - INFO - Known timestamp
-    ...    MainThread\tregular\t${tc[0, 1].timestamp} - INFO - <b>Current</b>
+    ...    *\tMainThread\tregular\t${tc[0, 0].timestamp} - INFO - Known timestamp
+    ...    *\tMainThread\tregular\t${tc[0, 1].timestamp} - INFO - <b>Current</b>
 
 Writing Non-ASCII To Debugfile
     [Documentation]    Tests also that '.txt' is appended if no extension given

--- a/atest/testdata/test_libraries/run_logging_tests_on_thread.py
+++ b/atest/testdata/test_libraries/run_logging_tests_on_thread.py
@@ -23,6 +23,6 @@ def run_logging_tests(output):
 
 
 output = (sys.argv + ['output.xml'])[1]
-t = Thread(target=lambda: run_logging_tests(output))
+t = Thread(target=lambda: run_logging_tests(output), name="MainThread")
 t.start()
 t.join()

--- a/src/robot/output/debugfile.py
+++ b/src/robot/output/debugfile.py
@@ -214,7 +214,7 @@ class _DebugFileWriter(LoggerApi):
             inEventLoop = "async"
         except RuntimeError:
             pass
-        text = "".join(f"{os.getpid()}\n{threading.current_thread().name}\t{inEventLoop}\t{item}\n" for item in text.rstrip().split('\n'))
+        text = "".join(f"{os.getpid()}\t{threading.current_thread().name}\t{inEventLoop}\t{item}\n" for item in text.rstrip().split('\n'))
         self._outfile.write(text)
         self._separator_written_last = separator
 

--- a/src/robot/output/debugfile.py
+++ b/src/robot/output/debugfile.py
@@ -17,6 +17,8 @@ from pathlib import Path
 import threading
 import queue
 from enum import Enum
+import os
+import asyncio
 
 from robot.errors import DataError
 from robot.utils import file_writer, seq2str2
@@ -204,7 +206,13 @@ class _DebugFileWriter(LoggerApi):
         self = _get_thread_local_instance_DebugFileWriter(self)
         if separator and self._separator_written_last:
             return
-        text = "".join(f"{threading.current_thread().name}\t{item}\n" for item in text.rstrip().split('\n'))
+        inEventLoop = "regular"
+        try:
+            asyncio.get_running_loop()
+            inEventLoop = "async"
+        except RuntimeError:
+            pass
+        text = "".join(f"{os.getpgid()}\n{threading.current_thread().name}\t{inEventLoop}\t{item}\n" for item in text.rstrip().split('\n'))
         self._outfile.write(text)
         self._separator_written_last = separator
 

--- a/src/robot/output/debugfile.py
+++ b/src/robot/output/debugfile.py
@@ -48,12 +48,6 @@ class _debug_worker:
         self._worker_thread = threading.Thread(target=_debug_worker._worker, args=(outfile, self._out_q), daemon=False)
         self._worker_thread.start()
 
-    def close(self):
-        self._out_q.put(("close", False,))
-
-    def write(self, text):
-        self._out_q.put(("write", text,))
-
     @property
     def closed(self):
         if self._worker_thread.is_alive():
@@ -94,7 +88,7 @@ class _debug_worker:
         _workers = {}
         while True:
             (outfile, q_res,) = _debug_worker._request_worker_q.get()
-            if not outfile in _workers:
+            if outfile not in _workers:
                 _workers[outfile] = _debug_worker(outfile)
             q_res.put(_workers[outfile])
 

--- a/src/robot/output/librarylogger.py
+++ b/src/robot/output/librarylogger.py
@@ -42,8 +42,7 @@ def write(msg: Any, level: str, html: bool = False):
             console(msg)
         else:
             raise RuntimeError(f"Invalid log level '{level}'.")
-    if current_thread().name in LOGGING_THREADS:
-        LOGGER.log_message(Message(msg, level, html))
+    LOGGER.log_message(Message(msg, level, html))
 
 
 def trace(msg, html=False):

--- a/src/robot/output/logger.py
+++ b/src/robot/output/logger.py
@@ -15,6 +15,7 @@
 
 from contextlib import contextmanager
 import os
+from threading import current_thread
 
 from robot.errors import DataError
 
@@ -205,7 +206,8 @@ class Logger(AbstractLogger):
             self._log_message_cache.append(msg)
             return
         for logger in self:
-            logger.log_message(msg)
+            if (current_thread().name in ['MainThread', 'RobotFrameworkTimeoutThread']) or hasattr(logger, "multithread_capable") and logger.multithread_capable:
+                logger.log_message(msg)
         if self._log_message_parents and self._output_file.is_logged(msg):
             self._log_message_parents[-1].body.append(msg)
         if msg.level in ('WARN', 'ERROR'):


### PR DESCRIPTION
This is an alternative implementation to this.: [thread-logging-in-debugfile](https://github.com/daj-code/robotframework/blob/thread-logging-in-debugfile)

The reason for this is that daj -code uses locks. Ensuring deadlock, life lock, race condition free code is hard.

I believe that for this problem queues are the correct way to go.

- locks interfere with timing, while queues only do so in out of memory situations
- lockless code allows to take full advantage of the gil removal/subinterpreter solutions and is compatible with subprocess based parallelism
- the concept presented is suitable to be extended to write a full log for every thread running, not just the debug file
- due to the fact that the logging infrastructure is thread local, the information between threads does not get mixed (indentation)
- asyncio is mentioned as the source of a log entry
- forking is handled correctly, the process with the same PID as the initial process, keeps ownership