### PR TITLE
Fix confusing error message when rebot with empty suite results

### DIFF
--- a/src/robot/reporting/resultwriter.py
+++ b/src/robot/reporting/resultwriter.py
@@ -115,10 +115,11 @@ class Results:
                                            *self._sources)
             if self._settings.rpa is None:
                 self._settings.rpa = self._result.rpa
-            modifier = ModelModifier(self._settings.pre_rebot_modifiers,
-                                     self._settings.process_empty_suite,
-                                     LOGGER)
-            self._result.suite.visit(modifier)
+            if self._settings.pre_rebot_modifiers:
+                modifier = ModelModifier(self._settings.pre_rebot_modifiers,
+                                        self._settings.process_empty_suite,
+                                        LOGGER)
+                self._result.suite.visit(modifier)
             self._result.configure(self._settings.status_rc,
                                    self._settings.suite_config,
                                    self._settings.statistics_config)


### PR DESCRIPTION
* empty robot file: `test.robot`
* run `robot --runemptysuite test.robot`
* Got "output.xml"
* run `rebot output.xml`

Before fix:

[ ERROR ] Suite 'Test' contains no tests after model modifiers.

Try --help for usage information.

After fix:
[ ERROR ] Suite 'Test' contains no tests.

Try --help for usage information.

Because user doesn't input any rebot pre run modifiers, the error message ` Suite 'Test' contains no tests after model modifiers.` is very confusing, and the pre run modifier should not be called as well.