### PR TITLE
Expand Button Displays + Sign for Failed or Skipped Tests in Report - log.html

### DIFF
--- a/src/robot/htmldata/rebot/log.js
+++ b/src/robot/htmldata/rebot/log.js
@@ -7,9 +7,6 @@ function toggleSuite(suiteId) {
 function toggleTest(testId) {
     toggleElement(testId, ['keyword']);
     var test = window.testdata.findLoaded(testId);
-    if (test.status == "FAIL" || test.status == "SKIP")
-        expandFailed(test);
-}
 
 function toggleKeyword(kwId) {
     toggleElement(kwId, ['keyword']);


### PR DESCRIPTION
**Description of Fix:**
- Ensures the expand button toggles correctly between `+` and `-` for failed and skipped tests in the log.html report.  
