### PR TITLE
Fix `Lists should be equal` with `ignore_case` and `ignore_order`

### DIFF
--- a/atest/robot/standard_libraries/collections/list.robot
+++ b/atest/robot/standard_libraries/collections/list.robot
@@ -353,3 +353,6 @@ List Should Not Contain Duplicates With Ignore Case
 
 List Should Contain Value With Ignore Case And Nested List and Dictionary
     Check Test Case    ${TEST NAME}
+
+Lists Should be equal with Ignore Case and Order
+    Check Test Case    ${TEST NAME}

--- a/atest/testdata/standard_libraries/collections/list.robot
+++ b/atest/testdata/standard_libraries/collections/list.robot
@@ -672,6 +672,12 @@ List Should Not Contain Duplicates With Ignore Case
 List Should Contain Value With Ignore Case And Nested List and Dictionary
     [Setup]    Create Lists For Testing Ignore Case
     List Should Contain Value  ${L4}  value=d    ignore_case=${True}
+    
+Lists Should be equal with Ignore Case and Order
+    [Setup]    Create Lists For Testing Ignore Case
+    [Template]    Lists Should Be Equal
+    list1=${L7}    list2=${L8}    ignore_order=${True}    ignore_case=${True}
+    list1=${L9}    list2=${L10}    ignore_order=${True}    ignore_case=${True}
 
 *** Keywords ***
 Validate invalid argument error
@@ -749,3 +755,11 @@ Create Lists For Testing Ignore Case
     Set Test Variable    \${L5}
     ${L6}    Create List    ${L1}    d    D    3   ${D1}
     Set Test Variable    \${L6}
+    ${L7}    Create List    apple    Banana    cherry
+    Set Test Variable    \${L7}
+    ${L8}    Create List    BANANA    cherry    APPLE
+    Set Test Variable    \${L8}
+    ${L9}    Create List    zebra!    ${EMPTY}    Elephant<    "Dog"    "Dog"
+    Set Test Variable    \${L9}
+    ${L10}    Create List    "dog"    ZEBRA!    "Dog"    elephant<    ${EMPTY}
+    Set Test Variable    \${L10}

--- a/src/robot/libraries/Collections.py
+++ b/src/robot/libraries/Collections.py
@@ -1178,9 +1178,9 @@ class Normalizer:
 
     def normalize_list(self, value):
         cls = type(value)
+        value = [self.normalize(v) for v in value]
         if self.ignore_order:
             value = sorted(value)
-        value = [self.normalize(v) for v in value]
         return self._try_to_preserve_type(value, cls)
 
     def _try_to_preserve_type(self, value, cls):


### PR DESCRIPTION
Fixes #5321 
Moved the step to normalize the case before sorting the list.
