### PR TITLE
add arabic

### DIFF
--- a/src/robot/conf/languages.py
+++ b/src/robot/conf/languages.py
@@ -1356,3 +1356,48 @@ class Ko(Language):
     but_prefixes = ['하지만']
     true_strings = ['참', '네', '켜기']
     false_strings = ['거짓', '아니오', '끄기']
+
+
+class Ar(Language):
+    """Arabic
+
+    New in Robot Framework 7.3.
+    """
+    settings_header = 'الإعدادات'
+    variables_header = 'المتغيرات'
+    test_cases_header = 'وضعيات الاختبار'
+    tasks_header = 'المهام'
+    keywords_header = 'الأوامر'
+    comments_header = 'التعليقات'
+    library_setting = 'المكتبة'
+    resource_setting = 'المورد'
+    variables_setting = 'المتغيرات'
+    name_setting = 'الاسم'
+    documentation_setting = 'التوثيق'
+    metadata_setting = 'البيانات الوصفية'
+    suite_setup_setting = 'إعداد المجموعة'
+    suite_teardown_setting = 'تفكيك المجموعة'
+    test_setup_setting = 'تهيئة الاختبار'
+    task_setup_setting = 'تهيئة المهمة'
+    test_teardown_setting = 'تفكيك الاختبار'
+    task_teardown_setting = 'تفكيك المهمة'
+    test_template_setting = 'قالب الاختبار'
+    task_template_setting = 'قالب المهمة'
+    test_timeout_setting = 'مهلة الاختبار'
+    task_timeout_setting = 'مهلة المهمة'
+    test_tags_setting = 'علامات الاختبار'
+    task_tags_setting = 'علامات المهمة'
+    keyword_tags_setting = 'علامات الأوامر'
+    setup_setting = 'إعداد'
+    teardown_setting = 'تفكيك'
+    template_setting = 'قالب'
+    tags_setting = 'العلامات'
+    timeout_setting = 'المهلة الزمنية'
+    arguments_setting = 'المعطيات'
+    given_prefixes = ['بافتراض']
+    when_prefixes = ['عندما', 'لما']
+    then_prefixes = ['إذن', 'عندها']
+    and_prefixes = ['و']
+    but_prefixes = ['لكن']
+    true_strings = ['نعم', 'صحيح']
+    false_strings = ['لا', 'خطأ']


### PR DESCRIPTION
This how it looks like on the vscode and on the logs

![image](https://github.com/user-attachments/assets/b5284f93-489e-4e82-a2a7-c719c0b74399)
![image](https://github.com/user-attachments/assets/3ffcc2d4-eb5e-46ec-a495-7ce9f7a63d51)


I believe that it can be good first step for supporting RTL languages . It's current state is already understandable and common sense display ( since that mixing RTL and LTR is common behavior already for RTL speakers )

further support could be adding RTL ability in the HTML logs and reports