### PR TITLE
Mention logging with ERROR level when using --exitonerror

### DIFF
--- a/doc/userguide/src/ExecutingTestCases/TestExecution.rst
+++ b/doc/userguide/src/ExecutingTestCases/TestExecution.rst
@@ -692,6 +692,11 @@ fatal and execution stopped so that remaining tests are marked failed. With
 parsing errors encountered before execution even starts, this means that no
 tests are actually run.
 
+When this option is enabled, using `ERROR` level in logs, such as `Log` keyword
+from BuiltIn or Python's standard logging module, will also fail the execution.
+Additionally, the TRY/EXCEPT stucture does not catch log messages with `ERROR`
+level, even when :option:`--exitonerror` is used.
+
 __ `Errors and warnings during execution`_
 
 Handling teardowns


### PR DESCRIPTION
Seems like this is not mentioned anywhere else. I scratched my head on it for a while.

It appears that the term "ERROR" is used for different purpose in TRY/EXCEPT (i.e. exception or failure) or logging (i.e. level).
Maybe it would be valuable to also mention it in the TRY/EXCEPT section :

```rst
.. note:: TRY/EXCEPT do not catch "ERROR" level logs, therefore they will not prevent exiting when :option:`--exitonerror` is used.
```