### PR TITLE
Fix expand icons for failed and skipped tests (#5322)

### DIFF
--- a/src/robot/htmldata/rebot/log.js
+++ b/src/robot/htmldata/rebot/log.js
@@ -5,10 +5,15 @@ function toggleSuite(suiteId) {
 }
 
 function toggleTest(testId) {
-    toggleElement(testId, ['keyword']);
     var test = window.testdata.findLoaded(testId);
-    if (test.status == "FAIL" || test.status == "SKIP")
+    var autoExpand = test.status == "FAIL" || test.status == "SKIP";
+    var closed = $('#' + testId).children('.element-header').hasClass('closed');
+
+    if (autoExpand)
         expandFailed(test);
+
+    if (!autoExpand || !closed)
+        toggleElement(testId, ['keyword']);
 }
 
 function toggleKeyword(kwId) {


### PR DESCRIPTION
Fixes an issue with log where expand icon of failed and skipped tests got stuck as `+` while toggling tests.
This was caused by expandFailed first removing the `closed` class from failed/skipped tests, only to be immediately re-inserted by toggleElement.

Now toggleElement is called only if test is not expanded with expandFailed (status != skip/fail), or the test element is currently not closed. In the latter case expandFailed does not affect the toggle, as it only removes `closed` class if it exists.

https://github.com/user-attachments/assets/b5f2c70b-5d55-445c-b3f6-b6a9c41cffbf
