### PR TITLE
Support not printing errors and warnings to console

### DIFF
--- a/src/robot/api/logger.py
+++ b/src/robot/api/logger.py
@@ -74,7 +74,12 @@ from robot.running.context import EXECUTION_CONTEXTS
 LOGLEVEL = Literal["TRACE", "DEBUG", "INFO", "CONSOLE", "HTML", "WARN", "ERROR"]
 
 
-def write(msg: str, level: LOGLEVEL = "INFO", html: bool = False):
+def write(
+    msg: str,
+    level: LOGLEVEL = "INFO",
+    html: bool = False,
+    also_console: bool | None = None,
+):
     """Writes the message to the log file using the given level.
 
     Valid log levels are ``TRACE``, ``DEBUG``, ``INFO`` (default), ``WARN``,
@@ -88,8 +93,11 @@ def write(msg: str, level: LOGLEVEL = "INFO", html: bool = False):
     specific methods such as ``info`` and ``debug`` that have separate
     ``html`` argument to control the message format.
     """
+    if also_console is None:
+        also_console = level in ("WARN", "ERROR")
+
     if EXECUTION_CONTEXTS.current is not None:
-        librarylogger.write(msg, level, html)
+        librarylogger.write(msg, level, html, also_console)
     else:
         logger = logging.getLogger("RobotFramework")
         level_int = {
@@ -120,19 +128,17 @@ def info(msg: str, html: bool = False, also_console: bool = False):
     If ``also_console`` argument is set to ``True``, the message is
     written both to the log file and to the console.
     """
-    write(msg, "INFO", html)
-    if also_console:
-        console(msg)
+    write(msg, "INFO", html, also_console)
 
 
-def warn(msg: str, html: bool = False):
+def warn(msg: str, html: bool = False, also_console: bool = True):
     """Writes the message to the log file using the ``WARN`` level."""
-    write(msg, "WARN", html)
+    write(msg, "WARN", html, also_console)
 
 
-def error(msg: str, html: bool = False):
+def error(msg: str, html: bool = False, also_console: bool = True):
     """Writes the message to the log file using the ``ERROR`` level."""
-    write(msg, "ERROR", html)
+    write(msg, "ERROR", html, also_console)
 
 
 def console(

--- a/src/robot/model/message.py
+++ b/src/robot/model/message.py
@@ -32,7 +32,7 @@ class Message(BodyItem):
 
     type = BodyItem.MESSAGE
     repr_args = ("message", "level")
-    __slots__ = ("message", "level", "html", "_timestamp")
+    __slots__ = ("message", "level", "html", "also_console", "_timestamp")
 
     def __init__(
         self,
@@ -40,12 +40,14 @@ class Message(BodyItem):
         level: MessageLevel = "INFO",
         html: bool = False,
         timestamp: "datetime|str|None" = None,
+        also_console: bool = False,
         parent: "BodyItem|None" = None,
     ):
         self.message = message
         self.level = level
         self.html = html
         self.timestamp = timestamp
+        self.also_console = also_console
         self.parent = parent
 
     @setter

--- a/src/robot/output/console/dotted.py
+++ b/src/robot/output/console/dotted.py
@@ -62,7 +62,7 @@ class DottedOutput(LoggerApi):
             self.stdout.write("\n")
 
     def message(self, msg):
-        if msg.level in ("WARN", "ERROR"):
+        if msg.also_console:
             self.stderr.error(msg.message, msg.level)
 
     def result_file(self, kind, path):

--- a/src/robot/output/console/highlighting.py
+++ b/src/robot/output/console/highlighting.py
@@ -124,8 +124,9 @@ class HighlightingStream:
             "ERROR": highlighter.red,
             "WARN": highlighter.yellow,
             "SKIP": highlighter.yellow,
-        }[status]
-        start()
+        }.get(status)
+        if start:
+            start()
         try:
             yield
         finally:

--- a/src/robot/output/console/quiet.py
+++ b/src/robot/output/console/quiet.py
@@ -25,7 +25,7 @@ class QuietOutput(LoggerApi):
         self._stderr = HighlightingStream(stderr or sys.__stderr__, colors)
 
     def message(self, msg):
-        if msg.level in ("WARN", "ERROR"):
+        if msg.also_console:
             self._stderr.error(msg.message, msg.level)
 
 

--- a/src/robot/output/console/verbose.py
+++ b/src/robot/output/console/verbose.py
@@ -70,7 +70,7 @@ class VerboseOutput(LoggerApi):
             self.writer.keyword_marker(result.status)
 
     def message(self, msg):
-        if msg.level in ("WARN", "ERROR"):
+        if msg.also_console:
             self.writer.error(msg.message, msg.level, clear=self.running_test)
 
     def result_file(self, kind, path):

--- a/src/robot/output/librarylogger.py
+++ b/src/robot/output/librarylogger.py
@@ -32,7 +32,7 @@ from .loggerhelper import Message, write_to_console
 LOGGING_THREADS = ["MainThread", "RobotFrameworkTimeoutThread"]
 
 
-def write(msg: Any, level: str, html: bool = False):
+def write(msg: Any, level: str, html: bool = False, also_console: bool = False):
     if not isinstance(msg, str):
         msg = safe_str(msg)
     if level.upper() not in ("TRACE", "DEBUG", "INFO", "HTML", "WARN", "ERROR"):
@@ -42,7 +42,7 @@ def write(msg: Any, level: str, html: bool = False):
         else:
             raise RuntimeError(f"Invalid log level '{level}'.")
     if current_thread().name in LOGGING_THREADS:
-        LOGGER.log_message(Message(msg, level, html))
+        LOGGER.log_message(Message(msg, level, html, also_console=also_console))
 
 
 def trace(msg, html=False):

--- a/src/robot/output/logger.py
+++ b/src/robot/output/logger.py
@@ -208,7 +208,7 @@ class Logger(AbstractLogger):
             logger.log_message(msg)
         if self._log_message_parents and self._output_file.is_logged(msg):
             self._log_message_parents[-1].body.append(msg)
-        if msg.level in ("WARN", "ERROR"):
+        if msg.also_console or msg.level in ("WARN", "ERROR"):
             self.message(msg)
 
     def log_output(self, output):

--- a/src/robot/output/loggerhelper.py
+++ b/src/robot/output/loggerhelper.py
@@ -98,9 +98,12 @@ class Message(BaseMessage):
         level: "MessageLevel|PseudoLevel" = "INFO",
         html: bool = False,
         timestamp: "datetime|str|None" = None,
+        also_console: bool = False,
     ):
         level, html = self._get_level_and_html(level, html)
-        super().__init__(message, level, html, timestamp or datetime.now())
+        super().__init__(
+            message, level, html, timestamp or datetime.now(), also_console
+        )
 
     def _get_level_and_html(self, level, html) -> "tuple[MessageLevel, bool]":
         level = level.upper()


### PR DESCRIPTION
There are use cases for printing a warning or error message to the log but not to the console.

This PR adds an optional `also_console` argument to `logger.write`, `logger.warn`, and `logger.error`. Its value is stored in the message object and based on it the loggers in `src/robot/output/console/` print the message or not.