### PR TITLE
Visualization of the robotframework

### DIFF
--- a/.codeboarding/Execution_Core.md
+++ b/.codeboarding/Execution_Core.md
@@ -1,0 +1,291 @@
+```mermaid
+
+graph LR
+
+    SuiteRunner["SuiteRunner"]
+
+    BodyRunner["BodyRunner"]
+
+    Namespace["Namespace"]
+
+    VariableManager["VariableManager"]
+
+    ArgumentHandler["ArgumentHandler"]
+
+    KeywordRunner["KeywordRunner"]
+
+    TestLibraries["TestLibraries"]
+
+    BuiltInLibraries["BuiltInLibraries"]
+
+    StatusReporter["StatusReporter"]
+
+    TimeoutHandler["TimeoutHandler"]
+
+    SuiteRunner -- "orchestrates" --> BodyRunner
+
+    SuiteRunner -- "utilizes" --> Namespace
+
+    SuiteRunner -- "interacts with" --> StatusReporter
+
+    BodyRunner -- "delegates to" --> KeywordRunner
+
+    BodyRunner -- "relies on" --> Namespace
+
+    BodyRunner -- "uses" --> ArgumentHandler
+
+    Namespace -- "interacts with" --> VariableManager
+
+    Namespace -- "interacts with" --> TestLibraries
+
+    VariableManager -- "provides services to" --> Namespace
+
+    VariableManager -- "provides services to" --> ArgumentHandler
+
+    KeywordRunner -- "uses" --> ArgumentHandler
+
+    KeywordRunner -- "interacts with" --> Namespace
+
+    TestLibraries -- "populates" --> Namespace
+
+    KeywordRunner -- "invokes implementations from" --> BuiltInLibraries
+
+    TimeoutHandler -- "interacts with" --> BodyRunner
+
+    TimeoutHandler -- "interacts with" --> KeywordRunner
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+One paragraph explaining the functionality which is represented by this graph. What the main flow is and what is its purpose.
+
+
+
+### SuiteRunner
+
+The top-level orchestrator for running test suites. It manages the overall execution lifecycle of a suite, including setup, teardown, and the sequential execution of its test cases and child suites. It delegates the actual execution of test bodies and keywords to other components.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/running/suiterunner.py#L35-L298" target="_blank" rel="noopener noreferrer">`robot.running.suiterunner.SuiteRunner` (35:298)</a>
+
+
+
+
+
+### BodyRunner
+
+Responsible for executing the "body" of a test case or a keyword, which consists of a sequence of other keywords. It iterates through these keywords, handles their execution, and manages their individual status and potential failures.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/running/bodyrunner.py#L39-L72" target="_blank" rel="noopener noreferrer">`robot.running.bodyrunner.BodyRunner` (39:72)</a>
+
+
+
+
+
+### Namespace
+
+Manages the dynamic execution context. This includes tracking the current variable scopes (global, suite, test, local), providing access to imported libraries, and resolving keywords. It acts as a central registry for runtime information, enabling dynamic keyword resolution and variable access.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/running/namespace.py#L33-L228" target="_blank" rel="noopener noreferrer">`robot.running.namespace.Namespace` (33:228)</a>
+
+
+
+
+
+### VariableManager
+
+A comprehensive system for handling all aspects of variables during test execution. This includes managing variable scopes, replacing variables in strings, and searching for variable values. It ensures dynamic data handling and resolution within tests.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/variables/scopes.py#L0-L0" target="_blank" rel="noopener noreferrer">`robot.variables.scopes` (0:0)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/variables/replacer.py#L0-L0" target="_blank" rel="noopener noreferrer">`robot.variables.replacer` (0:0)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/variables/search.py#L0-L0" target="_blank" rel="noopener noreferrer">`robot.variables.search` (0:0)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/variables/store.py#L0-L0" target="_blank" rel="noopener noreferrer">`robot.variables.store` (0:0)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/variables/finders.py#L0-L0" target="_blank" rel="noopener noreferrer">`robot.variables.finders` (0:0)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/variables/evaluation.py#L0-L0" target="_blank" rel="noopener noreferrer">`robot.variables.evaluation` (0:0)</a>
+
+
+
+
+
+### ArgumentHandler
+
+Responsible for parsing, resolving, converting, and validating arguments passed to keywords. It handles different argument types, default values, and type conversions to ensure keywords receive arguments in the correct format, supporting robust keyword invocation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/running/arguments/argumentparser.py#L0-L0" target="_blank" rel="noopener noreferrer">`robot.running.arguments.argumentparser` (0:0)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/running/arguments/argumentresolver.py#L0-L0" target="_blank" rel="noopener noreferrer">`robot.running.arguments.argumentresolver` (0:0)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/running/arguments/argumentconverter.py#L0-L0" target="_blank" rel="noopener noreferrer">`robot.running.arguments.argumentconverter` (0:0)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/running/arguments/argumentvalidator.py#L0-L0" target="_blank" rel="noopener noreferrer">`robot.running.arguments.argumentvalidator` (0:0)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/running/arguments/typeconverters.py#L0-L0" target="_blank" rel="noopener noreferrer">`robot.running.arguments.typeconverters` (0:0)</a>
+
+
+
+
+
+### KeywordRunner
+
+Represents the mechanism for dispatching and executing individual keywords. This component determines whether a keyword is a user-defined keyword or a library keyword and delegates to the appropriate concrete runner (`UserKeywordRunner` or `LibraryKeywordRunner`).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `robot.running.keywordrunner.UserKeywordRunner` (0:0)
+
+- `robot.running.keywordrunner.LibraryKeywordRunner` (0:0)
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/running/keywordimplementation.py#L0-L0" target="_blank" rel="noopener noreferrer">`robot.running.keywordimplementation` (0:0)</a>
+
+
+
+
+
+### TestLibraries
+
+Manages the loading, importing, and access to test libraries (both built-in and external). It ensures that library keywords are available for execution and handles dynamic library loading and keyword discovery.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/running/testlibraries.py#L0-L0" target="_blank" rel="noopener noreferrer">`robot.running.testlibraries.TestLibraries` (0:0)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/running/testlibraries.py#L0-L0" target="_blank" rel="noopener noreferrer">`robot.running.testlibraries.Importer` (0:0)</a>
+
+
+
+
+
+### BuiltInLibraries
+
+Provides a collection of fundamental keywords that are always available in Robot Framework. These libraries perform common operations like logging, variable manipulation, and flow control, forming the basic building blocks for tests.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/libraries/BuiltIn.py#L4091-L4369" target="_blank" rel="noopener noreferrer">`robot.libraries.BuiltIn` (4091:4369)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/libraries/Collections.py#L987-L1261" target="_blank" rel="noopener noreferrer">`robot.libraries.Collections` (987:1261)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/libraries/OperatingSystem.py#L39-L1449" target="_blank" rel="noopener noreferrer">`robot.libraries.OperatingSystem` (39:1449)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/libraries/Process.py#L35-L906" target="_blank" rel="noopener noreferrer">`robot.libraries.Process` (35:906)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/libraries/XML.py#L45-L1458" target="_blank" rel="noopener noreferrer">`robot.libraries.XML` (45:1458)</a>
+
+
+
+
+
+### StatusReporter
+
+Tracks and reports the real-time status and outcomes of test execution steps, including suites, tests, and keywords. It provides updates to listeners and other output components, ensuring that the progress and results of the execution are communicated.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/running/statusreporter.py#L24-L105" target="_blank" rel="noopener noreferrer">`robot.running.statusreporter.StatusReporter` (24:105)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/running/status.py#L0-L0" target="_blank" rel="noopener noreferrer">`robot.running.status` (0:0)</a>
+
+
+
+
+
+### TimeoutHandler
+
+Manages and enforces timeouts for test cases and keywords, ensuring that execution does not exceed predefined time limits and preventing tests from hanging indefinitely.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `robot.running.timeout.Timeout` (0:0)
+
+- `robot.running.timeout.Runner` (0:0)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Test_Data_Management.md
+++ b/.codeboarding/Test_Data_Management.md
@@ -1,0 +1,101 @@
+```mermaid
+
+graph LR
+
+    Parsing_Engine["Parsing Engine"]
+
+    Test_Data_Model["Test Data Model"]
+
+    Test_Execution_Results_Model["Test Execution Results Model"]
+
+    Parsing_Engine -- "produces" --> Test_Data_Model
+
+    Test_Data_Model -- "is consumed by" --> Test_Execution_Results_Model
+
+    Test_Execution_Results_Model -- "is derived from" --> Test_Data_Model
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The `Test Data Management` component is fundamental to Robot Framework, serving as the central hub for representing and processing all test-related information. It is comprised of three core sub-components: the `Parsing Engine`, the `Test Data Model`, and the `Test Execution Results Model`. These components work in concert to transform raw test specifications into executable structures and, subsequently, to capture and store the outcomes of test runs.
+
+
+
+### Parsing Engine
+
+This component is the initial entry point for test data. It is responsible for reading raw Robot Framework test files (e.g., `.robot`, `.resource`) and converting their content into a structured, in-memory representation. This process involves lexical analysis (tokenizing the input) and syntactic analysis (building the hierarchical test suite structure). It acts as the bridge between the plain text test definitions and the internal object model.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/parsing/parser/parser.py#L26-L59" target="_blank" rel="noopener noreferrer">`src.robot.parsing.parser.parser:get_model` (26:59)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/parsing/lexer/lexer.py#L96-L208" target="_blank" rel="noopener noreferrer">`src.robot.parsing.lexer.lexer.Lexer` (96:208)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/parsing/suitestructure.py#L115-L185" target="_blank" rel="noopener noreferrer">`src.robot.parsing.suitestructure.SuiteStructureBuilder` (115:185)</a>
+
+
+
+
+
+### Test Data Model
+
+This component defines the canonical in-memory object model for representing Robot Framework test specifications *before* execution. It provides a structured, programmatic interface to test suites, individual test cases, and keywords, including their settings, arguments, and body content. This model is the direct output of the `Parsing Engine` and serves as the input for the test execution phase.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/model/testsuite.py#L38-L482" target="_blank" rel="noopener noreferrer">`src.robot.model.testsuite.TestSuite` (38:482)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/model/testcase.py#L36-L218" target="_blank" rel="noopener noreferrer">`src.robot.model.testcase.TestCase` (36:218)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/model/keyword.py#L25-L73" target="_blank" rel="noopener noreferrer">`src.robot.model.keyword.Keyword` (25:73)</a>
+
+
+
+
+
+### Test Execution Results Model
+
+This component extends the `Test Data Model` by incorporating execution-specific information. It defines the data structures used to store the detailed outcomes of a test run, including execution status (pass/fail), error messages, timestamps, and statistics for suites, test cases, and keywords. This model is populated during test execution and is crucial for generating reports and logs.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/result/model.py#L1051-L1317" target="_blank" rel="noopener noreferrer">`src.robot.result.model.TestSuite` (1051:1317)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/result/model.py#L1002-L1048" target="_blank" rel="noopener noreferrer">`src.robot.result.model.TestCase` (1002:1048)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/result/model.py#L788-L999" target="_blank" rel="noopener noreferrer">`src.robot.result.model.Keyword` (788:999)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/User_Interface_Configuration.md
+++ b/.codeboarding/User_Interface_Configuration.md
@@ -1,0 +1,207 @@
+```mermaid
+
+graph LR
+
+    Command_Line_Interface_CLI_Entry_Points["Command-Line Interface (CLI) Entry Points"]
+
+    Robot_Framework_Core_Settings_Management["Robot Framework Core Settings Management"]
+
+    Rebot_Tool_Settings_Management["Rebot Tool Settings Management"]
+
+    Test_Data_Suite_Configuration["Test Data & Suite Configuration"]
+
+    Output_Logging_Configuration["Output & Logging Configuration"]
+
+    Failed_Test_Data_Collection["Failed Test Data Collection"]
+
+    Core_Configuration_Utilities["Core Configuration Utilities"]
+
+    Command_Line_Interface_CLI_Entry_Points -- "Initializes" --> Robot_Framework_Core_Settings_Management
+
+    Command_Line_Interface_CLI_Entry_Points -- "Initializes" --> Rebot_Tool_Settings_Management
+
+    Robot_Framework_Core_Settings_Management -- "Configures" --> Test_Data_Suite_Configuration
+
+    Robot_Framework_Core_Settings_Management -- "Configures" --> Output_Logging_Configuration
+
+    Robot_Framework_Core_Settings_Management -- "Utilizes" --> Failed_Test_Data_Collection
+
+    Robot_Framework_Core_Settings_Management -- "Utilizes" --> Core_Configuration_Utilities
+
+    Rebot_Tool_Settings_Management -- "Utilizes" --> Core_Configuration_Utilities
+
+    Failed_Test_Data_Collection -- "Provides data to" --> Robot_Framework_Core_Settings_Management
+
+    Core_Configuration_Utilities -- "Supports" --> Robot_Framework_Core_Settings_Management
+
+    Core_Configuration_Utilities -- "Supports" --> Rebot_Tool_Settings_Management
+
+    Test_Data_Suite_Configuration -- "Receives configuration from" --> Robot_Framework_Core_Settings_Management
+
+    Output_Logging_Configuration -- "Receives configuration from" --> Robot_Framework_Core_Settings_Management
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This subsystem serves as the primary interface for users to interact with Robot Framework, handling command-line input, managing all framework-level and execution-specific settings, and orchestrating the initial setup of the test automation flow. It acts as the control center, translating user commands and configurations into the necessary internal processes.
+
+
+
+### Command-Line Interface (CLI) Entry Points
+
+This component serves as the primary user-facing interface for all Robot Framework tools. It is responsible for parsing command-line arguments provided by the user and initiating the appropriate execution flow for specific tools such as `robot` (for test execution), `rebot` (for post-processing outputs), `libdoc` (for library documentation), and `testdoc` (for test documentation).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `RobotFramework:main` (0:0)
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/rebot.py#L345-L361" target="_blank" rel="noopener noreferrer">`Rebot:main` (345:361)</a>
+
+- `LibDoc:main` (0:0)
+
+- `TestDoc:main` (0:0)
+
+
+
+
+
+### Robot Framework Core Settings Management
+
+This central component is responsible for parsing, validating, storing, and providing all configuration settings relevant to the primary Robot Framework test execution. It consolidates user-defined options (from command-line arguments, configuration files, etc.) and makes them accessible to other parts of the framework, covering aspects like input sources, output paths, logging levels, and test selection criteria.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `RobotSettings` (0:0)
+
+
+
+
+
+### Rebot Tool Settings Management
+
+A specialized component dedicated to managing configuration settings specifically for the `rebot` tool. It handles options related to post-processing Robot Framework XML output files, such as generating reports and logs, customizing their titles and appearance, and merging multiple output files.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `RebotSettings` (0:0)
+
+
+
+
+
+### Test Data & Suite Configuration
+
+This component is responsible for interpreting and applying user-defined configurations related to test data sources and the structure of the test suite. It includes building the executable test suite from various inputs (e.g., test files, directories) and applying pre-run modifications such as including/excluding tests or modifying the test model based on user settings.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `TestSuiteBuilder` (0:0)
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/atest/robot/cli/model_modifiers/ModelModifier.py#L5-L80" target="_blank" rel="noopener noreferrer">`ModelModifier` (5:80)</a>
+
+
+
+
+
+### Output & Logging Configuration
+
+Manages the configuration and generation of various output artifacts from a test run, including detailed log files, human-readable reports, and xUnit-compatible outputs. It ensures that test results are captured, formatted, and persisted according to user preferences for analysis and integration.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `ResultWriter` (0:0)
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/output/pyloggingconf.py#L0-L0" target="_blank" rel="noopener noreferrer">`pyloggingconf` (0:0)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/api/logger.py#L0-L0" target="_blank" rel="noopener noreferrer">`logger` (0:0)</a>
+
+
+
+
+
+### Failed Test Data Collection
+
+This component is responsible for identifying and gathering information about tests or suites that failed in a previous Robot Framework execution. The collected data is then utilized by the `Robot Framework Core Settings Management` component to support features like `--rerunfailed`, enabling efficient re-execution of only problematic tests.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `gather_failed_tests` (0:0)
+
+- `gather_failed_suites` (0:0)
+
+
+
+
+
+### Core Configuration Utilities
+
+Provides a set of low-level, general-purpose utility functions that support various aspects of configuration processing, data manipulation, and text handling across the `User Interface & Configuration` subsystem. These include functions for path manipulation, escaping special characters, and managing text formatting limits.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/utils/escaping.py#L0-L0" target="_blank" rel="noopener noreferrer">`escaping` (0:0)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/utils/markuputils.py#L0-L0" target="_blank" rel="noopener noreferrer">`markuputils` (0:0)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/utils/robotpath.py#L0-L0" target="_blank" rel="noopener noreferrer">`robotpath` (0:0)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/utils/text.py#L0-L0" target="_blank" rel="noopener noreferrer">`text` (0:0)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,183 @@
+```mermaid
+
+graph LR
+
+    User_Interface_Configuration["User Interface & Configuration"]
+
+    Test_Data_Management["Test Data Management"]
+
+    Execution_Core["Execution Core"]
+
+    Reporting_Output["Reporting & Output"]
+
+    User_Interface_Configuration -- "Initializes & Configures" --> Test_Data_Management
+
+    User_Interface_Configuration -- "Initiates & Configures" --> Execution_Core
+
+    User_Interface_Configuration -- "Directs & Configures" --> Reporting_Output
+
+    Test_Data_Management -- "Provides Structured Test Data to" --> Execution_Core
+
+    Test_Data_Management -- "Provides Execution Results to" --> Reporting_Output
+
+    Execution_Core -- "Updates with Execution Results" --> Test_Data_Management
+
+    Execution_Core -- "Sends Real-time Events & Logs to" --> Reporting_Output
+
+    click User_Interface_Configuration href "https://github.com/robotframework/robotframework/blob/master/.codeboarding//User_Interface_Configuration.md" "Details"
+
+    click Test_Data_Management href "https://github.com/robotframework/robotframework/blob/master/.codeboarding//Test_Data_Management.md" "Details"
+
+    click Execution_Core href "https://github.com/robotframework/robotframework/blob/master/.codeboarding//Execution_Core.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The architecture of Robot Framework can be effectively summarized by four fundamental components, each representing a distinct phase or responsibility within the test automation lifecycle. These components are chosen for their critical roles in processing, executing, and reporting, and for their ability to encapsulate related functionalities identified in the CFG and Source Analysis.
+
+
+
+### User Interface & Configuration
+
+This component serves as the primary entry point for all Robot Framework functionalities. It is responsible for parsing command-line arguments, loading and managing all framework-level and execution-specific settings, and orchestrating the overall test automation flow based on user input. It acts as the control center, initiating and configuring subsequent processes.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/run.py#L450-L499" target="_blank" rel="noopener noreferrer">`src.robot.run.RobotFramework:main` (450:499)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/rebot.py#L345-L361" target="_blank" rel="noopener noreferrer">`src.robot.rebot.Rebot:main` (345:361)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/libdoc.py#L184-L221" target="_blank" rel="noopener noreferrer">`src.robot.libdoc.LibDoc:main` (184:221)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/testdoc.py#L118-L122" target="_blank" rel="noopener noreferrer">`src.robot.testdoc.TestDoc:main` (118:122)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/conf/settings.py#L493-L714" target="_blank" rel="noopener noreferrer">`src.robot.conf.settings.RobotSettings` (493:714)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/conf/settings.py#L717-L799" target="_blank" rel="noopener noreferrer">`src.robot.conf.settings.RebotSettings` (717:799)</a>
+
+
+
+
+
+### Test Data Management
+
+This component is the backbone for representing and processing test information. It encompasses the parsing engine that converts raw Robot Framework test files (e.g., `.robot`, `.resource`) into an internal, structured object model (suites, test cases, keywords). It also defines and holds the detailed results of test execution, making it the central data structure that flows through the entire framework.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/model/testsuite.py#L38-L482" target="_blank" rel="noopener noreferrer">`src.robot.model.testsuite.TestSuite` (38:482)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/model/testcase.py#L36-L218" target="_blank" rel="noopener noreferrer">`src.robot.model.testcase.TestCase` (36:218)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/model/keyword.py#L25-L73" target="_blank" rel="noopener noreferrer">`src.robot.model.keyword.Keyword` (25:73)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/result/model.py#L1051-L1317" target="_blank" rel="noopener noreferrer">`src.robot.result.model.TestSuite` (1051:1317)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/result/model.py#L1002-L1048" target="_blank" rel="noopener noreferrer">`src.robot.result.model.TestCase` (1002:1048)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/result/model.py#L788-L999" target="_blank" rel="noopener noreferrer">`src.robot.result.model.Keyword` (788:999)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/parsing/parser/parser.py#L26-L59" target="_blank" rel="noopener noreferrer">`src.robot.parsing.parser.parser:get_model` (26:59)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/parsing/lexer/lexer.py#L96-L208" target="_blank" rel="noopener noreferrer">`src.robot.parsing.lexer.lexer.Lexer` (96:208)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/parsing/suitestructure.py#L115-L185" target="_blank" rel="noopener noreferrer">`src.robot.parsing.suitestructure.SuiteStructureBuilder` (115:185)</a>
+
+
+
+
+
+### Execution Core
+
+This is the heart of Robot Framework, responsible for the actual running of test suites, individual test cases, and keywords. It manages the execution flow, handles argument passing, resolves variables dynamically, and dispatches calls to various test libraries (BuiltIn, Collections, OS, etc.) to perform the defined actions. It tracks the real-time status and outcomes of each step.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/running/suiterunner.py#L35-L298" target="_blank" rel="noopener noreferrer">`src.robot.running.suiterunner.SuiteRunner` (35:298)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/running/bodyrunner.py#L39-L72" target="_blank" rel="noopener noreferrer">`src.robot.running.bodyrunner.BodyRunner` (39:72)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/running/namespace.py#L33-L228" target="_blank" rel="noopener noreferrer">`src.robot.running.namespace.Namespace` (33:228)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/variables/scopes.py#L28-L173" target="_blank" rel="noopener noreferrer">`src.robot.variables.scopes.VariableScopes` (28:173)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/variables/replacer.py#L26-L210" target="_blank" rel="noopener noreferrer">`src.robot.variables.replacer.VariableReplacer` (26:210)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/variables/search.py#L22-L30" target="_blank" rel="noopener noreferrer">`src.robot.variables.search:search_variable` (22:30)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/libraries/BuiltIn.py#L4091-L4369" target="_blank" rel="noopener noreferrer">`src.robot.libraries.BuiltIn.BuiltIn` (4091:4369)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/libraries/Collections.py#L987-L1261" target="_blank" rel="noopener noreferrer">`src.robot.libraries.Collections.Collections` (987:1261)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/libraries/OperatingSystem.py#L39-L1449" target="_blank" rel="noopener noreferrer">`src.robot.libraries.OperatingSystem.OperatingSystem` (39:1449)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/libraries/Process.py#L35-L906" target="_blank" rel="noopener noreferrer">`src.robot.libraries.Process.Process` (35:906)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/libraries/XML.py#L45-L1458" target="_blank" rel="noopener noreferrer">`src.robot.libraries.XML.XML` (45:1458)</a>
+
+
+
+
+
+### Reporting & Output
+
+This component handles all forms of output generated by Robot Framework. It includes real-time logging to the console and various log files (XML, plain text), generating comprehensive human-readable HTML logs and reports from the execution result model, and providing an extensible API for external listeners to consume execution events. It also manages the post-processing and combination of raw XML output files (Rebot functionality).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/output/logger.py#L42-L460" target="_blank" rel="noopener noreferrer">`src.robot.output.logger.Logger` (42:460)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/reporting/resultwriter.py#L26-L87" target="_blank" rel="noopener noreferrer">`src.robot.reporting.resultwriter.ResultWriter` (26:87)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/reporting/jsmodelbuilders.py#L46-L73" target="_blank" rel="noopener noreferrer">`src.robot.reporting.jsmodelbuilders.JsModelBuilder` (46:73)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/rebot.py#L345-L361" target="_blank" rel="noopener noreferrer">`src.robot.rebot.Rebot:main` (345:361)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/result/resultbuilder.py#L103-L204" target="_blank" rel="noopener noreferrer">`src.robot.result.resultbuilder.ExecutionResultBuilder` (103:204)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/output/listeners.py#L31-L95" target="_blank" rel="noopener noreferrer">`src.robot.output.listeners.Listeners` (31:95)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/output/listeners.py#L263-L586" target="_blank" rel="noopener noreferrer">`src.robot.output.listeners.ListenerV2Facade` (263:586)</a>
+
+- <a href="https://github.com/robotframework/robotframework/blob/master/src/robot/output/listeners.py#L162-L260" target="_blank" rel="noopener noreferrer">`src.robot.output.listeners.ListenerV3Facade` (162:260)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
Hey, I have generated a diagram representation for the robotframework codebase. You can see how it renders here: 
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/robotframework/on_boarding.md

The idea of these diagrams is to be a codemap for new contributors - giving them high-level representation of the main components and now having context on how to start working on the component that they are interested. Seems like there are lots of people playing with your codebase (2.5k+ forks!).

I saw you have a custom docs generation process, we have introduced a free github action to keep the generations up-to-date, so I'd love to integrate that for you if you like the diagram first documentation!

Full transparency: we’re exploring this idea as a potential startup, but we’re still early and figuring out what’s actually useful to developers.