### PR TITLE
extract untrusted github.head_ref and github.ref_name inputs to environment variables

### DIFF
--- a/.github/workflows/acceptance_tests_cpython.yml
+++ b/.github/workflows/acceptance_tests_cpython.yml
@@ -94,6 +94,7 @@ jobs:
         if: failure()
         env:
           RFLOGS_API_KEY: ${{ secrets.RFLOGS_API_KEY }}
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         working-directory: atest/results
         shell: python
         run: |
@@ -116,7 +117,7 @@ jobs:
                   "--tag", f"workflow:${{ github.workflow }}",
                   "--tag", f"os:${{ runner.os }}",
                   "--tag", f"python-version:${{ matrix.python-version }}",
-                  "--tag", f"branch:${{ github.head_ref || github.ref_name }}",
+                  "--tag", f"branch:{os.environ['BRANCH_NAME']}",
                   result_dir
               ]
 

--- a/.github/workflows/acceptance_tests_cpython_pr.yml
+++ b/.github/workflows/acceptance_tests_cpython_pr.yml
@@ -81,6 +81,7 @@ jobs:
         if: failure()
         env:
           RFLOGS_API_KEY: ${{ secrets.RFLOGS_API_KEY }}
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         working-directory: atest/results
         shell: python
         run: |
@@ -103,7 +104,7 @@ jobs:
                   "--tag", f"workflow:${{ github.workflow }}",
                   "--tag", f"os:${{ runner.os }}",
                   "--tag", f"python-version:${{ matrix.python-version }}",
-                  "--tag", f"branch:${{ github.head_ref || github.ref_name }}",
+                  "--tag", f"branch:{os.environ['BRANCH_NAME']}",
                   result_dir
               ]
 


### PR DESCRIPTION
Hi! GitHub treated `github.head_ref` and `GitHub.ref_name` as [the untrusted inputs](https://securitylab.github.com/resources/github-actions-untrusted-input/). Extracting them to env var will prevent some potential script injection even if `subprocess.check_call` seems could prevent command injection. But don't know whether there exists any unknown injections for it. So I think that extracting will be safer.