### PR TITLE
Fix #5500: event loop cannot re-initialize after finishing a suite

### DIFF
--- a/src/robot/running/context.py
+++ b/src/robot/running/context.py
@@ -35,6 +35,7 @@ class Asynchronous:
     def close_loop(self):
         if self._loop_ref:
             self._loop_ref.close()
+            self._loop_ref = None
 
     def run_until_complete(self, coroutine):
         task = self.event_loop.create_task(coroutine)


### PR DESCRIPTION
This PR fixes #5500

## Issue

After `robot.run()` ends, `close_loop()` is called, closing the active event loop, but not resetting _loop_ref, so when the next call, it cannot reinitialize the event loop again

## Solution
reset _loop_ref to None after closing the loop