### PR TITLE
fix minor error in get_variable_value docstring

### DIFF
--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -1749,7 +1749,7 @@ class _Variables(_BuiltInBase):
         | ${y} =    `Get Variable Value`    $a    ${b}
         | ${z} =    `Get Variable Value`    $z
         =>
-        - ``${x}`` gets value of ``${a}`` if ``${a}`` exists and string ``default`` otherwise
+        - ``${x}`` gets value of ``${a}`` if ``${a}`` exists and string ``example`` otherwise
         - ``${y}`` gets value of ``${a}`` if ``${a}`` exists and value of ``${b}`` otherwise
         - ``${z}`` is set to Python ``None`` if it does not exist previously
         """


### PR DESCRIPTION
Fixing minor docstring error in `BuiltIn.get_variable_value`

don't think it's worth filing an issue for this, @pekkaklarck 