### PR TITLE
Fix: Handle empty string in `_convert_to_index`

### DIFF
--- a/src/robot/libraries/String.py
+++ b/src/robot/libraries/String.py
@@ -820,7 +820,7 @@ class String:
 
     def _convert_to_index(self, value, name):
         if value == "":
-            return 0
+            return None
         if value is None:
             return None
         return self._convert_to_integer(value, name)

--- a/utest/libraries/test_string.py
+++ b/utest/libraries/test_string.py
@@ -1,0 +1,17 @@
+import unittest
+from robot.libraries.String import String
+
+class TestStringLibrary(unittest.TestCase):
+    def setUp(self):
+        self.string_lib = String()
+
+    def test_get_substring_empty_end(self):
+        result = self.string_lib.get_substring("foobar", 1, "")
+        self.assertEqual(result, "oobar")
+
+    def test_split_to_lines_empty_end(self):
+        result = self.string_lib.split_to_lines("foo\nbar\nbaz", 1, "")
+        self.assertEqual(result, ["bar", "baz"])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The `_convert_to_index` helper method in the `String` library incorrectly converted an empty string to `0`, causing slicing operations like `get_substring` and `split_to_lines` to fail when an empty string was used as the `end` index.

This commit changes `_convert_to_index` to return `None` for an empty string, which correctly slices to the end of the sequence.

Added unit tests for `get_substring` and `split_to_lines` to verify the fix.