### PR TITLE
feat: deprecate string usage in Convert To List with warning

### DIFF
--- a/logs/.e0b4d3cecc61067bf318824d38b6444bf2fbbe27-audit.json
+++ b/logs/.e0b4d3cecc61067bf318824d38b6444bf2fbbe27-audit.json
@@ -1,0 +1,15 @@
+{
+    "keep": {
+        "days": true,
+        "amount": 14
+    },
+    "auditLog": "/Users/soulsniper/robotframework/logs/.e0b4d3cecc61067bf318824d38b6444bf2fbbe27-audit.json",
+    "files": [
+        {
+            "date": 1762656359615,
+            "name": "/Users/soulsniper/robotframework/logs/mcp-puppeteer-2025-11-08.log",
+            "hash": "fd7fa9fade75e7b4aaff6aa1c47bc16a40c323abecd2641bb4497f1d27a8aeeb"
+        }
+    ],
+    "hashType": "sha256"
+}

--- a/logs/mcp-puppeteer-2025-11-08.log
+++ b/logs/mcp-puppeteer-2025-11-08.log
@@ -1,0 +1,6 @@
+{"level":"info","message":"Starting MCP server","service":"mcp-puppeteer","timestamp":"2025-11-08 21:45:59.725"}
+{"level":"info","message":"MCP server started successfully","service":"mcp-puppeteer","timestamp":"2025-11-08 21:45:59.727"}
+{"level":"info","message":"Puppeteer MCP Server closing","service":"mcp-puppeteer","timestamp":"2025-11-08 21:50:25.666"}
+{"level":"info","message":"Starting MCP server","service":"mcp-puppeteer","timestamp":"2025-11-08 21:50:30.233"}
+{"level":"info","message":"MCP server started successfully","service":"mcp-puppeteer","timestamp":"2025-11-08 21:50:30.237"}
+{"level":"info","message":"Puppeteer MCP Server closing","service":"mcp-puppeteer","timestamp":"2025-11-08 21:50:35.418"}

--- a/src/robot/libraries/Collections.py
+++ b/src/robot/libraries/Collections.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 
 import copy
+import warnings
 from itertools import chain
 from typing import (
     Any, Iterable, Iterator, Literal, Mapping, MutableMapping, MutableSequence,
@@ -44,6 +45,13 @@ class _List:
         To split strings into characters, the `Split String To Characters` from
         the String Library can be used.
         """
+        if isinstance(item, str):
+            warnings.warn(
+                "Using 'Convert To List' with strings is deprecated. "
+                "Use 'Split String To Characters' from the String library instead.",
+                UserWarning,
+                stacklevel=2,
+            )
         return list(item)  # type: ignore
 
     def append_to_list(self, list_: MutableSequence, *values: object):


### PR DESCRIPTION
## Overview
This PR addresses issue #5538 by deprecating the usage of strings with the `Convert To List` keyword in the Collections library. A deprecation warning is now issued when a string is passed to this keyword, directing users to use `Split String To Characters` from the String library instead.

## Checklist
- [x] Code changes implemented
- [ ] Tests updated (pending)
- [x] Deprecation warning added

## Proof
The changes introduce a deprecation warning when the `Convert To List` keyword receives a string input. This will guide users to use the more appropriate `Split String To Characters` keyword from the String library, improving clarity and preventing potential misuse.

## Closes
#5538