### PR TITLE
Add Robot Framework version display to HTML reports

### DIFF
--- a/src/robot/conf/settings.py
+++ b/src/robot/conf/settings.py
@@ -30,6 +30,7 @@ from robot.utils import (
     abspath, create_destination_directory, escape, get_link_path, html_escape,
     is_list_like, plural_or_not as s, seq2str, split_args_from_name_or_path
 )
+from robot.version import get_full_version
 
 from .gatherfailed import gather_failed_suites, gather_failed_tests
 from .languages import Languages
@@ -756,6 +757,7 @@ class RebotSettings(_BaseSettings):
             "reportURL": self._url_from_path(self.log, self.report),
             "splitLogBase": os.path.basename(os.path.splitext(self.log)[0]),
             "defaultLevel": self["VisibleLogLevel"],
+            "generator": get_full_version("Robot Framework"),
         }
 
     @property
@@ -767,6 +769,7 @@ class RebotSettings(_BaseSettings):
             "title": html_escape(self["ReportTitle"] or ""),
             "logURL": self._url_from_path(self.report, self.log),
             "background": self._resolve_background_colors(),
+            "generator": get_full_version("Robot Framework"),
         }
 
     def _url_from_path(self, source, destination):

--- a/src/robot/htmldata/rebot/common.css
+++ b/src/robot/htmldata/rebot/common.css
@@ -352,3 +352,12 @@ th.stats-col-graph:hover {
 [data-theme="light"] .dark-mode-icon {
     display: block;
 }
+#generator-info {
+    padding: 0.3em 0.5em;
+    font-size: 0.75em;
+    color: var(--text-color);
+    background: var(--highlight-color);
+    opacity: 0.8;
+    text-align: center;
+    word-break: break-word;
+}

--- a/src/robot/htmldata/rebot/view.js
+++ b/src/robot/htmldata/rebot/view.js
@@ -55,6 +55,7 @@ function setTitle(suiteName, type) {
 
 function addHeader() {
     var generated = util.timestamp(window.output.generated);
+    var generator = window.settings.generator || '';
     $.tmpl('<h1>${title}</h1>' +
            '<button id=theme-toggle>' +
              lightModeIcon +
@@ -65,11 +66,13 @@ function addHeader() {
              '<span id="generated-ago">${ago} ago</span>' +
            '</div>' +
            '<div id="top-right-header">' +
+             '{{if generator}}<div id="generator-info">${generator}</div>{{/if}}' +
              '<div id="report-or-log-link"><a href="#"></a></div>' +
            '</div>', {
         generated: util.createGeneratedString(generated),
         ago: util.createGeneratedAgoString(generated),
-        title: document.title
+        title: document.title,
+        generator: generator
     }).appendTo($('#header'));
     document.getElementById('theme-toggle')?.addEventListener('click', theme.onClick);
 }


### PR DESCRIPTION
Modify the backend configuration to include version info in the settings
Update the frontend JavaScript to display the version in the header
Add CSS styling to ensure it's visible in both light and dark themes
I'll submit a PR shortly with the implementation. Let me know if you have any specific preferences for the placement or styling!
1. Backend - 
2. 
src/robot/conf/settings.py
Added import: from robot.version import get_full_version
Modified 
log_config
 property to include "generator": get_full_version("Robot Framework")
Modified 
report_config
 property to include "generator": get_full_version("Robot Framework")
This ensures the version is available in window.settings.generator in the generated HTML.

3. Frontend - 
src/robot/htmldata/rebot/view.js
Updated 
addHeader()
 function to retrieve version from settings
Added conditional rendering: {{if generator}}<div id="generator-info">${generator}</div>{{/if}}
Passed generator data to the template
4. Styling - 
src/robot/htmldata/rebot/common.css
Added #generator-info styles with:
Smaller font size (0.75em) to keep it subtle
Theme-aware colors using CSS variables
Appropriate padding and opacity for visual hierarchy