### PR TITLE
Add support for prefixing suite keywords with suite name

### DIFF
--- a/src/robot/running/namespace.py
+++ b/src/robot/running/namespace.py
@@ -511,6 +511,12 @@ class KeywordStore:
     def _get_explicit_runner(self, name):
         kws_and_names = []
         for owner_name, kw_name in self._get_owner_and_kw_names(name):
+            # Check suite file first (if suite name matches)
+            if (self.suite_file and self.suite_file.owner 
+                    and eq(self.suite_file.owner.name, owner_name)):
+                for kw in self.suite_file.find_keywords(kw_name):
+                    kws_and_names.append((kw, kw_name))
+            # Then check libraries and resources
             for owner in (*self.libraries.values(), *self.resources.values()):
                 if eq(owner.name, owner_name):
                     for kw in owner.find_keywords(kw_name):


### PR DESCRIPTION

### Solution

Modified the [_get_explicit_runner()](cci:1://file:///Users/aman/Downloads/robotframework/src/robot/running/namespace.py:510:4-527:56) method in [src/robot/running/namespace.py](cci:7://file:///Users/aman/Downloads/robotframework/src/robot/running/namespace.py:0:0-0:0) to also check the suite file's keywords when a prefix is used.

**Key changes:**
- Check `suite_file.owner.name` before searching libraries/resources
- Added proper None checks for robustness
- Suite keywords checked first, maintaining consistency with unprefixed resolution

### Testing

Verified with test case:
```robot
*** Test Cases ***
Simple test
    Some keyword    123    
    MySuite.Some keyword    123    

*** Keywords ***
Some keyword
    [Arguments]        ${alpha}
    Log    ${alpha}    