### PR TITLE
Fix unit test with Python 3.15.0a3

### DIFF
--- a/src/robot/result/resultbuilder.py
+++ b/src/robot/result/resultbuilder.py
@@ -166,11 +166,12 @@ class ExecutionResultBuilder:
             else:
                 end(elem)
                 elem.clear()
+        # Python 3.15 emits a warning if context is not closed, but `close` is
+        # new in Python 3.13.
         try:
-            # From Python 3.15 it is required to close the context
             context.close()
         except AttributeError:
-            pass    # Compatibility with old Python versions without close
+            pass
 
     def _omit_keywords(self, context):
         omitted_elements = {"kw", "for", "while", "if", "try", "group", "variable"}


### PR DESCRIPTION
With Python 3.15.0a3 10 unit tests fail with a similar output:

```
======================================================================
FAIL: test_run_once (test_run_and_rebot.TestRun.test_run_once)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/builddir/build/BUILD/python-robotframework-7.4-build/robotframework-7.4/utest/api/test_run_and_rebot.py", line 64, in test_run_once
    self._assert_outputs([("Pass And Fail", 2), (LOG, 1), ("Report:", 0)])
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/builddir/build/BUILD/python-robotframework-7.4-build/robotframework-7.4/utest/resources/runningtestcase.py", line 40, in _assert_outputs
    self._assert_output(sys.stderr, None)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/builddir/build/BUILD/python-robotframework-7.4-build/robotframework-7.4/utest/resources/runningtestcase.py", line 48, in _assert_output
    self._assert_no_output(output)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/builddir/build/BUILD/python-robotframework-7.4-build/robotframework-7.4/utest/resources/runningtestcase.py", line 52, in _assert_no_output
    raise AssertionError(f"Expected output to be empty:{output}")
AssertionError: Expected output to be empty:/builddir/build/BUILD/python-robotframework-7.4-build/robotframework-7.4/utest/../src/robot/result/resultbuilder.py:147: ResourceWarning: unclosed iterparse iterator '/tmp/output.xml'
  self._parse(source, handler.start, handler.end)

```

This is due to warning raised with new Python versions for unclosed xml.etree.ElementTree.iterparse(), see also: https://github.com/python/cpython/issues/140601

Fix this by explicitly closing the context before it goes out of scope.

Note: to keep code compatible with older Python versions, catch the exception if close() method is not present
