### PR TITLE
Feature 2549 - support HTML in test and suite documentation

### DIFF
--- a/atest/robot/output/js_model.robot
+++ b/atest/robot/output/js_model.robot
@@ -12,6 +12,11 @@ Strings like </script> logged as HTML are escaped in JS model
     Strings logged as HTML are escaped    log
     Strings logged as HTML are escaped    report
 
+HTML prefix in test documentation is rendered as HTML
+    Check test case    Test With HTML Doc
+    Model contains HTML from doc
+    ...    window.output?"strings"?*<b>Bold Documentation</b>*
+
 *** Keywords ***
 Run tests with options containing </script>
     ${options} =    Catenate
@@ -45,3 +50,8 @@ Get JS model
     ${strings} =    Get Lines Matching Pattern    ${file}    window.output?"strings"?*
     ${settings} =    Get Lines Matching Pattern    ${file}    window.settings =*
     RETURN    ${strings}    ${settings}
+
+Model contains HTML from doc
+    [Arguments]    ${pattern}
+    ${file} =    Get File    ${OUTDIR}/log.html
+    Should Contain    ${file}    ${pattern}

--- a/atest/testdata/output/js_model.robot
+++ b/atest/testdata/output/js_model.robot
@@ -15,6 +15,10 @@ HTML </script>
     Log    <b>HTML</b></script>    HTML
     Fail    *HTML* <b>HTML</b></script>
 
+Test With HTML Doc
+    [Documentation]    *HTML* <b>Bold Documentation</b>
+    Log    Test passed
+
 *** Keywords ***
 </script>
     [Documentation]    </script>

--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -4106,6 +4106,9 @@ class _Misc(_BuiltInBase):
         this can be changed using the optional ``append`` argument similarly
         as with `Set Test Message` keyword.
 
+        It is possible to use HTML format in the message by starting the message
+        with ``*HTML*`` similarly as with `Set Test Message` keyword.
+
         An optional ``separator`` argument can be used to provide custom separator
         string when appending to the old text. A single space is used as separator
         by default.
@@ -4122,7 +4125,7 @@ class _Misc(_BuiltInBase):
                 "'Set Test Documentation' keyword cannot be used in "
                 "suite setup or teardown."
             )
-        test.doc = self._get_new_text(test.doc, doc, append, separator=separator)
+        test.doc = self._get_new_text(test.doc, doc, append, handle_html=True, separator=separator)
         self._variables.set_test("${TEST_DOCUMENTATION}", test.doc)
         logger.info(f"Set test documentation to:\n{test.doc}")
 
@@ -4139,6 +4142,9 @@ class _Misc(_BuiltInBase):
         this can be changed using the optional ``append`` argument similarly
         as with `Set Test Message` keyword.
 
+        It is possible to use HTML format in the message by starting the message
+        with ``*HTML*`` similarly as with `Set Test Message` keyword.
+
         This keyword sets the documentation of the current suite by default.
         If the optional ``top`` argument is given a true value, the documentation
         of the top level suite is altered instead.
@@ -4153,7 +4159,7 @@ class _Misc(_BuiltInBase):
         The ``separator`` argument is new in Robot Framework 7.2.
         """
         suite = self._get_context(top).suite
-        suite.doc = self._get_new_text(suite.doc, doc, append, separator=separator)
+        suite.doc = self._get_new_text(suite.doc, doc, append, handle_html=True, separator=separator)
         self._variables.set_suite("${SUITE_DOCUMENTATION}", suite.doc, top)
         logger.info(f"Set suite documentation to:\n{suite.doc}")
 

--- a/src/robot/reporting/jsmodelbuilders.py
+++ b/src/robot/reporting/jsmodelbuilders.py
@@ -83,6 +83,11 @@ class Builder:
         self._html = self._context.html
         self._timestamp = self._context.timestamp
 
+    def _try_handle_html(self, value: str):
+        if value.startswith("*HTML*"):
+            return self._string(value[6:].lstrip(), escape=False)
+        return None
+
     def _get_status(self, item, note_only=False):
         model = (
             STATUSES[item.status],
@@ -99,10 +104,7 @@ class Builder:
                     index = self._string(match.group(1))
                     return (*model, index)
             return model
-        if msg.startswith("*HTML*"):
-            index = self._string(msg[6:].lstrip(), escape=False)
-        else:
-            index = self._string(msg)
+        index = self._try_handle_html(msg) or self._string(msg)
         return (*model, index)
 
     def _build_body(self, body, split=False):
@@ -135,7 +137,7 @@ class SuiteBuilder(Builder):
                 self._string(suite.name, attr=True),
                 self._string(suite.source),
                 self._context.relative_source(suite.source),
-                self._html(suite.doc),
+                self._try_handle_html(suite.doc) or self._html(suite.doc),
                 tuple(self._yield_metadata(suite)),
                 self._get_status(suite),
                 tuple(self._build_suite(s) for s in suite.suites),
@@ -166,7 +168,7 @@ class TestBuilder(Builder):
             return (
                 self._string(test.name, attr=True),
                 self._string(test.timeout),
-                self._html(test.doc),
+                self._try_handle_html(test.doc) or self._html(test.doc),
                 tuple(self._string(t) for t in test.tags),
                 self._get_status(test),
                 self._build_body(body, split=True),

--- a/utest/reporting/test_jsmodelbuilders.py
+++ b/utest/reporting/test_jsmodelbuilders.py
@@ -130,6 +130,14 @@ class TestBuildTestSuite(unittest.TestCase):
             suite, "quote:&quot; and *url* https://url.com", '<b>"Doc"</b>'
         )
 
+    def test_suite_html_doc(self):
+        suite = TestSuite(name="Suite", doc="*HTML* <b>Bold</b>")
+        self._verify_suite(suite, name="Suite", doc="<b>Bold</b>")
+
+    def test_test_html_doc(self):
+        test = TestCase(name="Test", doc="*HTML* <span>Custom</span>")
+        self._verify_test(test, name="Test", doc="<span>Custom</span>")
+
     def test_default_keyword(self):
         self._verify_body_item(Keyword())
 


### PR DESCRIPTION
Proposal for [#2549 - HTML support for set_test_documentation() and set_suite_documentation()](https://github.com/robotframework/robotframework/issues/2549)