### PR TITLE
fix: handle bool to int/float type conversion in user keywords

### DIFF
--- a/atest/testdata/keywords/type_conversion/annotations.robot
+++ b/atest/testdata/keywords/type_conversion/annotations.robot
@@ -36,6 +36,8 @@ Integer
     Integer              100_e_-_2                 1
     Integer              ${41}                     41
     Integer              ${-4.0}                   -4
+    Integer              ${TRUE}                   1
+    Integer              ${FALSE}                  0
 
 Integer as hex
     Integer              0x0                       0
@@ -106,6 +108,8 @@ Float
     Float                ${4}                      4.0
     Float                ${-4.1}                   -4.1
     Float                ${FRACTION 1/2}           0.5
+    Float                ${TRUE}                   1.0
+    Float                ${FALSE}                  0.0
 
 Invalid float
     [Template]           Conversion Should Fail

--- a/atest/testdata/keywords/type_conversion/keyword_decorator.robot
+++ b/atest/testdata/keywords/type_conversion/keyword_decorator.robot
@@ -24,6 +24,8 @@ Integer
     Integer              10E99                     10**100
     Integer              ${41}                     41
     Integer              ${-4.0}                   -4
+    Integer              ${TRUE}                   1
+    Integer              ${FALSE}                  0
 
 Integer as hex
     Integer              0x0                        0

--- a/doc/userguide/src/ExtendingRobotFramework/CreatingTestLibraries.rst
+++ b/doc/userguide/src/ExtendingRobotFramework/CreatingTestLibraries.rst
@@ -1279,8 +1279,8 @@ Other types cause conversion failures.
    |              |               |            |              | Translations_ appendix for supported translations.             |                                      |
    +--------------+---------------+------------+--------------+----------------------------------------------------------------+--------------------------------------+
    | int_         | Integral_     | integer,   | str_,        | Conversion is done using the int_ built-in function. Floats    | | `42`                               |
-   |              |               | long       | float_       | are accepted only if they can be represented as integers       | | `-1`                               |
-   |              |               |            |              | exactly. For example, `1.0` is accepted and `1.1` is not.      | | `10 000 000`                       |
+   |              |               | long       | float_,      | are accepted only if they can be represented as integers       | | `-1`                               |
+   |              |               |            | bool_        | exactly. For example, `1.0` is accepted and `1.1` is not.      | | `10 000 000`                       |
    |              |               |            |              | If converting a string to an integer fails and the type        | | `1e100`                            |
    |              |               |            |              | is got implicitly based on a default value, conversion to      | | `0xFF`                             |
    |              |               |            |              | float is attempted as well.                                    | | `0o777`                            |
@@ -1288,13 +1288,16 @@ Other types cause conversion failures.
    |              |               |            |              | Starting from Robot Framework 4.1, it is possible to use       | | `0xBAD_C0FFEE`                     |
    |              |               |            |              | hexadecimal, octal and binary numbers by prefixing values with | | `${1}`                             |
    |              |               |            |              | `0x`, `0o` and `0b`, respectively.                             | | `${1.0}`                           |
-   |              |               |            |              |                                                                |                                      |
+   |              |               |            |              |                                                                | | `${True}` (converted to `1`)       |
    |              |               |            |              | Starting from Robot Framework 4.1, spaces and underscores can  |                                      |
    |              |               |            |              | be used as visual separators for digit grouping purposes.      |                                      |
    |              |               |            |              |                                                                |                                      |
    |              |               |            |              | Starting from Robot Framework 7.0, strings representing floats |                                      |
    |              |               |            |              | are accepted as long as their decimal part is zero. This       |                                      |
    |              |               |            |              | includes using the scientific notation like `1e100`.           |                                      |
+   |              |               |            |              |                                                                |                                      |
+   |              |               |            |              | Starting from Robot Framework 7.5, Boolean values `True` and   |                                      |
+   |              |               |            |              | `False` are converted to integers `1` and `0`.                 |                                      |
    +--------------+---------------+------------+--------------+----------------------------------------------------------------+--------------------------------------+
    | float_       | Real_         | double     | str_,        | Conversion is done using the float_ built-in.                  | | `3.14`                             |
    |              |               |            | Real_        |                                                                | | `2.9979e8`                         |

--- a/src/robot/running/arguments/typeconverters.py
+++ b/src/robot/running/arguments/typeconverters.py
@@ -322,9 +322,17 @@ class IntegerConverter(TypeConverter):
     type = int
     abc = Integral
     type_name = "integer"
-    value_types = (str, float)
+    value_types = (str, float, bool)
+
+    def no_conversion_needed(self, value):
+        # bool is subclass of int but should convert to 0/1
+        if isinstance(value, bool):
+            return False
+        return super().no_conversion_needed(value)
 
     def _non_string_convert(self, value):
+        if isinstance(value, bool):
+            return int(value)
         if value.is_integer():
             return int(value)
         raise ValueError("Conversion would lose precision.")


### PR DESCRIPTION
## Summary
Fixes #5630.
**Root cause:** `IntegerConverter.no_conversion_needed` returned `True` for booleans because `bool` is a subclass of `int`, so `isinstance(True, int)` passes. The boolean value was kept as-is instead of converting to 0/1.
**Fix:** Override `no_conversion_needed` in `IntegerConverter` to return `False` for booleans, and handle bool→int in `_non_string_convert`.
## Changes
- `src/robot/running/arguments/typeconverters.py`: IntegerConverter now converts bool to int (0/1); added bool to value_types
- `atest/testdata/keywords/type_conversion/annotations.robot`: added bool→int and bool→float test cases
- `atest/testdata/keywords/type_conversion/keyword_decorator.robot`: added bool→int test cases
- `doc/userguide/src/ExtendingRobotFramework/CreatingTestLibraries.rst`: updated supported types table — added bool_ as input type for integer, documented RF 7.5 behavior
## Testing
- Added `${TRUE}` → 1 and `${FALSE}` → 0 for Integer conversion
- Added `${TRUE}` → 1.0 and `${FALSE}` → 0.0 for Float conversion