### PR TITLE
Fix type conversion between int/float and bool in user keywords

### DIFF
--- a/src/robot/running/arguments/typeconverters.py
+++ b/src/robot/running/arguments/typeconverters.py
@@ -27,7 +27,13 @@ from typing import Any, Literal, TYPE_CHECKING, Union
 from robot.conf import Languages
 from robot.libraries.DateTime import convert_date, convert_time
 from robot.utils import (
-    eq, get_error_message, plural_or_not as s, safe_str, Secret, seq2str, type_name
+    eq,
+    get_error_message,
+    plural_or_not as s,
+    safe_str,
+    Secret,
+    seq2str,
+    type_name,
 )
 
 if TYPE_CHECKING:
@@ -304,7 +310,7 @@ class BooleanConverter(TypeConverter):
     value_types = (str, int, float, NoneType)
 
     def _non_string_convert(self, value):
-        return value
+        return bool(value)
 
     def _string_convert(self, value):
         normalized = value.title()
@@ -322,9 +328,16 @@ class IntegerConverter(TypeConverter):
     type = int
     abc = Integral
     type_name = "integer"
-    value_types = (str, float)
+    value_types = (str, float, bool)
+
+    def no_conversion_needed(self, value: Any) -> bool:
+        if isinstance(value, bool):
+            return False
+        return super().no_conversion_needed(value)
 
     def _non_string_convert(self, value):
+        if isinstance(value, bool):
+            return int(value)
         if value.is_integer():
             return int(value)
         raise ValueError("Conversion would lose precision.")
@@ -361,9 +374,16 @@ class FloatConverter(TypeConverter):
     type = float
     abc = Real
     type_name = "float"
-    value_types = (str, Real)
+    value_types = (str, Real, bool)
+
+    def no_conversion_needed(self, value: Any) -> bool:
+        if isinstance(value, bool):
+            return False
+        return super().no_conversion_needed(value)
 
     def _convert(self, value):
+        if isinstance(value, bool):
+            return float(value)
         try:
             return float(self._remove_number_separators(value))
         except ValueError:
@@ -893,7 +913,6 @@ class SecretConverter(TypeConverter):
 
 
 class CustomConverter(TypeConverter):
-
     def __init__(
         self,
         type_info: "TypeInfo",
@@ -927,7 +946,6 @@ class CustomConverter(TypeConverter):
 
 
 class UnknownConverter(TypeConverter):
-
     def convert(self, value, name=None, kind="Argument"):
         return value
 


### PR DESCRIPTION
## Summary

Fixes #5622

In Python, `bool` is a subclass of `int`, which caused incorrect type conversion behavior in user keyword arguments:

- `bool` values (`True`/`False`) passed to `int` or `float` arguments were not converted
- `int`/`float` values passed to `bool` arguments were not converted

### Root Cause

The `no_conversion_needed` method in `TypeConverter` checks `isinstance(value, type_info.type)`. Since `bool` is a subclass of `int`:
- `isinstance(True, int)` returns `True`
- So `no_conversion_needed(True)` incorrectly returned `True` for `int` arguments

### Changes

1. **BooleanConverter._non_string_convert**: Now converts `int`/`float` to `bool` using `bool(value)`

2. **IntegerConverter**:
   - Added `bool` to `value_types`
   - Override `no_conversion_needed` to return `False` for `bool` values
   - Added `bool` handling in `_non_string_convert`

3. **FloatConverter**:
   - Added `bool` to `value_types`
   - Override `no_conversion_needed` to return `False` for `bool` values
   - Added `bool` handling in `_convert`

### Before

```robotframework
Log As Int    ${TRUE}     # → True <class 'bool'>  (wrong!)
Log As Bool   ${3.0}      # → 3.0 <class 'float'>  (wrong!)
```

### After

```robotframework
Log As Int    ${TRUE}     # → 1 <class 'int'>      (correct!)
Log As Bool   ${3.0}      # → True <class 'bool'>  (correct!)
```