### PR TITLE
TypeInfoParser crashes with UnboundLocalError or hangs on | inside type parameters

### DIFF
--- a/src/robot/running/arguments/typeinfoparser.py
+++ b/src/robot/running/arguments/typeinfoparser.py
@@ -154,7 +154,8 @@ class TypeInfoParser:
                 param = TypeInfo()
                 param.nested = self.params()
             else:
-                self.error(f"Invalid type string '{self.source}': expected type name.")
+                self.error("Type name missing.")
+
             if literal:
                 param = self._literal_param(param)
             params.append(param)
@@ -220,3 +221,4 @@ class TypeInfoParser:
         raise ValueError(
             f"Parsing type {self.source!r} failed: Error at {position}: {message}"
         )
+        

--- a/src/robot/running/arguments/typeinfoparser.py
+++ b/src/robot/running/arguments/typeinfoparser.py
@@ -153,6 +153,8 @@ class TypeInfoParser:
                 self.advance()
                 param = TypeInfo()
                 param.nested = self.params()
+            else:
+                self.error("Type name missing.")
             if literal:
                 param = self._literal_param(param)
             params.append(param)

--- a/src/robot/running/arguments/typeinfoparser.py
+++ b/src/robot/running/arguments/typeinfoparser.py
@@ -154,7 +154,7 @@ class TypeInfoParser:
                 param = TypeInfo()
                 param.nested = self.params()
             else:
-                self.error("Type name missing.")
+                self.error(f"Invalid type string '{self.source}': expected type name.")
             if literal:
                 param = self._literal_param(param)
             params.append(param)

--- a/utest/running/test_typeinfoparser.py
+++ b/utest/running/test_typeinfoparser.py
@@ -173,9 +173,9 @@ class TestTypeInfoParser(unittest.TestCase):
             ("x[y,,]", 4, "Type missing before ','."),
             ("x | ,", 4, "Type name missing."),
             ("x|||", 2, "Type name missing."),
-            ("list[| str]", 5, "Invalid type string 'list[| str]': expected type name."),
-            ("list[int, | str]", 10, "Invalid type string 'list[int, | str]': expected type name."),
-            ("list[|]", 5, "Invalid type string 'list[|]': expected type name."),
+            ("list[| str]", 5, "Type name missing."),
+            ("list[int, | str]", 10, "Type name missing."),
+            ("list[|]", 5, "Type name missing."),
             ("list[int||str]", 9, "Type name missing."),
             ("list[int|]", 9, "Type name missing."),
             ('"x"y', 3, "Extra content after '\"x\"'."),
@@ -190,3 +190,4 @@ class TestTypeInfoParser(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+    

--- a/utest/running/test_typeinfoparser.py
+++ b/utest/running/test_typeinfoparser.py
@@ -173,6 +173,8 @@ class TestTypeInfoParser(unittest.TestCase):
             ("x[y,,]", 4, "Type missing before ','."),
             ("x | ,", 4, "Type name missing."),
             ("x|||", 2, "Type name missing."),
+            ("list[| str]", 5, "Type name missing."),
+            ("list[int, | str]", 10, "Type name missing."),
             ('"x"y', 3, "Extra content after '\"x\"'."),
         ]:
             position = f"index {position}" if isinstance(position, int) else position

--- a/utest/running/test_typeinfoparser.py
+++ b/utest/running/test_typeinfoparser.py
@@ -190,4 +190,3 @@ class TestTypeInfoParser(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-    

--- a/utest/running/test_typeinfoparser.py
+++ b/utest/running/test_typeinfoparser.py
@@ -173,8 +173,11 @@ class TestTypeInfoParser(unittest.TestCase):
             ("x[y,,]", 4, "Type missing before ','."),
             ("x | ,", 4, "Type name missing."),
             ("x|||", 2, "Type name missing."),
-            ("list[| str]", 5, "Type name missing."),
-            ("list[int, | str]", 10, "Type name missing."),
+            ("list[| str]", 5, "Invalid type string 'list[| str]': expected type name."),
+            ("list[int, | str]", 10, "Invalid type string 'list[int, | str]': expected type name."),
+            ("list[|]", 5, "Invalid type string 'list[|]': expected type name."),
+            ("list[int||str]", 9, "Type name missing."),
+            ("list[int|]", 9, "Type name missing."),
             ('"x"y', 3, "Extra content after '\"x\"'."),
         ]:
             position = f"index {position}" if isinstance(position, int) else position


### PR DESCRIPTION
Fixes #5650

Root cause: In `params()`, when a PIPE token appeared inside type 
parameters, none of the if/elif branches handled it causing:

- UnboundLocalError on first occurrence (param never assigned)
- Infinite loop/hang on second+ occurrence (never advances past PIPE)

Fix: Added else clause to raise a proper ValueError immediately.

Added 2 test cases to cover both failure scenarios:
- list[| str]
- list[int, | str]