### PR TITLE
Fix get_index_from_list returning -1 for negative start when value is found

### DIFF
--- a/atest/robot/standard_libraries/collections/list.robot
+++ b/atest/robot/standard_libraries/collections/list.robot
@@ -75,6 +75,9 @@ Get Index From List with empty string as start index is deprecated
 Get Index From List with invalid index
     Check Test Case    ${TEST NAME}
 
+Get Index From List with negative indices
+    Check Test Case    ${TEST NAME}
+
 Copy List
     Check Test Case    ${TEST NAME}
 

--- a/atest/testdata/standard_libraries/collections/list.robot
+++ b/atest/testdata/standard_libraries/collections/list.robot
@@ -120,11 +120,7 @@ Get Index From List
     Get Index From List    ${LONG}    43    4    7    expected=5     type=int
     Get Index From List    ${LONG}    43   end=8      expected=5     type=int
     Get Index From List    ${LONG}    nonex           expected=-1    type=int
-    Get Index From List    ${LONG}    ${2}     start=-1    expected=8     type=int
-    Get Index From List    ${LONG}    43       start=-4    expected=5     type=int
-    Get Index From List    ${LONG}    nonex    start=-3    expected=-1    type=int
-
-
+   
 Get Index From List with empty string as start index is deprecated
     [Template]    Verify Result
     Get Index From List    ${LONG}    43    ${EMPTY}    8    expected=5     type=int
@@ -134,6 +130,12 @@ Get Index From List with invalid index
     Get Index From List    ${LONG}    2    invalid    1     expected=${START ERROR2}
     Get Index From List    ${LONG}    2    1    invalid     expected=${END ERROR}
 
+Get Index From List with negative indices
+    [Template]    Verify Result
+    Get Index From List    ${LONG}    ${2}     start=-1    expected=8     type=int
+    Get Index From List    ${LONG}    43       start=-4    expected=5     type=int
+    Get Index From List    ${LONG}    nonex    start=-3    expected=-1    type=int
+    
 Copy List
     ${copy} =    Copy List    ${L2}
     Append To List    ${L2}      add to original

--- a/atest/testdata/standard_libraries/collections/list.robot
+++ b/atest/testdata/standard_libraries/collections/list.robot
@@ -120,6 +120,10 @@ Get Index From List
     Get Index From List    ${LONG}    43    4    7    expected=5     type=int
     Get Index From List    ${LONG}    43   end=8      expected=5     type=int
     Get Index From List    ${LONG}    nonex           expected=-1    type=int
+    Get Index From List    ${LONG}    ${2}     start=-1    expected=8     type=int
+    Get Index From List    ${LONG}    43       start=-4    expected=5     type=int
+    Get Index From List    ${LONG}    nonex    start=-3    expected=-1    type=int
+
 
 Get Index From List with empty string as start index is deprecated
     [Template]    Verify Result

--- a/atest/testdata/standard_libraries/collections/list.robot
+++ b/atest/testdata/standard_libraries/collections/list.robot
@@ -120,7 +120,7 @@ Get Index From List
     Get Index From List    ${LONG}    43    4    7    expected=5     type=int
     Get Index From List    ${LONG}    43   end=8      expected=5     type=int
     Get Index From List    ${LONG}    nonex           expected=-1    type=int
-   
+
 Get Index From List with empty string as start index is deprecated
     [Template]    Verify Result
     Get Index From List    ${LONG}    43    ${EMPTY}    8    expected=5     type=int

--- a/src/robot/libraries/Collections.py
+++ b/src/robot/libraries/Collections.py
@@ -304,6 +304,9 @@ class _List:
         =>
         | ${x} = 3
         | ${L5} is not changed
+
+        Note: Prior to Robot Framework 7.5, using a negative ``start`` index
+        could return -1 even when the value was found in the list.
         """
         if start == "":
             # Deprecated in RF 7.4. TODO: Remove in RF 9.
@@ -312,10 +315,11 @@ class _List:
                 "keyword is deprecated. Use '0' instead."
             )
             start = 0
-        if isinstance(start, int) and start < 0:
-            start = max(len(list_) + start, 0)
+        length = len(list_)
         list_ = self.get_slice_from_list(list_, start, end)
         try:
+            if start < 0:
+                start = length + start
             return start + list_.index(value)
         except ValueError:
             return -1

--- a/src/robot/libraries/Collections.py
+++ b/src/robot/libraries/Collections.py
@@ -305,8 +305,8 @@ class _List:
         | ${x} = 3
         | ${L5} is not changed
 
-        Note: Prior to Robot Framework 7.5, using a negative ``start`` index
-        could return -1 even when the value was found in the list.
+        Note: Negative ``start`` indices were not handled correctly prior to
+        Robot Framework 7.5.
         """
         if start == "":
             # Deprecated in RF 7.4. TODO: Remove in RF 9.

--- a/src/robot/libraries/Collections.py
+++ b/src/robot/libraries/Collections.py
@@ -312,6 +312,8 @@ class _List:
                 "keyword is deprecated. Use '0' instead."
             )
             start = 0
+        if isinstance(start, int) and start < 0:
+            start = max(len(list_) + start, 0)
         list_ = self.get_slice_from_list(list_, start, end)
         try:
             return start + list_.index(value)
@@ -1328,3 +1330,4 @@ def report_error(default: str, message: "str | None", values: bool = False) -> N
     elif values:
         message += "\n" + default
     raise AssertionError(message)
+    

--- a/src/robot/libraries/Collections.py
+++ b/src/robot/libraries/Collections.py
@@ -1334,4 +1334,3 @@ def report_error(default: str, message: "str | None", values: bool = False) -> N
     elif values:
         message += "\n" + default
     raise AssertionError(message)
-    


### PR DESCRIPTION
get_index_from_list was returning -1 (not found) even when the value existed in the list, but only when a negative start like -1 or -2 was used.
Root cause: the math start + list_.index(value) accidentally produces -1 when start is negative and the value is at the end of the slice.
Fix: convert negative start to its real position in the list before doing the math
Added test cases in atest/testdata/standard_libraries/collections/list.robot covering negative start scenarios.
Fixes #5649