### PR TITLE
Document Markdown support for tests (#5603)

### DIFF
--- a/doc/userguide/src/Appendices/Registrations.rst
+++ b/doc/userguide/src/Appendices/Registrations.rst
@@ -15,6 +15,9 @@ Suite file extensions
 :file:`.robot.rst`
     Suite file using the `reStructuredText format`_.
 
+:file:`.robot.md`
+    Suite file using the `Markdown format`_.
+
 :file:`.rbt`
     Suite file using the `JSON format`_.
 
@@ -37,10 +40,14 @@ Resource file extensions
 :file:`.rst` and :file:`.rest`
     Resource file using the `reStructuredText format`__.
 
+:file:`.md` and :file:`.markdown`
+    Resource file using the `Markdown format`__.
+
 :file:`.rsrc` and :file:`.json`
     Resource file using the `JSON format`__.
 
 __ `Resource files using reStructured text format`_
+__ `Resource files using Markdown format`_
 __ `Resource files using JSON format`_
 
 Media type

--- a/doc/userguide/src/CreatingTestData/ResourceAndVariableFiles.rst
+++ b/doc/userguide/src/CreatingTestData/ResourceAndVariableFiles.rst
@@ -181,6 +181,52 @@ defines `${MESSAGE}` variable and creates :name:`My Keyword` keyword:
 
 __ `reStructuredText format`_
 
+Resource files using Markdown format
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The `Markdown format`_ that can be used with `suite files`_ works also with
+resource files. Such resource files can use either :file:`.md` or
+:file:`.markdown` extension and they are otherwise imported exactly as normal
+resource files:
+
+.. sourcecode:: robotframework
+
+   *** Settings ***
+   Resource         example.md
+
+When parsing resource files using the Markdown format, Robot Framework
+ignores all data outside fenced code blocks with the ``robotframework`` or ``robot``
+language tag exactly the same way as when parsing `Markdown suite files`__.
+For example, the following resource file imports :name:`OperatingSystem` library,
+defines ``${MESSAGE}`` variable and creates :name:`My Keyword` keyword:
+
+.. sourcecode:: markdown
+
+    # Resource file using Markdown
+
+    This text is outside code blocks and thus ignored.
+
+    ```robotframework
+    *** Settings ***
+    Library          OperatingSystem
+
+    *** Variables ***
+    ${MESSAGE}       Hello, world!
+    ```
+
+    Also this text is outside code blocks and ignored. Code blocks not
+    containing Robot Framework data are ignored as well.
+
+    ```robotframework
+    # Both space and pipe separated formats are supported.
+
+    | *** Keywords ***  |                        |         |
+    | My Keyword        | [Arguments]            | ${path} |
+    |                   | Directory Should Exist | ${path} |
+    ```
+
+__ `Markdown format`_
+
 Resource files using JSON format
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/userguide/src/CreatingTestData/TestDataSyntax.rst
+++ b/doc/userguide/src/CreatingTestData/TestDataSyntax.rst
@@ -334,13 +334,13 @@ that is easy to read, write and preview using standard editors and tools.
           external Python module to be installed.
 
 When Robot Framework parses Markdown files, it searches for code blocks
-starting with fences of at least three backticks ``(`)`` or tildes ``(~)``
-and the ``robotframework`` (or simply ``robot``) language tag. All content
-outside such blocks is ignored. The parser follows the CommonMark_ specification
-for fenced code blocks, which means that the opening and closing fences must
-match and the closing fence must be at least as long as the opening one. If a
-code block is not closed properly, the rest of the file will be considered
-as part of the code block itself.
+starting with fences of at least three backticks :codesc:`\`\`\`` or tildes
+:codesc:`~~~` and the ``robotframework`` (or simply ``robot``) language tag.
+All content outside such blocks is ignored. The parser follows the CommonMark_
+specification for fenced code blocks, which means that the opening and closing
+fences must match and the closing fence must be at least as long as the
+opening one. If a code block is not closed properly, the rest of the file
+will be considered as part of the code block itself.
 
 .. sourcecode:: markdown
 

--- a/doc/userguide/src/CreatingTestData/TestDataSyntax.rst
+++ b/doc/userguide/src/CreatingTestData/TestDataSyntax.rst
@@ -118,6 +118,11 @@ the :file:`.robot.rst` extension are parsed by default. If you would
 rather use just :file:`.rst` or :file:`.rest` extension, that needs to be
 configured separately.
 
+Robot Framework supports also Markdown_ files so that normal Robot Framework
+data is `embedded into code blocks`__. Only files with the :file:`.robot.md`
+extension are parsed by default. If you would rather use just :file:`.md` or
+:file:`.markdown` extension, that needs to be configured separately.
+
 Robot Framework data can also be created in the `JSON format`_ that is targeted
 more for tool developers than normal Robot Framework users. Only JSON files
 with the custom :file:`.rbt` extension are parsed by default.
@@ -133,6 +138,7 @@ format at all.
 
 __ `Selecting files to parse`_
 __ `reStructuredText format`_
+__ `Markdown format`_
 
 .. _space separated plain text format:
 .. _plain text format:
@@ -314,6 +320,74 @@ when processing files using reStructuredText tooling normally.
 
 .. note:: Parsing :file:`.robot.rst` files automatically is new in
           Robot Framework 6.1.
+
+Markdown format
+~~~~~~~~~~~~~~~
+
+Markdown_ is a lightweight plain text markup syntax that is widely used for
+documentation, README files, and technical content across the software
+development industry. Because of its natural fit for narrative documentation,
+using Markdown with Robot Framework allows you to create test data in a format
+that is easy to read, write and preview using standard editors and tools.
+
+.. note:: Using Markdown_ files with Robot Framework does not require any
+          external Python module to be installed.
+
+When Robot Framework parses Markdown files, it searches for code blocks
+starting with fences of at least three backticks ``(`)`` or tildes ``(~)``
+and the ``robotframework`` (or simply ``robot``) language tag. All content
+outside such blocks is ignored. The parser follows the CommonMark_ specification
+for fenced code blocks, which means that the opening and closing fences must
+match and the closing fence must be at least as long as the opening one. If a
+code block is not closed properly, the rest of the file will be considered
+as part of the code block itself.
+
+.. sourcecode:: markdown
+
+    # Markdown example
+
+    This text is outside code blocks and thus ignored.
+
+    ```robotframework
+    *** Settings ***
+    Documentation    Example using the Markdown format.
+    Library          OperatingSystem
+
+    *** Variables ***
+    ${MESSAGE}       Hello, world!
+
+    *** Test Cases ***
+    My Test
+        [Documentation]    Example test.
+        Log    ${MESSAGE}
+        My Keyword    ${CURDIR}
+
+    *** Keywords ***
+    My Keyword
+        [Arguments]    ${path}
+        Directory Should Exist    ${path}
+    ```
+
+    More free text here. There could be additional code blocks with more
+    Robot Framework data as well.
+
+    ```python
+    # This code block is ignored.
+    def example():
+        print('Hello, world!')
+    ```
+
+Robot Framework supports Markdown files using :file:`.robot.md`,
+:file:`.md` and :file:`.markdown` extensions. To avoid parsing unrelated
+Markdown files, only files with the :file:`.robot.md` extension
+are parsed by default when executing a directory. Parsing files with
+the :file:`.md` or :file:`.markdown` extension `can be enabled`__ by using
+either :option:`--parseinclude` or :option:`--extension` option.
+
+__ `Selecting files to parse`_
+
+.. note:: Parsing :file:`.robot.md` files automatically is new in
+          Robot Framework 7.5.
 
 JSON format
 ~~~~~~~~~~~

--- a/doc/userguide/src/ExecutingTestCases/ConfiguringExecution.rst
+++ b/doc/userguide/src/ExecutingTestCases/ConfiguringExecution.rst
@@ -23,6 +23,7 @@ on the extension:
 - :file:`.robot` files and files that are not recognized are parsed using
   the normal `Robot Framework parser`__.
 - :file:`.rst` and :file:`.rest` files are parsed using the `reStructuredText parser`__.
+- :file:`.md` and :file:`.markdown` files are parsed using the `Markdown parser`__.
 - :file:`.rbt` and :file:`.json` files are parsed using the `JSON parser`__.
 - Files supported by `custom parsers`__ are parsed by a matching parser.
 
@@ -31,10 +32,12 @@ Examples::
     robot example.robot    # Standard Robot Framework parser.
     robot example.tsv      # Must be compatible with the standard parser.
     robot example.rst      # reStructuredText parser.
+    robot example.md       # Markdown parser.
     robot x.robot y.rst    # Parse both files using an appropriate parser.
 
 __ `Supported file formats`_
 __ `reStructuredText format`_
+__ `Markdown format`_
 __ `JSON format`_
 __ `Using custom parsers`_
 
@@ -48,6 +51,7 @@ the following rules:
   (:file:`_`) are ignored.
 - :file:`.robot` files are parsed using the normal `Robot Framework parser`__.
 - :file:`.robot.rst` files are parsed using the `reStructuredText parser`__.
+- :file:`.robot.md` files are parsed using the `Markdown parser`__.
 - :file:`.rbt` files are parsed using the `JSON parser`__.
 - Files supported by `custom parsers`__ are parsed by a matching parser.
 - Other files are ignored unless parsing them has been enabled by using
@@ -57,6 +61,7 @@ the following rules:
 __ `Suite directories`_
 __ `Supported file formats`_
 __ `reStructuredText format`_
+__ `Markdown format`_
 __ `JSON format`_
 __ `Using custom parsers`_
 
@@ -98,6 +103,7 @@ even if they by `default would not be`__. What parser to use depends on
 the used extension:
 
 - :file:`.rst` and :file:`.rest` files are parsed using the `reStructuredText parser`__.
+- :file:`.md` and :file:`.markdown` files are parsed using the `Markdown parser`__.
 - :file:`.json` files are parsed using the `JSON parser`__.
 - Other files are parsed using the normal `Robot Framework parser`__.
 
@@ -109,6 +115,7 @@ to quote or escape the pattern like `'*.robot'` or `\*.robot`.
 
 __ `Included and excluded files`_
 __ `reStructuredText format`_
+__ `Markdown format`_
 __ `JSON format`_
 __ `Supported file formats`_
 

--- a/doc/userguide/src/RobotFrameworkUserGuide.rst
+++ b/doc/userguide/src/RobotFrameworkUserGuide.rst
@@ -244,3 +244,5 @@
 .. _XML-RPC: http://www.xmlrpc.com/
 .. _RIDE: https://github.com/robotframework/RIDE
 .. _Slack: http://slack.robotframework.org
+.. _Markdown: https://en.wikipedia.org/wiki/Markdown
+.. _CommonMark: https://spec.commonmark.org


### PR DESCRIPTION
This PR updates the documentation with the Markdown support on embedding tests/task. 

Refers to #5603