### PR TITLE
Remove support to use & as alias for AND with tag patterns

### DIFF
--- a/atest/robot/tags/include_and_exclude.robot
+++ b/atest/robot/tags/include_and_exclude.robot
@@ -124,11 +124,6 @@ Deprecated operator usage
     --exclude    e*ORBAD      OR
     --include    i*NOTBAD     NOT
 
-Deprecated & operator
-    [Template]    Validate deprecated operator warning
-    --include    INCL1&*    &
-    --exclude    e*&*       &
-
 *** Keywords ***
 Run And Check Include And Exclude
     [Arguments]    ${params}    @{expected}    ${sources}=${DATA SOURCES}    ${warnings}=False
@@ -139,14 +134,9 @@ Run And Check Include And Exclude
 Validate deprecated operator warning
     [Arguments]    ${option}    ${pattern}    ${operator}
     Run And Check Include And Exclude    ${option} ${pattern}    @{INCL_ALL}    warnings=True
-    IF    $operator == '&'
-        VAR    ${explanation}
-        ...    Boolean operator '&' is deprecated, use 'AND' instead.
-    ELSE
-        VAR    ${explanation}
-        ...    '${operator}' is currently considered to be a Boolean operator, but in the future
-        ...    operators must be surrounded with spaces or tag names must be lower case.
-    END
+    VAR    ${explanation}
+    ...    '${operator}' is currently considered to be a Boolean operator, but in the future
+    ...    operators must be surrounded with spaces or tag names must be lower case.
     VAR    ${expected}
     ...    Problems when ${{"including" if $option == "--include" else "excluding"}} tests by tags:
     ...    The behavior of tag pattern '${pattern}' will change in Robot Framework 8.0: ${explanation}

--- a/atest/robot/tags/include_and_exclude_with_rebot.robot
+++ b/atest/robot/tags/include_and_exclude_with_rebot.robot
@@ -153,10 +153,6 @@ Deprecated operator usage
     --exclude    e*ORBAD      OR
     --include    i*NOTBAD     NOT
 
-Deprecated & operator
-    [Template]    Validate deprecated operator warning
-    --include    INCL1&*    &
-    --exclude    e*&*       &
 
 *** Keywords ***
 Create Input Files
@@ -182,14 +178,9 @@ Run And Check Include And Exclude
 Validate deprecated operator warning
     [Arguments]    ${option}    ${pattern}    ${operator}
     Run And Check Include And Exclude    ${option} ${pattern}    @{INCL_ALL}    warnings=True
-    IF    $operator == '&'
-        VAR    ${explanation}
-        ...    Boolean operator '&' is deprecated, use 'AND' instead.
-    ELSE
-        VAR    ${explanation}
-        ...    '${operator}' is currently considered to be a Boolean operator, but in the future
-        ...    operators must be surrounded with spaces or tag names must be lower case.
-    END
+    VAR    ${explanation}
+    ...    '${operator}' is currently considered to be a Boolean operator, but in the future
+    ...    operators must be surrounded with spaces or tag names must be lower case.
     VAR    ${expected}
     ...    Problems when ${{"including" if $option == "--include" else "excluding"}} tests by tags:
     ...    The behavior of tag pattern '${pattern}' will change in Robot Framework 8.0: ${explanation}
@@ -203,3 +194,4 @@ Run And Check Error
     ...    [ ERROR ] Suite '${suite name}' contains no tests matching ${filter msg}.
     ...    ${USAGE TIP}\n
     File Should Not Exist    ${OUTFILE}
+    

--- a/atest/robot/tags/include_and_exclude_with_rebot.robot
+++ b/atest/robot/tags/include_and_exclude_with_rebot.robot
@@ -194,4 +194,3 @@ Run And Check Error
     ...    [ ERROR ] Suite '${suite name}' contains no tests matching ${filter msg}.
     ...    ${USAGE TIP}\n
     File Should Not Exist    ${OUTFILE}
-    

--- a/doc/userguide/src/ExecutingTestCases/BasicUsage.rst
+++ b/doc/userguide/src/ExecutingTestCases/BasicUsage.rst
@@ -244,9 +244,6 @@ from highest to lowest, is `AND`, `OR` and `NOT`::
           `xORy`. Using patterns like `XORY` still works with Robot Framework 7.5,
           but such usages are deprecated.
 
-.. note:: Older Robot Framework versions support `&` operator as an alias for `AND`.
-          This was deprecated in Robot Framework 7.5 and the support will be removed
-          in Robot Framework 8.0.
 
 ``ROBOT_OPTIONS`` and ``REBOT_OPTIONS`` environment variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/userguide/src/ExecutingTestCases/BasicUsage.rst
+++ b/doc/userguide/src/ExecutingTestCases/BasicUsage.rst
@@ -244,6 +244,8 @@ from highest to lowest, is `AND`, `OR` and `NOT`::
           `xORy`. Using patterns like `XORY` still works with Robot Framework 7.5,
           but such usages are deprecated.
 
+.. note:: Robot Framework 7.5 supported `&` operator as an alias for `AND`,
+          but this is no longer supported in Robot Framework 8.0.
 
 ``ROBOT_OPTIONS`` and ``REBOT_OPTIONS`` environment variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/robot/model/tags.py
+++ b/src/robot/model/tags.py
@@ -167,14 +167,7 @@ class TagPattern(ABC):
             must_match, *must_not_match = cls._split(pattern, "NOT", usage)
             return NotTagPattern(must_match, must_not_match)
         if "OR" in pattern:
-            return OrTagPattern(cls._split(pattern, "OR", usage))
-        if "&" in pattern:
-            cls._deprecated(
-                pattern,
-                "Boolean operator '&' is deprecated, use 'AND' instead.",
-                usage,
-            )
-            pattern = pattern.replace("&", " AND ")
+            return OrTagPattern(cls._split(pattern, "OR", usage))  
         if "AND" in pattern:
             return AndTagPattern(cls._split(pattern, "AND", usage))
         return SingleTagPattern(pattern)

--- a/utest/model/test_tags.py
+++ b/utest/model/test_tags.py
@@ -236,22 +236,7 @@ class TestTagPatterns(unittest.TestCase):
         assert_false(patterns.match(["x"]))
         assert_false(patterns.match(["x", "y"]))
         assert_true(patterns.match(["x", "Y", "z"]))
-        assert_true(patterns.match(["a", "y", "z", "b", "X"]))
-
-    def test_ampersand_is_deprecated(self):
-        with warnings.catch_warnings(record=True) as w:
-            patterns = TagPatterns(["x&y&z"])
-        assert_equal(w[0].category, UserWarning)
-        assert_equal(
-            str(w[0].message),
-            "The behavior of tag pattern 'x&y&z' will change in Robot Framework 8.0: "
-            "Boolean operator '&' is deprecated, use 'AND' instead.",
-        )
-        assert_false(patterns.match([]))
-        assert_false(patterns.match(["x"]))
-        assert_true(patterns.match(["x", "y", "z"]))
-        assert_false(patterns.match(["y", "z"]))
-        assert_equal(str(patterns[0]), "x AND y AND z")
+        assert_true(patterns.match(["a", "y", "z", "b", "X"]))    
 
     def test_or(self):
         patterns = TagPatterns(["xORy", "???ORz"])


### PR DESCRIPTION
Fixes #5662 
Removes & operator support completely as planned for RF 8.0.

Changes:
Removed & handling block from TagPattern.from_string() in tags.py
Removed test_ampersand_is_deprecated from unit tests
Removed Deprecated & operator test cases from acceptance tests
Updated Validate deprecated operator warning keyword
Removed outdated note from documentation