### PR TITLE
Python 3.14: avoid library import crash with deferred annotations

### DIFF
--- a/atest/robot/keywords/type_conversion/annotations.robot
+++ b/atest/robot/keywords/type_conversion/annotations.robot
@@ -266,8 +266,3 @@ Default value is used if explicit type conversion fails
 
 Explicit conversion failure is used if both conversions fail
     Check Test Case    ${TESTNAME}
-
-Deferred evaluation of annotations
-    [Documentation]    https://peps.python.org/pep-0649
-    [Tags]    require-py3.14
-    Check Test Case    ${TESTNAME}

--- a/atest/robot/keywords/type_conversion/deferred_annotations.robot
+++ b/atest/robot/keywords/type_conversion/deferred_annotations.robot
@@ -1,0 +1,14 @@
+*** Settings ***
+Suite Setup      Run Tests    ${EMPTY}    keywords/type_conversion/deferred_annotations.robot
+Force Tags       require-py3.14
+Resource         atest_resource.robot
+
+*** Test Cases ***
+Type checking annotation
+    Check Test Case    ${TESTNAME}
+
+Type checking annotation with mixed types
+    Check Test Case    ${TESTNAME}
+
+Nonexisting annotation
+    Check Test Case    ${TESTNAME}

--- a/atest/robot/keywords/type_conversion/deferred_annotations.robot
+++ b/atest/robot/keywords/type_conversion/deferred_annotations.robot
@@ -1,14 +1,18 @@
 *** Settings ***
 Suite Setup      Run Tests    ${EMPTY}    keywords/type_conversion/deferred_annotations.robot
-Force Tags       require-py3.14
+Test Tags        require-py3.14
 Resource         atest_resource.robot
 
 *** Test Cases ***
+Deferred evaluation of annotations
+    [Documentation]    https://peps.python.org/pep-0649
+    Check Test Case    ${TESTNAME}
+
 Type checking annotation
     Check Test Case    ${TESTNAME}
 
-Type checking annotation with mixed types
+Nonexisting annotation
     Check Test Case    ${TESTNAME}
 
-Nonexisting annotation
+Type checking annotation with parameterized generic
     Check Test Case    ${TESTNAME}

--- a/atest/testdata/keywords/type_conversion/DeferredAnnotations.py
+++ b/atest/testdata/keywords/type_conversion/DeferredAnnotations.py
@@ -1,14 +1,23 @@
+from typing import TYPE_CHECKING
+
 from robot.api.deco import library
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class Library:
-
     def deferred_evaluation_of_annotations(self, arg: Argument) -> str:  # noqa: F821
         return arg.value
 
+    def type_checking_annotation(self, seq: Sequence[int]) -> int:  # noqa: F821
+        return sum(seq)
+
+    def nonexisting_annotation(self, arg: NonExisting):  # noqa: F821
+        return arg
+
 
 class Argument:
-
     def __init__(self, value: str):
         self.value = value
 

--- a/atest/testdata/keywords/type_conversion/DeferredAnnotations.py
+++ b/atest/testdata/keywords/type_conversion/DeferredAnnotations.py
@@ -3,21 +3,26 @@ from typing import TYPE_CHECKING
 from robot.api.deco import library
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from typing import Sequence
+    class TypeCheckingOnly: ...
 
 
 class Library:
+
     def deferred_evaluation_of_annotations(self, arg: Argument) -> str:  # noqa: F821
         return arg.value
 
-    def type_checking_annotation(self, seq: Sequence[int]) -> int:  # noqa: F821
-        return sum(seq)
+    def type_checking_annotation(self, arg: TypeCheckingOnly) -> TypeCheckingOnly:  # noqa: F821
+        return arg
 
     def nonexisting_annotation(self, arg: NonExisting):  # noqa: F821
         return arg
 
+    def my_sum(self, seq: Sequence[int]) -> int:  # noqa: F821
+        return sum(seq)
 
 class Argument:
+
     def __init__(self, value: str):
         self.value = value
 

--- a/atest/testdata/keywords/type_conversion/annotations.robot
+++ b/atest/testdata/keywords/type_conversion/annotations.robot
@@ -1,6 +1,5 @@
 *** Settings ***
 Library                  Annotations.py
-Library                  DeferredAnnotations.py
 Library                  OperatingSystem
 Resource                 conversion.resource
 
@@ -705,8 +704,3 @@ Explicit conversion failure is used if both conversions fail
     [Template]    Conversion Should Fail
     Type and default 4                             BANG!                 type=list         error=Invalid expression.
     Type and default 3                             BANG!                 type=timedelta    error=Invalid time string 'BANG!'.
-
-Deferred evaluation of annotations
-    [Tags]    require-py3.14
-    ${value} =    Deferred evaluation of annotations    PEP 649
-    Should be equal    ${value}    PEP 649

--- a/atest/testdata/keywords/type_conversion/deferred_annotations.robot
+++ b/atest/testdata/keywords/type_conversion/deferred_annotations.robot
@@ -2,19 +2,18 @@
 Library    DeferredAnnotations.py
 
 *** Test Cases ***
-Type checking annotation
-    [Tags]    require-py3.14
-    ${result} =    Type checking annotation    [1, 2]
-    Should Be Equal    ${result}    ${3}
+Deferred evaluation of annotations
+    ${value} =    Deferred evaluation of annotations    PEP 649
+    Should be equal    ${value}    PEP 649
 
-Type checking annotation with mixed types
-    [Tags]    require-py3.14
-    ${result} =    Type checking annotation    [1, "2"]
-    Should Be Equal    ${result}    ${3}
+Type checking annotation
+    ${result} =    Type checking annotation    ${1}
+    Should Be Equal    ${result}    ${1}
 
 Nonexisting annotation
-    [Tags]    require-py3.14
     ${result} =    Nonexisting annotation    hello
     Should Be Equal    ${result}    hello
 
-
+Type checking annotation with parameterized generic
+    ${result} =    My Sum    [1, "2"]
+    Should Be Equal    ${result}    ${3}

--- a/atest/testdata/keywords/type_conversion/deferred_annotations.robot
+++ b/atest/testdata/keywords/type_conversion/deferred_annotations.robot
@@ -1,0 +1,20 @@
+*** Settings ***
+Library    DeferredAnnotations.py
+
+*** Test Cases ***
+Type checking annotation
+    [Tags]    require-py3.14
+    ${result} =    Type checking annotation    [1, 2]
+    Should Be Equal    ${result}    ${3}
+
+Type checking annotation with mixed types
+    [Tags]    require-py3.14
+    ${result} =    Type checking annotation    [1, "2"]
+    Should Be Equal    ${result}    ${3}
+
+Nonexisting annotation
+    [Tags]    require-py3.14
+    ${result} =    Nonexisting annotation    hello
+    Should Be Equal    ${result}    hello
+
+

--- a/src/robot/running/arguments/argumentparser.py
+++ b/src/robot/running/arguments/argumentparser.py
@@ -122,15 +122,13 @@ class PythonArgumentParser(ArgumentParser):
         try:
             return get_type_hints(method)
         except Exception:  # Can raise pretty much anything
-            # Prefer raw annotations to preserve behavior with existing forward
-            # references like Union["nonex", ...] used in current tests.
             try:
                 # Not all functions have `__annotations__`.
                 # https://github.com/robotframework/robotframework/issues/4059
                 return getattr(method, "__annotations__", {})
             except Exception:
-                # With deferred annotations on Python 3.14, evaluating
-                # `__annotations__` itself can fail (e.g. TYPE_CHECKING-only imports).
+                # Handle deferred annotations on Python 3.14.
+                # https://github.com/robotframework/robotframework/issues/5658
                 if Format:
                     return get_type_hints(method, format=Format.STRING)
                 return {}

--- a/src/robot/running/arguments/argumentparser.py
+++ b/src/robot/running/arguments/argumentparser.py
@@ -17,6 +17,11 @@ from abc import ABC, abstractmethod
 from inspect import isclass, Parameter, signature
 from typing import Any, Callable, get_type_hints
 
+try:
+    from annotationlib import Format
+except ImportError:
+    Format = None
+
 from robot.errors import DataError
 from robot.utils import NOT_SET, split_from_equals
 from robot.variables import search_variable
@@ -50,7 +55,8 @@ class PythonArgumentParser(ArgumentParser):
 
     def parse(self, method, name=None):
         try:
-            sig = signature(method)
+            config = {"annotation_format": Format.FORWARDREF} if Format else {}
+            sig = signature(method, **config)
         except ValueError:  # Can occur with C functions (incl. many builtins).
             return ArgumentSpec(name, self.type, var_positional="args")
         except TypeError as err:  # Occurs if handler isn't actually callable.
@@ -116,9 +122,18 @@ class PythonArgumentParser(ArgumentParser):
         try:
             return get_type_hints(method)
         except Exception:  # Can raise pretty much anything
-            # Not all functions have `__annotations__`.
-            # https://github.com/robotframework/robotframework/issues/4059
-            return getattr(method, "__annotations__", {})
+            # Prefer raw annotations to preserve behavior with existing forward
+            # references like Union["nonex", ...] used in current tests.
+            try:
+                # Not all functions have `__annotations__`.
+                # https://github.com/robotframework/robotframework/issues/4059
+                return getattr(method, "__annotations__", {})
+            except Exception:
+                # With deferred annotations on Python 3.14, evaluating
+                # `__annotations__` itself can fail (e.g. TYPE_CHECKING-only imports).
+                if Format:
+                    return get_type_hints(method, format=Format.STRING)
+                return {}
 
 
 class ArgumentSpecParser(ArgumentParser):


### PR DESCRIPTION
Issue: https://github.com/robotframework/robotframework/issues/5658

This PR fixes a Python 3.14 compatibility issue where library import can fail when Robot inspects keyword annotations.

On Python 3.14, `inspect.signature()` may evaluate annotations while creating keywords. That causes problems with deferred annotations such as names imported only under `TYPE_CHECKING`, and more generally with annotations that cannot be resolved at introspection time.

The fix uses `annotationlib.Format.FORWARDREF` with `inspect.signature()` on Python 3.14 to avoid the import-time crash.

For type hints, the fallback logic needs to preserve existing behavior with annotations like `Union["nonex", "references"]`. Because of that, `_get_types()` now first tries normal `get_type_hints()`, then falls back to raw `__annotations__`, and only if accessing `__annotations__` itself fails does it use `get_type_hints(..., format=Format.STRING)`.

The PR also adds acceptance tests for deferred annotations covering:
- `TYPE_CHECKING`-only generic annotations
- non-existing annotations