### PR TITLE
ConsoleOutput: Replace LoggerApi by ListenerFacade inheritance 

### DIFF
--- a/src/robot/conf/settings.py
+++ b/src/robot/conf/settings.py
@@ -646,6 +646,7 @@ class RobotSettings(_BaseSettings):
             "markers": self.console_markers,
             "stdout": self["StdOut"],
             "stderr": self["StdErr"],
+            "log_level": self.log_level,
         }
 
     @property
@@ -771,6 +772,7 @@ class RebotSettings(_BaseSettings):
             "links": self.console_links,
             "stdout": self["StdOut"],
             "stderr": self["StdErr"],
+            "log_level": self.log_level,
         }
 
     @property

--- a/src/robot/output/console/dotted.py
+++ b/src/robot/output/console/dotted.py
@@ -14,19 +14,19 @@
 #  limitations under the License.
 
 import sys
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import Literal, TYPE_CHECKING
 
 from robot.model import SuiteVisitor
 from robot.utils import plural_or_not as s, secs_to_timestr
 
-from ..loggerapi import LoggerApi
 from .highlighting import HighlightingStream
 
 if TYPE_CHECKING:
     from robot.result import TestCase, TestSuite
 
 
-class DottedOutput(LoggerApi):
+class DottedOutput:
 
     def __init__(self, width=78, colors="AUTO", links="AUTO", stdout=None, stderr=None):
         self.width = width
@@ -65,7 +65,26 @@ class DottedOutput(LoggerApi):
         if msg.level in ("WARN", "ERROR") and msg.console:
             self.stderr.error(msg.message, msg.level)
 
-    def result_file(self, kind, path):
+    def output_file(self, path: "Path"):
+        self.result_file("Output", path)
+
+    def report_file(self, path: "Path"):
+        self.result_file("Report", path)
+
+    def log_file(self, path: "Path"):
+        self.result_file("Log", path)
+
+    def xunit_file(self, path: "Path"):
+        self.result_file("XUnit", path)
+
+    def debug_file(self, path: "Path"):
+        self.result_file("Debug", path)
+
+    def result_file(
+        self,
+        kind: "Literal['Output', 'Report', 'Log', 'XUnit', 'Debug']",
+        path: "Path",
+    ):
         self.stdout.result_file(kind, path)
 
 

--- a/src/robot/output/console/quiet.py
+++ b/src/robot/output/console/quiet.py
@@ -14,12 +14,13 @@
 #  limitations under the License.
 
 import sys
+from pathlib import Path
+from typing import Literal
 
-from ..loggerapi import LoggerApi
 from .highlighting import HighlightingStream
 
 
-class QuietOutput(LoggerApi):
+class QuietOutput:
 
     def __init__(self, colors="AUTO", stderr=None):
         self._stderr = HighlightingStream(stderr or sys.__stderr__, colors)
@@ -28,6 +29,57 @@ class QuietOutput(LoggerApi):
         if msg.level in ("WARN", "ERROR") and msg.console:
             self._stderr.error(msg.message, msg.level)
 
+    def output_file(self, path):
+        pass
 
-class NoOutput(LoggerApi):
-    pass
+    def report_file(self, path):
+        pass
+
+    def log_file(self, path):
+        pass
+
+    def xunit_file(self, path):
+        pass
+
+    def debug_file(self, path):
+        pass
+
+    def result_file(
+        self,
+        kind: "Literal['Output', 'Report', 'Log', 'XUnit', 'Debug']",
+        path: "Path",
+    ):
+        result_file = getattr(self, f"{kind.lower()}_file", None)
+        if result_file:
+            result_file(path)
+
+
+class NoOutput:
+
+    def message(self, msg):
+        pass
+
+    def log_message(self, msg):
+        pass
+
+    def output_file(self, path):
+        pass
+
+    def report_file(self, path):
+        pass
+
+    def log_file(self, path):
+        pass
+
+    def xunit_file(self, path):
+        pass
+
+    def debug_file(self, path):
+        pass
+
+    def result_file(
+        self,
+        kind: "Literal['Output', 'Report', 'Log', 'XUnit', 'Debug']",
+        path: "Path",
+    ):
+        pass

--- a/src/robot/output/console/verbose.py
+++ b/src/robot/output/console/verbose.py
@@ -14,15 +14,19 @@
 #  limitations under the License.
 
 import sys
+from pathlib import Path
+from typing import Literal, TYPE_CHECKING
 
 from robot.errors import DataError
 from robot.utils import get_console_length, getshortdoc, isatty, pad_console_length
 
-from ..loggerapi import LoggerApi
 from .highlighting import HighlightingStream
 
+if TYPE_CHECKING:
+    from robot import result, running
 
-class VerboseOutput(LoggerApi):
+
+class VerboseOutput:
 
     def __init__(
         self,
@@ -73,7 +77,32 @@ class VerboseOutput(LoggerApi):
         if msg.level in ("WARN", "ERROR") and msg.console:
             self.writer.error(msg.message, msg.level, clear=self.running_test)
 
-    def result_file(self, kind, path):
+    def start_keyword(self, data: "running.Keyword", result: "result.Keyword"):
+        self.start_body_item(data, result)
+
+    def end_keyword(self, data: "running.Keyword", result: "result.Keyword"):
+        self.end_body_item(data, result)
+
+    def output_file(self, path: "Path"):
+        self.result_file("Output", path)
+
+    def report_file(self, path: "Path"):
+        self.result_file("Report", path)
+
+    def log_file(self, path: "Path"):
+        self.result_file("Log", path)
+
+    def xunit_file(self, path: "Path"):
+        self.result_file("XUnit", path)
+
+    def debug_file(self, path: "Path"):
+        self.result_file("Debug", path)
+
+    def result_file(
+        self,
+        kind: "Literal['Output', 'Report', 'Log', 'XUnit', 'Debug']",
+        path: "Path",
+    ):
         self.writer.result_file(kind, path)
 
 

--- a/src/robot/output/listenerfacade.py
+++ b/src/robot/output/listenerfacade.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from abc import ABC
 from collections.abc import Callable
+from pathlib import Path
 
 from robot.errors import DataError
 from robot.model import BodyItem
@@ -431,19 +432,19 @@ class ListenerV2Facade(ListenerFacade):
             },
         )
 
-    def output_file(self, path):
+    def output_file(self, path: Path):
         self._output_file(str(path))
 
-    def report_file(self, path):
+    def report_file(self, path: Path):
         self._report_file(str(path))
 
-    def log_file(self, path):
+    def log_file(self, path: Path):
         self._log_file(str(path))
 
-    def xunit_file(self, path):
+    def xunit_file(self, path: Path):
         self._xunit_file(str(path))
 
-    def debug_file(self, path):
+    def debug_file(self, path: Path):
         self._debug_file(str(path))
 
     def _suite_attrs(self, data, result, end=False):

--- a/src/robot/output/listenerfacade.py
+++ b/src/robot/output/listenerfacade.py
@@ -1,0 +1,575 @@
+#  Copyright 2008-2015 Nokia Networks
+#  Copyright 2016-     Robot Framework Foundation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from abc import ABC
+from collections.abc import Callable
+
+from robot.errors import DataError
+from robot.model import BodyItem
+from robot.utils import get_error_details, safe_str, type_name
+
+from .loggerapi import LoggerApi
+from .loglevel import LogLevel, SettableLevel
+
+
+class ListenerFacade(LoggerApi, ABC):
+
+    def __init__(
+        self,
+        listener,
+        name,
+        log_level,
+        library=None,
+        error: Callable[[str], object] | None = None,
+        info: Callable[[str], object] | None = None,
+    ):
+        self.listener = listener
+        self.name = name
+        self._is_logged = log_level.is_logged
+        self.library = library
+        self.priority = self._get_priority(listener)
+        self._error = error
+        self._info = info
+
+    def _get_priority(self, listener):
+        priority = getattr(listener, "ROBOT_LISTENER_PRIORITY", 0)
+        if isinstance(priority, (int, float)):
+            return priority
+        try:
+            try:
+                return int(priority)
+            except ValueError:
+                return float(priority)
+        except (ValueError, TypeError):
+            raise DataError(f"Invalid listener priority '{priority}'.")
+
+    @classmethod
+    def from_object(
+        cls,
+        listener: object,
+        log_level: "LogLevel | SettableLevel" = "INFO",
+        library: object = None,
+        error: Callable[[str], object] | None = None,
+        info: Callable[[str], object] | None = None,
+        name: str | None = None,
+    ) -> "ListenerFacade":
+        if isinstance(log_level, str):
+            log_level = LogLevel(log_level)
+        name = name or getattr(listener, "__name__", None) or type_name(listener)
+        if cls._get_version(listener) == 2:
+            return ListenerV2Facade(listener, name, log_level, library, error, info)
+        return ListenerV3Facade(listener, name, log_level, library, error, info)
+
+    @classmethod
+    def _get_version(cls, listener):
+        version = getattr(listener, "ROBOT_LISTENER_API_VERSION", 3)
+        try:
+            version = int(version)
+            if version not in (2, 3):
+                raise ValueError
+        except (ValueError, TypeError):
+            raise DataError(f"Unsupported API version '{version}'.")
+        return version
+
+    def _get_method(self, name, fallback=None):
+        for method_name in self._get_method_names(name):
+            method = getattr(self.listener, method_name, None)
+            if method:
+                return ListenerMethod(method, self.name, self._error, self._info)
+        return fallback or ListenerMethod(None, self.name, self._error, self._info)
+
+    def _get_method_names(self, name):
+        names = [name, self._to_camelCase(name)] if "_" in name else [name]
+        if self.library is not None:
+            names += ["_" + name for name in names]
+        return names
+
+    def _to_camelCase(self, name):
+        first, *rest = name.split("_")
+        return "".join([first] + [part.capitalize() for part in rest])
+
+
+class ListenerV3Facade(ListenerFacade):
+
+    def __init__(
+        self,
+        listener,
+        name,
+        log_level,
+        library=None,
+        error=None,
+        info=None,
+    ):
+        super().__init__(listener, name, log_level, library, error, info)
+        get = self._get_method
+        # Suite
+        self.start_suite = get("start_suite")
+        self.end_suite = get("end_suite")
+        # Test
+        self.start_test = get("start_test")
+        self.end_test = get("end_test")
+        # Fallbacks for body items
+        start_body_item = get("start_body_item")
+        end_body_item = get("end_body_item")
+        # Fallbacks for keywords
+        start_keyword = get("start_keyword", start_body_item)
+        end_keyword = get("end_keyword", end_body_item)
+        # Keywords
+        self.start_user_keyword = get(
+            "start_user_keyword",
+            lambda data, implementation, result: start_keyword(data, result),
+        )
+        self.end_user_keyword = get(
+            "end_user_keyword",
+            lambda data, implementation, result: end_keyword(data, result),
+        )
+        self.start_library_keyword = get(
+            "start_library_keyword",
+            lambda data, implementation, result: start_keyword(data, result),
+        )
+        self.end_library_keyword = get(
+            "end_library_keyword",
+            lambda data, implementation, result: end_keyword(data, result),
+        )
+        self.start_invalid_keyword = get(
+            "start_invalid_keyword",
+            lambda data, implementation, result: start_keyword(data, result),
+        )
+        self.end_invalid_keyword = get(
+            "end_invalid_keyword",
+            lambda data, implementation, result: end_keyword(data, result),
+        )
+        # IF
+        self.start_if = get("start_if", start_body_item)
+        self.end_if = get("end_if", end_body_item)
+        self.start_if_branch = get("start_if_branch", start_body_item)
+        self.end_if_branch = get("end_if_branch", end_body_item)
+        # TRY
+        self.start_try = get("start_try", start_body_item)
+        self.end_try = get("end_try", end_body_item)
+        self.start_try_branch = get("start_try_branch", start_body_item)
+        self.end_try_branch = get("end_try_branch", end_body_item)
+        # FOR
+        self.start_for = get("start_for", start_body_item)
+        self.end_for = get("end_for", end_body_item)
+        self.start_for_iteration = get("start_for_iteration", start_body_item)
+        self.end_for_iteration = get("end_for_iteration", end_body_item)
+        # WHILE
+        self.start_while = get("start_while", start_body_item)
+        self.end_while = get("end_while", end_body_item)
+        self.start_while_iteration = get("start_while_iteration", start_body_item)
+        self.end_while_iteration = get("end_while_iteration", end_body_item)
+        # GROUP
+        self.start_group = get("start_group", start_body_item)
+        self.end_group = get("end_group", end_body_item)
+        # VAR
+        self.start_var = get("start_var", start_body_item)
+        self.end_var = get("end_var", end_body_item)
+        # BREAK
+        self.start_break = get("start_break", start_body_item)
+        self.end_break = get("end_break", end_body_item)
+        # CONTINUE
+        self.start_continue = get("start_continue", start_body_item)
+        self.end_continue = get("end_continue", end_body_item)
+        # RETURN
+        self.start_return = get("start_return", start_body_item)
+        self.end_return = get("end_return", end_body_item)
+        # ERROR
+        self.start_error = get("start_error", start_body_item)
+        self.end_error = get("end_error", end_body_item)
+        # Messages
+        self._log_message = get("log_message")
+        self.message = get("message")
+        # Imports
+        self.library_import = get("library_import")
+        self.resource_import = get("resource_import")
+        self.variables_import = get("variables_import")
+        # Result files
+        self.output_file = get("output_file")
+        self.report_file = get("report_file")
+        self.log_file = get("log_file")
+        self.xunit_file = get("xunit_file")
+        self.debug_file = get("debug_file")
+        # Close
+        self.close = get("close")
+
+    def log_message(self, message):
+        if self._is_logged(message):
+            self._log_message(message)
+
+
+class ListenerV2Facade(ListenerFacade):
+
+    def __init__(
+        self,
+        listener,
+        name,
+        log_level,
+        library=None,
+        error=None,
+        info=None,
+    ):
+        super().__init__(listener, name, log_level, library, error, info)
+        get = self._get_method
+        # Suite
+        self._start_suite = get("start_suite")
+        self._end_suite = get("end_suite")
+        # Test
+        self._start_test = get("start_test")
+        self._end_test = get("end_test")
+        # Keyword and control structures
+        self._start_kw = get("start_keyword")
+        self._end_kw = get("end_keyword")
+        # Messages
+        self._log_message = get("log_message")
+        self._message = get("message")
+        # Imports
+        self._library_import = get("library_import")
+        self._resource_import = get("resource_import")
+        self._variables_import = get("variables_import")
+        # Result files
+        self._output_file = get("output_file")
+        self._report_file = get("report_file")
+        self._log_file = get("log_file")
+        self._xunit_file = get("xunit_file")
+        self._debug_file = get("debug_file")
+        # Close
+        self._close = get("close")
+
+    def start_suite(self, data, result):
+        self._start_suite(result.name, self._suite_attrs(data, result))
+
+    def end_suite(self, data, result):
+        self._end_suite(result.name, self._suite_attrs(data, result, end=True))
+
+    def start_test(self, data, result):
+        self._start_test(result.name, self._test_attrs(data, result))
+
+    def end_test(self, data, result):
+        self._end_test(result.name, self._test_attrs(data, result, end=True))
+
+    def start_keyword(self, data, result):
+        self._start_kw(result.full_name, self._keyword_attrs(data, result))
+
+    def end_keyword(self, data, result):
+        self._end_kw(result.full_name, self._keyword_attrs(data, result, end=True))
+
+    def start_for(self, data, result):
+        extra = self._for_extra_attrs(result)
+        self._start_kw(result._log_name, self._attrs(data, result, **extra))
+
+    def end_for(self, data, result):
+        extra = self._for_extra_attrs(result)
+        self._end_kw(result._log_name, self._attrs(data, result, **extra, end=True))
+
+    def _for_extra_attrs(self, result):
+        extra = {
+            "variables": list(result.assign),
+            "flavor": result.flavor or "",
+            "values": list(result.values),
+        }
+        if result.flavor == "IN ENUMERATE":
+            extra["start"] = result.start
+        elif result.flavor == "IN ZIP":
+            extra["fill"] = result.fill
+            extra["mode"] = result.mode
+        return extra
+
+    def start_for_iteration(self, data, result):
+        attrs = self._attrs(data, result, variables=dict(result.assign))
+        self._start_kw(result._log_name, attrs)
+
+    def end_for_iteration(self, data, result):
+        attrs = self._attrs(data, result, variables=dict(result.assign), end=True)
+        self._end_kw(result._log_name, attrs)
+
+    def start_while(self, data, result):
+        attrs = self._attrs(
+            data,
+            result,
+            condition=result.condition,
+            limit=result.limit,
+            on_limit=result.on_limit,
+            on_limit_message=result.on_limit_message,
+        )
+        self._start_kw(result._log_name, attrs)
+
+    def end_while(self, data, result):
+        attrs = self._attrs(
+            data,
+            result,
+            condition=result.condition,
+            limit=result.limit,
+            on_limit=result.on_limit,
+            on_limit_message=result.on_limit_message,
+            end=True,
+        )
+        self._end_kw(result._log_name, attrs)
+
+    def start_while_iteration(self, data, result):
+        self._start_kw(result._log_name, self._attrs(data, result))
+
+    def end_while_iteration(self, data, result):
+        self._end_kw(result._log_name, self._attrs(data, result, end=True))
+
+    def start_group(self, data, result):
+        self._start_kw(result._log_name, self._attrs(data, result, name=result.name))
+
+    def end_group(self, data, result):
+        attrs = self._attrs(data, result, name=result.name, end=True)
+        self._end_kw(result._log_name, attrs)
+
+    def start_if_branch(self, data, result):
+        extra = {"condition": result.condition} if result.type != result.ELSE else {}
+        self._start_kw(result._log_name, self._attrs(data, result, **extra))
+
+    def end_if_branch(self, data, result):
+        extra = {"condition": result.condition} if result.type != result.ELSE else {}
+        self._end_kw(result._log_name, self._attrs(data, result, **extra, end=True))
+
+    def start_try_branch(self, data, result):
+        extra = self._try_extra_attrs(result)
+        self._start_kw(result._log_name, self._attrs(data, result, **extra))
+
+    def end_try_branch(self, data, result):
+        extra = self._try_extra_attrs(result)
+        self._end_kw(result._log_name, self._attrs(data, result, **extra, end=True))
+
+    def _try_extra_attrs(self, result):
+        if result.type == BodyItem.EXCEPT:
+            return {
+                "patterns": list(result.patterns),
+                "pattern_type": result.pattern_type,
+                "variable": result.assign,
+            }
+        return {}
+
+    def start_return(self, data, result):
+        attrs = self._attrs(data, result, values=list(result.values))
+        self._start_kw(result._log_name, attrs)
+
+    def end_return(self, data, result):
+        attrs = self._attrs(data, result, values=list(result.values), end=True)
+        self._end_kw(result._log_name, attrs)
+
+    def start_continue(self, data, result):
+        self._start_kw(result._log_name, self._attrs(data, result))
+
+    def end_continue(self, data, result):
+        self._end_kw(result._log_name, self._attrs(data, result, end=True))
+
+    def start_break(self, data, result):
+        self._start_kw(result._log_name, self._attrs(data, result))
+
+    def end_break(self, data, result):
+        self._end_kw(result._log_name, self._attrs(data, result, end=True))
+
+    def start_error(self, data, result):
+        self._start_kw(result._log_name, self._attrs(data, result))
+
+    def end_error(self, data, result):
+        self._end_kw(result._log_name, self._attrs(data, result, end=True))
+
+    def start_var(self, data, result):
+        extra = self._var_extra_attrs(result)
+        self._start_kw(result._log_name, self._attrs(data, result, **extra))
+
+    def end_var(self, data, result):
+        extra = self._var_extra_attrs(result)
+        self._end_kw(result._log_name, self._attrs(data, result, **extra, end=True))
+
+    def _var_extra_attrs(self, result):
+        if result.name.startswith("$"):
+            value = (result.separator or " ").join(result.value)
+        else:
+            value = list(result.value)
+        return {"name": result.name, "value": value, "scope": result.scope or "LOCAL"}
+
+    def log_message(self, message):
+        if self._is_logged(message):
+            self._log_message(self._message_attributes(message))
+
+    def message(self, message):
+        self._message(self._message_attributes(message))
+
+    def library_import(self, library, importer):
+        attrs = {
+            "args": list(importer.args),
+            "originalname": library.real_name,
+            "source": str(library.source or ""),
+            "importer": str(importer.source),
+        }
+        self._library_import(library.name, attrs)
+
+    def resource_import(self, resource, importer):
+        self._resource_import(
+            resource.name,
+            {"source": str(resource.source), "importer": str(importer.source)},
+        )
+
+    def variables_import(self, attrs: dict, importer):
+        self._variables_import(
+            attrs["name"],
+            {
+                "args": list(attrs["args"]),
+                "source": str(attrs["source"]),
+                "importer": str(importer.source),
+            },
+        )
+
+    def output_file(self, path):
+        self._output_file(str(path))
+
+    def report_file(self, path):
+        self._report_file(str(path))
+
+    def log_file(self, path):
+        self._log_file(str(path))
+
+    def xunit_file(self, path):
+        self._xunit_file(str(path))
+
+    def debug_file(self, path):
+        self._debug_file(str(path))
+
+    def _suite_attrs(self, data, result, end=False):
+        attrs = dict(
+            id=data.id,
+            doc=result.doc,
+            metadata=dict(result.metadata),
+            starttime=result.starttime,
+            longname=result.full_name,
+            tests=[t.name for t in data.tests],
+            suites=[s.name for s in data.suites],
+            totaltests=data.test_count,
+            source=str(data.source or ""),
+        )
+        if end:
+            attrs.update(
+                endtime=result.endtime,
+                elapsedtime=result.elapsedtime,
+                status=result.status,
+                message=result.message,
+                statistics=result.stat_message,
+            )
+        return attrs
+
+    def _test_attrs(self, data, result, end=False):
+        attrs = dict(
+            id=data.id,
+            doc=result.doc,
+            tags=list(result.tags),
+            lineno=data.lineno,
+            starttime=result.starttime,
+            longname=result.full_name,
+            source=str(data.source or ""),
+            template=data.template or "",
+            originalname=data.name,
+        )
+        if end:
+            attrs.update(
+                endtime=result.endtime,
+                elapsedtime=result.elapsedtime,
+                status=result.status,
+                message=result.message,
+            )
+        return attrs
+
+    def _keyword_attrs(self, data, result, end=False):
+        attrs = dict(
+            doc=result.doc,
+            lineno=data.lineno,
+            type=result.type,
+            status=result.status,
+            starttime=result.starttime,
+            source=str(data.source or ""),
+            kwname=result.name or "",
+            libname=result.owner or "",
+            args=[a if isinstance(a, str) else safe_str(a) for a in result.args],
+            assign=list(result.assign),
+            tags=list(result.tags),
+        )
+        if end:
+            attrs.update(
+                endtime=result.endtime,
+                elapsedtime=result.elapsedtime,
+            )
+        return attrs
+
+    def _attrs(self, data, result, end=False, **extra):
+        attrs = dict(
+            doc="",
+            lineno=data.lineno,
+            type=result.type,
+            status=result.status,
+            starttime=result.starttime,
+            source=str(data.source or ""),
+            kwname=result._log_name,
+            libname="",
+            args=[],
+            assign=[],
+            tags=[],
+            **extra,
+        )
+        if end:
+            attrs.update(
+                endtime=result.endtime,
+                elapsedtime=result.elapsedtime,
+            )
+        return attrs
+
+    def _message_attributes(self, msg):
+        ts = msg.timestamp.isoformat(" ", timespec="milliseconds").replace("-", "")
+        return {
+            "timestamp": ts,
+            "message": msg.message,
+            "level": msg.level,
+            "html": "yes" if msg.html else "no",
+        }
+
+    def close(self):
+        self._close()
+
+
+class ListenerMethod:
+
+    def __init__(
+        self,
+        method,
+        name,
+        error: Callable[[str], object] | None = None,
+        info: Callable[[str], object] | None = None,
+    ):
+        self.method = method
+        self.listener_name = name
+        self._error = error
+        self._info = info
+
+    def __call__(self, *args):
+        try:
+            if self.method is not None:
+                self.method(*args)
+        except Exception:
+            message, details = get_error_details()
+            if self._error:
+                self._error(
+                    f"Calling method '{self.method.__name__}' of listener "
+                    f"'{self.listener_name}' failed: {message}"
+                )
+            if self._info:
+                self._info(f"Details:\n{details}")
+
+    def __bool__(self):
+        return self.method is not None

--- a/src/robot/output/listenerfacade.py
+++ b/src/robot/output/listenerfacade.py
@@ -33,18 +33,18 @@ class ListenerFacade(LoggerApi, ABC):
         self,
         listener,
         name,
+        error_logger: Callable[[str], object],
+        info_logger: Callable[[str], object],
         log_level,
         library=None,
-        error: Callable[[str], object] | None = None,
-        info: Callable[[str], object] | None = None,
     ):
         self.listener = listener
         self.name = name
         self._is_logged = log_level.is_logged
         self.library = library
         self.priority = self._get_priority(listener)
-        self._error = error
-        self._info = info
+        self._error_logger = error_logger
+        self._info_logger = info_logger
 
     def _get_priority(self, listener):
         priority = getattr(listener, "ROBOT_LISTENER_PRIORITY", 0)
@@ -62,18 +62,32 @@ class ListenerFacade(LoggerApi, ABC):
     def from_object(
         cls,
         listener: object,
+        error_logger: Callable[[str], object],
+        info_logger: Callable[[str], object],
         log_level: "LogLevel | SettableLevel" = "INFO",
         library: object = None,
-        error: Callable[[str], object] | None = None,
-        info: Callable[[str], object] | None = None,
         name: str | None = None,
     ) -> "ListenerFacade":
         if isinstance(log_level, str):
             log_level = LogLevel(log_level)
         name = name or getattr(listener, "__name__", None) or type_name(listener)
         if cls._get_version(listener) == 2:
-            return ListenerV2Facade(listener, name, log_level, library, error, info)
-        return ListenerV3Facade(listener, name, log_level, library, error, info)
+            return ListenerV2Facade(
+                listener,
+                name,
+                error_logger,
+                info_logger,
+                log_level,
+                library,
+            )
+        return ListenerV3Facade(
+            listener,
+            name,
+            error_logger,
+            info_logger,
+            log_level,
+            library,
+        )
 
     @classmethod
     def _get_version(cls, listener):
@@ -90,8 +104,8 @@ class ListenerFacade(LoggerApi, ABC):
         for method_name in self._get_method_names(name):
             method = getattr(self.listener, method_name, None)
             if method:
-                return ListenerMethod(method, self.name, self._error, self._info)
-        return fallback or ListenerMethod(None, self.name, self._error, self._info)
+                return ListenerMethod(method, self.name, self._error_logger, self._info_logger)
+        return fallback or ListenerMethod(None, self.name, self._error_logger, self._info_logger)
 
     def _get_method_names(self, name):
         names = [name, self._to_camelCase(name)] if "_" in name else [name]
@@ -110,12 +124,12 @@ class ListenerV3Facade(ListenerFacade):
         self,
         listener,
         name,
+        error_logger: Callable[[str], object],
+        info_logger: Callable[[str], object],
         log_level,
         library=None,
-        error=None,
-        info=None,
     ):
-        super().__init__(listener, name, log_level, library, error, info)
+        super().__init__(listener, name, error_logger, info_logger, log_level, library)
         get = self._get_method
         # Suite
         self.start_suite = get("start_suite")
@@ -219,12 +233,12 @@ class ListenerV2Facade(ListenerFacade):
         self,
         listener,
         name,
+        error_logger: Callable[[str], object],
+        info_logger: Callable[[str], object],
         log_level,
         library=None,
-        error=None,
-        info=None,
     ):
-        super().__init__(listener, name, log_level, library, error, info)
+        super().__init__(listener, name, error_logger, info_logger, log_level, library)
         get = self._get_method
         # Suite
         self._start_suite = get("start_suite")
@@ -552,13 +566,13 @@ class ListenerMethod:
         self,
         method,
         name,
-        error: Callable[[str], object] | None = None,
-        info: Callable[[str], object] | None = None,
+        error_logger: Callable[[str], object],
+        info_logger: Callable[[str], object],
     ):
         self.method = method
         self.listener_name = name
-        self._error = error
-        self._info = info
+        self._error_logger = error_logger
+        self._info_logger = info_logger
 
     def __call__(self, *args):
         try:
@@ -566,13 +580,11 @@ class ListenerMethod:
                 self.method(*args)
         except Exception:
             message, details = get_error_details()
-            if self._error:
-                self._error(
-                    f"Calling method '{self.method.__name__}' of listener "
-                    f"'{self.listener_name}' failed: {message}"
-                )
-            if self._info:
-                self._info(f"Details:\n{details}")
+            self._error_logger(
+                f"Calling method '{self.method.__name__}' of listener "
+                f"'{self.listener_name}' failed: {message}"
+            )
+            self._info_logger(f"Details:\n{details}")
 
     def __bool__(self):
         return self.method is not None

--- a/src/robot/output/listenerfacade.py
+++ b/src/robot/output/listenerfacade.py
@@ -13,6 +13,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from __future__ import annotations
+
 from abc import ABC
 from collections.abc import Callable
 

--- a/src/robot/output/listeners.py
+++ b/src/robot/output/listeners.py
@@ -103,10 +103,10 @@ def create_listener_facade(
         listener_obj, name = _import_listener(listener)
         return ListenerFacade.from_object(
             listener_obj,
+            LOGGER.error,
+            LOGGER.info,
             log_level,
             library,
-            error=LOGGER.error,
-            info=LOGGER.info,
             name=name,
         )
     except DataError as err:

--- a/src/robot/output/listeners.py
+++ b/src/robot/output/listeners.py
@@ -17,7 +17,7 @@ import os.path
 from collections.abc import Sequence
 
 from robot.errors import DataError
-from robot.utils import Importer, split_args_from_name_or_path
+from robot.utils import Importer, split_args_from_name_or_path, type_name
 
 from .listenerfacade import ListenerFacade
 from .logger import LOGGER
@@ -111,9 +111,7 @@ def create_listener_facade(
             name=name,
         )
     except DataError as err:
-        name = listener if isinstance(listener, str) else getattr(listener, "__name__", None)
-        if not name:
-            name = type(listener).__name__
+        name = listener if isinstance(listener, str) else type_name(listener)
         raise DataError(f"Taking listener '{name}' into use failed: {err}")
 
 

--- a/src/robot/output/listeners.py
+++ b/src/robot/output/listeners.py
@@ -14,23 +14,18 @@
 #  limitations under the License.
 
 import os.path
-from abc import ABC
 from collections.abc import Sequence
-from pathlib import Path
 
 from robot.errors import DataError
-from robot.model import BodyItem
-from robot.utils import (
-    get_error_details, Importer, safe_str, split_args_from_name_or_path, type_name
-)
+from robot.utils import Importer, split_args_from_name_or_path
 
+from .listenerfacade import ListenerFacade
 from .logger import LOGGER
-from .loggerapi import LoggerApi
 from .loglevel import LogLevel, SettableLevel
 
 
 class Listeners:
-    _listeners: "list[ListenerFacade]"
+    _listeners: list
 
     def __init__(
         self,
@@ -42,7 +37,6 @@ class Listeners:
         self._log_level = log_level
         self._listeners = self._import_listeners(listeners)
 
-    # Must be property to allow LibraryListeners to override it.
     @property
     def listeners(self):
         return self._listeners
@@ -53,7 +47,7 @@ class Listeners:
             if library and isinstance(listener, str) and listener.upper() == "SELF":
                 listener = library.instance
             try:
-                facade = ListenerFacade.create(listener, self._log_level, library)
+                facade = create_listener_facade(listener, self._log_level, library)
             except DataError as err:
                 if library:
                     raise
@@ -70,7 +64,6 @@ class Listeners:
 
 
 class LibraryListeners(Listeners):
-    _listeners: "list[list[ListenerFacade]]"
 
     def __init__(self, log_level: "LogLevel | str" = "INFO"):
         super().__init__(log_level=log_level)
@@ -99,531 +92,40 @@ class LibraryListeners(Listeners):
         self._listeners[-1] = remaining
 
 
-class ListenerFacade(LoggerApi, ABC):
+def create_listener_facade(
+    listener: "str | object",
+    log_level: "LogLevel | SettableLevel" = "INFO",
+    library: object = None,
+) -> ListenerFacade:
+    if isinstance(log_level, str):
+        log_level = LogLevel(log_level)
+    try:
+        listener_obj = _import_listener(listener)
+        name = listener if isinstance(listener, str) else None
+        return ListenerFacade.from_object(
+            listener_obj,
+            log_level,
+            library,
+            error=LOGGER.error,
+            info=LOGGER.info,
+            name=name,
+        )
+    except DataError as err:
+        name = listener if isinstance(listener, str) else getattr(listener, "__name__", None)
+        if not name:
+            name = type(listener).__name__
+        raise DataError(f"Taking listener '{name}' into use failed: {err}")
 
-    def __init__(self, listener, name, log_level, library=None):
-        self.listener = listener
-        self.name = name
-        self._is_logged = log_level.is_logged
-        self.library = library
-        self.priority = self._get_priority(listener)
 
-    def _get_priority(self, listener):
-        priority = getattr(listener, "ROBOT_LISTENER_PRIORITY", 0)
-        if isinstance(priority, (int, float)):
-            return priority
+def _import_listener(listener: "str | object") -> object:
+    if isinstance(listener, str):
+        name, args = split_args_from_name_or_path(listener)
+        importer = Importer("listener", logger=LOGGER)
         try:
-            try:
-                return int(priority)
-            except ValueError:
-                return float(priority)
-        except (ValueError, TypeError):
-            raise DataError(f"Invalid listener priority '{priority}'.")
-
-    @classmethod
-    def create(
-        cls,
-        listener: "str | object",
-        log_level: "LogLevel | SettableLevel" = "INFO",
-        library: object = None,
-    ) -> "ListenerFacade":
-        if isinstance(log_level, str):
-            log_level = LogLevel(log_level)
-        try:
-            return cls._import_listener(listener, log_level, library)
-        except DataError as err:
-            name = listener if isinstance(listener, str) else type_name(listener)
-            raise DataError(f"Taking listener '{name}' into use failed: {err}")
-
-    @classmethod
-    def _import_listener(cls, listener, log_level, library=None) -> "ListenerFacade":
-        if isinstance(listener, str):
-            name, args = split_args_from_name_or_path(listener)
-            importer = Importer("listener", logger=LOGGER)
-            listener = importer.import_class_or_module(
+            return importer.import_class_or_module(
                 os.path.normpath(name),
                 instantiate_with_args=args,
             )
-        else:
-            # Modules have `__name__`, with others better to use `type_name`.
-            name = getattr(listener, "__name__", None) or type_name(listener)
-        if cls._get_version(listener) == 2:
-            return ListenerV2Facade(listener, name, log_level, library)
-        return ListenerV3Facade(listener, name, log_level, library)
-
-    @classmethod
-    def _get_version(cls, listener):
-        version = getattr(listener, "ROBOT_LISTENER_API_VERSION", 3)
-        try:
-            version = int(version)
-            if version not in (2, 3):
-                raise ValueError
-        except (ValueError, TypeError):
-            raise DataError(f"Unsupported API version '{version}'.")
-        return version
-
-    def _get_method(self, name, fallback=None):
-        for method_name in self._get_method_names(name):
-            method = getattr(self.listener, method_name, None)
-            if method:
-                return ListenerMethod(method, self.name)
-        return fallback or ListenerMethod(None, self.name)
-
-    def _get_method_names(self, name):
-        names = [name, self._to_camelCase(name)] if "_" in name else [name]
-        if self.library is not None:
-            names += ["_" + name for name in names]
-        return names
-
-    def _to_camelCase(self, name):
-        first, *rest = name.split("_")
-        return "".join([first] + [part.capitalize() for part in rest])
-
-
-class ListenerV3Facade(ListenerFacade):
-
-    def __init__(self, listener, name, log_level, library=None):
-        super().__init__(listener, name, log_level, library)
-        get = self._get_method
-        # Suite
-        self.start_suite = get("start_suite")
-        self.end_suite = get("end_suite")
-        # Test
-        self.start_test = get("start_test")
-        self.end_test = get("end_test")
-        # Fallbacks for body items
-        start_body_item = get("start_body_item")
-        end_body_item = get("end_body_item")
-        # Fallbacks for keywords
-        start_keyword = get("start_keyword", start_body_item)
-        end_keyword = get("end_keyword", end_body_item)
-        # Keywords
-        self.start_user_keyword = get(
-            "start_user_keyword",
-            lambda data, implementation, result: start_keyword(data, result),
-        )
-        self.end_user_keyword = get(
-            "end_user_keyword",
-            lambda data, implementation, result: end_keyword(data, result),
-        )
-        self.start_library_keyword = get(
-            "start_library_keyword",
-            lambda data, implementation, result: start_keyword(data, result),
-        )
-        self.end_library_keyword = get(
-            "end_library_keyword",
-            lambda data, implementation, result: end_keyword(data, result),
-        )
-        self.start_invalid_keyword = get(
-            "start_invalid_keyword",
-            lambda data, implementation, result: start_keyword(data, result),
-        )
-        self.end_invalid_keyword = get(
-            "end_invalid_keyword",
-            lambda data, implementation, result: end_keyword(data, result),
-        )
-        # IF
-        self.start_if = get("start_if", start_body_item)
-        self.end_if = get("end_if", end_body_item)
-        self.start_if_branch = get("start_if_branch", start_body_item)
-        self.end_if_branch = get("end_if_branch", end_body_item)
-        # TRY
-        self.start_try = get("start_try", start_body_item)
-        self.end_try = get("end_try", end_body_item)
-        self.start_try_branch = get("start_try_branch", start_body_item)
-        self.end_try_branch = get("end_try_branch", end_body_item)
-        # FOR
-        self.start_for = get("start_for", start_body_item)
-        self.end_for = get("end_for", end_body_item)
-        self.start_for_iteration = get("start_for_iteration", start_body_item)
-        self.end_for_iteration = get("end_for_iteration", end_body_item)
-        # WHILE
-        self.start_while = get("start_while", start_body_item)
-        self.end_while = get("end_while", end_body_item)
-        self.start_while_iteration = get("start_while_iteration", start_body_item)
-        self.end_while_iteration = get("end_while_iteration", end_body_item)
-        # GROUP
-        self.start_group = get("start_group", start_body_item)
-        self.end_group = get("end_group", end_body_item)
-        # VAR
-        self.start_var = get("start_var", start_body_item)
-        self.end_var = get("end_var", end_body_item)
-        # BREAK
-        self.start_break = get("start_break", start_body_item)
-        self.end_break = get("end_break", end_body_item)
-        # CONTINUE
-        self.start_continue = get("start_continue", start_body_item)
-        self.end_continue = get("end_continue", end_body_item)
-        # RETURN
-        self.start_return = get("start_return", start_body_item)
-        self.end_return = get("end_return", end_body_item)
-        # ERROR
-        self.start_error = get("start_error", start_body_item)
-        self.end_error = get("end_error", end_body_item)
-        # Messages
-        self._log_message = get("log_message")
-        self.message = get("message")
-        # Imports
-        self.library_import = get("library_import")
-        self.resource_import = get("resource_import")
-        self.variables_import = get("variables_import")
-        # Result files
-        self.output_file = get("output_file")
-        self.report_file = get("report_file")
-        self.log_file = get("log_file")
-        self.xunit_file = get("xunit_file")
-        self.debug_file = get("debug_file")
-        # Close
-        self.close = get("close")
-
-    def log_message(self, message):
-        if self._is_logged(message):
-            self._log_message(message)
-
-
-class ListenerV2Facade(ListenerFacade):
-
-    def __init__(self, listener, name, log_level, library=None):
-        super().__init__(listener, name, log_level, library)
-        get = self._get_method
-        # Suite
-        self._start_suite = get("start_suite")
-        self._end_suite = get("end_suite")
-        # Test
-        self._start_test = get("start_test")
-        self._end_test = get("end_test")
-        # Keyword and control structures
-        self._start_kw = get("start_keyword")
-        self._end_kw = get("end_keyword")
-        # Messages
-        self._log_message = get("log_message")
-        self._message = get("message")
-        # Imports
-        self._library_import = get("library_import")
-        self._resource_import = get("resource_import")
-        self._variables_import = get("variables_import")
-        # Result files
-        self._output_file = get("output_file")
-        self._report_file = get("report_file")
-        self._log_file = get("log_file")
-        self._xunit_file = get("xunit_file")
-        self._debug_file = get("debug_file")
-        # Close
-        self._close = get("close")
-
-    def start_suite(self, data, result):
-        self._start_suite(result.name, self._suite_attrs(data, result))
-
-    def end_suite(self, data, result):
-        self._end_suite(result.name, self._suite_attrs(data, result, end=True))
-
-    def start_test(self, data, result):
-        self._start_test(result.name, self._test_attrs(data, result))
-
-    def end_test(self, data, result):
-        self._end_test(result.name, self._test_attrs(data, result, end=True))
-
-    def start_keyword(self, data, result):
-        self._start_kw(result.full_name, self._keyword_attrs(data, result))
-
-    def end_keyword(self, data, result):
-        self._end_kw(result.full_name, self._keyword_attrs(data, result, end=True))
-
-    def start_for(self, data, result):
-        extra = self._for_extra_attrs(result)
-        self._start_kw(result._log_name, self._attrs(data, result, **extra))
-
-    def end_for(self, data, result):
-        extra = self._for_extra_attrs(result)
-        self._end_kw(result._log_name, self._attrs(data, result, **extra, end=True))
-
-    def _for_extra_attrs(self, result):
-        extra = {
-            "variables": list(result.assign),
-            "flavor": result.flavor or "",
-            "values": list(result.values),
-        }
-        if result.flavor == "IN ENUMERATE":
-            extra["start"] = result.start
-        elif result.flavor == "IN ZIP":
-            extra["fill"] = result.fill
-            extra["mode"] = result.mode
-        return extra
-
-    def start_for_iteration(self, data, result):
-        attrs = self._attrs(data, result, variables=dict(result.assign))
-        self._start_kw(result._log_name, attrs)
-
-    def end_for_iteration(self, data, result):
-        attrs = self._attrs(data, result, variables=dict(result.assign), end=True)
-        self._end_kw(result._log_name, attrs)
-
-    def start_while(self, data, result):
-        attrs = self._attrs(
-            data,
-            result,
-            condition=result.condition,
-            limit=result.limit,
-            on_limit=result.on_limit,
-            on_limit_message=result.on_limit_message,
-        )
-        self._start_kw(result._log_name, attrs)
-
-    def end_while(self, data, result):
-        attrs = self._attrs(
-            data,
-            result,
-            condition=result.condition,
-            limit=result.limit,
-            on_limit=result.on_limit,
-            on_limit_message=result.on_limit_message,
-            end=True,
-        )
-        self._end_kw(result._log_name, attrs)
-
-    def start_while_iteration(self, data, result):
-        self._start_kw(result._log_name, self._attrs(data, result))
-
-    def end_while_iteration(self, data, result):
-        self._end_kw(result._log_name, self._attrs(data, result, end=True))
-
-    def start_group(self, data, result):
-        self._start_kw(result._log_name, self._attrs(data, result, name=result.name))
-
-    def end_group(self, data, result):
-        attrs = self._attrs(data, result, name=result.name, end=True)
-        self._end_kw(result._log_name, attrs)
-
-    def start_if_branch(self, data, result):
-        extra = {"condition": result.condition} if result.type != result.ELSE else {}
-        self._start_kw(result._log_name, self._attrs(data, result, **extra))
-
-    def end_if_branch(self, data, result):
-        extra = {"condition": result.condition} if result.type != result.ELSE else {}
-        self._end_kw(result._log_name, self._attrs(data, result, **extra, end=True))
-
-    def start_try_branch(self, data, result):
-        extra = self._try_extra_attrs(result)
-        self._start_kw(result._log_name, self._attrs(data, result, **extra))
-
-    def end_try_branch(self, data, result):
-        extra = self._try_extra_attrs(result)
-        self._end_kw(result._log_name, self._attrs(data, result, **extra, end=True))
-
-    def _try_extra_attrs(self, result):
-        if result.type == BodyItem.EXCEPT:
-            return {
-                "patterns": list(result.patterns),
-                "pattern_type": result.pattern_type,
-                "variable": result.assign,
-            }
-        return {}
-
-    def start_return(self, data, result):
-        attrs = self._attrs(data, result, values=list(result.values))
-        self._start_kw(result._log_name, attrs)
-
-    def end_return(self, data, result):
-        attrs = self._attrs(data, result, values=list(result.values), end=True)
-        self._end_kw(result._log_name, attrs)
-
-    def start_continue(self, data, result):
-        self._start_kw(result._log_name, self._attrs(data, result))
-
-    def end_continue(self, data, result):
-        self._end_kw(result._log_name, self._attrs(data, result, end=True))
-
-    def start_break(self, data, result):
-        self._start_kw(result._log_name, self._attrs(data, result))
-
-    def end_break(self, data, result):
-        self._end_kw(result._log_name, self._attrs(data, result, end=True))
-
-    def start_error(self, data, result):
-        self._start_kw(result._log_name, self._attrs(data, result))
-
-    def end_error(self, data, result):
-        self._end_kw(result._log_name, self._attrs(data, result, end=True))
-
-    def start_var(self, data, result):
-        extra = self._var_extra_attrs(result)
-        self._start_kw(result._log_name, self._attrs(data, result, **extra))
-
-    def end_var(self, data, result):
-        extra = self._var_extra_attrs(result)
-        self._end_kw(result._log_name, self._attrs(data, result, **extra, end=True))
-
-    def _var_extra_attrs(self, result):
-        if result.name.startswith("$"):
-            value = (result.separator or " ").join(result.value)
-        else:
-            value = list(result.value)
-        return {"name": result.name, "value": value, "scope": result.scope or "LOCAL"}
-
-    def log_message(self, message):
-        if self._is_logged(message):
-            self._log_message(self._message_attributes(message))
-
-    def message(self, message):
-        self._message(self._message_attributes(message))
-
-    def library_import(self, library, importer):
-        attrs = {
-            "args": list(importer.args),
-            "originalname": library.real_name,
-            "source": str(library.source or ""),
-            "importer": str(importer.source),
-        }
-        self._library_import(library.name, attrs)
-
-    def resource_import(self, resource, importer):
-        self._resource_import(
-            resource.name,
-            {"source": str(resource.source), "importer": str(importer.source)},
-        )
-
-    def variables_import(self, attrs: dict, importer):
-        self._variables_import(
-            attrs["name"],
-            {
-                "args": list(attrs["args"]),
-                "source": str(attrs["source"]),
-                "importer": str(importer.source),
-            },
-        )
-
-    def output_file(self, path: Path):
-        self._output_file(str(path))
-
-    def report_file(self, path: Path):
-        self._report_file(str(path))
-
-    def log_file(self, path: Path):
-        self._log_file(str(path))
-
-    def xunit_file(self, path: Path):
-        self._xunit_file(str(path))
-
-    def debug_file(self, path: Path):
-        self._debug_file(str(path))
-
-    def _suite_attrs(self, data, result, end=False):
-        attrs = dict(
-            id=data.id,
-            doc=result.doc,
-            metadata=dict(result.metadata),
-            starttime=result.starttime,
-            longname=result.full_name,
-            tests=[t.name for t in data.tests],
-            suites=[s.name for s in data.suites],
-            totaltests=data.test_count,
-            source=str(data.source or ""),
-        )
-        if end:
-            attrs.update(
-                endtime=result.endtime,
-                elapsedtime=result.elapsedtime,
-                status=result.status,
-                message=result.message,
-                statistics=result.stat_message,
-            )
-        return attrs
-
-    def _test_attrs(self, data, result, end=False):
-        attrs = dict(
-            id=data.id,
-            doc=result.doc,
-            tags=list(result.tags),
-            lineno=data.lineno,
-            starttime=result.starttime,
-            longname=result.full_name,
-            source=str(data.source or ""),
-            template=data.template or "",
-            originalname=data.name,
-        )
-        if end:
-            attrs.update(
-                endtime=result.endtime,
-                elapsedtime=result.elapsedtime,
-                status=result.status,
-                message=result.message,
-            )
-        return attrs
-
-    def _keyword_attrs(self, data, result, end=False):
-        attrs = dict(
-            doc=result.doc,
-            lineno=data.lineno,
-            type=result.type,
-            status=result.status,
-            starttime=result.starttime,
-            source=str(data.source or ""),
-            kwname=result.name or "",
-            libname=result.owner or "",
-            args=[a if isinstance(a, str) else safe_str(a) for a in result.args],
-            assign=list(result.assign),
-            tags=list(result.tags),
-        )
-        if end:
-            attrs.update(
-                endtime=result.endtime,
-                elapsedtime=result.elapsedtime,
-            )
-        return attrs
-
-    def _attrs(self, data, result, end=False, **extra):
-        attrs = dict(
-            doc="",
-            lineno=data.lineno,
-            type=result.type,
-            status=result.status,
-            starttime=result.starttime,
-            source=str(data.source or ""),
-            kwname=result._log_name,
-            libname="",
-            args=[],
-            assign=[],
-            tags=[],
-            **extra,
-        )
-        if end:
-            attrs.update(
-                endtime=result.endtime,
-                elapsedtime=result.elapsedtime,
-            )
-        return attrs
-
-    def _message_attributes(self, msg):
-        # Timestamp in our legacy format.
-        ts = msg.timestamp.isoformat(" ", timespec="milliseconds").replace("-", "")
-        return {
-            "timestamp": ts,
-            "message": msg.message,
-            "level": msg.level,
-            "html": "yes" if msg.html else "no",
-        }
-
-    def close(self):
-        self._close()
-
-
-class ListenerMethod:
-
-    def __init__(self, method, name):
-        self.method = method
-        self.listener_name = name
-
-    def __call__(self, *args):
-        try:
-            if self.method is not None:
-                self.method(*args)
-        except Exception:
-            message, details = get_error_details()
-            LOGGER.error(
-                f"Calling method '{self.method.__name__}' of listener "
-                f"'{self.listener_name}' failed: {message}"
-            )
-            LOGGER.info(f"Details:\n{details}")
-
-    def __bool__(self):
-        return self.method is not None
+        except DataError as err:
+            raise err
+    return listener

--- a/src/robot/output/listeners.py
+++ b/src/robot/output/listeners.py
@@ -100,8 +100,7 @@ def create_listener_facade(
     if isinstance(log_level, str):
         log_level = LogLevel(log_level)
     try:
-        listener_obj = _import_listener(listener)
-        name = listener if isinstance(listener, str) else None
+        listener_obj, name = _import_listener(listener)
         return ListenerFacade.from_object(
             listener_obj,
             log_level,
@@ -115,15 +114,16 @@ def create_listener_facade(
         raise DataError(f"Taking listener '{name}' into use failed: {err}")
 
 
-def _import_listener(listener: "str | object") -> object:
+def _import_listener(listener: "str | object") -> "tuple[object, str | None]":
     if isinstance(listener, str):
         name, args = split_args_from_name_or_path(listener)
+        name = os.path.normpath(name)
         importer = Importer("listener", logger=LOGGER)
         try:
             return importer.import_class_or_module(
-                os.path.normpath(name),
+                name,
                 instantiate_with_args=args,
-            )
+            ), name
         except DataError as err:
             raise err
-    return listener
+    return listener, None

--- a/src/robot/output/logger.py
+++ b/src/robot/output/logger.py
@@ -20,7 +20,9 @@ from robot.errors import DataError
 
 from .console import ConsoleOutput
 from .filelogger import FileLogger
+from .listenerfacade import ListenerFacade
 from .loggerhelper import AbstractLogger, write_to_console
+from .loglevel import SettableLevel
 from .stdoutlogsplitter import StdoutLogSplitter
 
 
@@ -108,11 +110,11 @@ class Logger(AbstractLogger):
         markers="AUTO",
         stdout=None,
         stderr=None,
+        log_level: "SettableLevel" = "INFO",
     ):
-        self._console = ConsoleOutput(
-            type, width, colors, links, markers, stdout, stderr
-        )
-        self._relay_cached_messages(self._console)
+        logger = ConsoleOutput(type, width, colors, links, markers, stdout, stderr)
+        self._console = ListenerFacade.from_object(logger, log_level=log_level)
+        self._relay_cached_messages(logger)
 
     def _relay_cached_messages(self, logger):
         if self._message_cache:

--- a/src/robot/output/logger.py
+++ b/src/robot/output/logger.py
@@ -113,7 +113,12 @@ class Logger(AbstractLogger):
         log_level: "SettableLevel" = "INFO",
     ):
         logger = ConsoleOutput(type, width, colors, links, markers, stdout, stderr)
-        self._console = ListenerFacade.from_object(logger, log_level=log_level)
+        self._console = ListenerFacade.from_object(
+            logger,
+            self.error,
+            self.info,
+            log_level=log_level,
+        )
         self._relay_cached_messages(logger)
 
     def _relay_cached_messages(self, logger):

--- a/utest/output/test_listeners.py
+++ b/utest/output/test_listeners.py
@@ -5,7 +5,7 @@ from robot.errors import DataError
 from robot.model import BodyItem
 from robot.output import LOGGER
 from robot.output.listenerfacade import ListenerFacade
-from robot.output.listeners import Listeners, create_listener_facade
+from robot.output.listeners import create_listener_facade, Listeners
 from robot.running.outputcapture import OutputCapturer
 from robot.utils import DotDict
 from robot.utils.asserts import assert_equal, assert_raises_with_msg

--- a/utest/output/test_listeners.py
+++ b/utest/output/test_listeners.py
@@ -4,7 +4,8 @@ import unittest
 from robot.errors import DataError
 from robot.model import BodyItem
 from robot.output import LOGGER
-from robot.output.listeners import ListenerFacade, Listeners
+from robot.output.listenerfacade import ListenerFacade
+from robot.output.listeners import Listeners
 from robot.running.outputcapture import OutputCapturer
 from robot.utils import DotDict
 from robot.utils.asserts import assert_equal, assert_raises_with_msg
@@ -115,7 +116,7 @@ class ListenAll(ListenOutputs):
 
 
 class TestListeners(unittest.TestCase):
-    listener_name = "test_listeners.ListenAll"
+    listener_name = f"{__name__}.ListenAll"
     stat_message = "stat message"
 
     def setUp(self):
@@ -197,7 +198,6 @@ class TestListenerPriority(unittest.TestCase):
     def test_invalid_priority(self):
         assert_raises_with_msg(
             DataError,
-            "Taking listener 'Listener' into use failed: "
             "Invalid listener priority 'invalid'.",
             self._create_listener,
             "invalid",
@@ -210,7 +210,7 @@ class TestListenerPriority(unittest.TestCase):
             assert_equal(type(listener.priority), type(expected))
 
     def _create_listener(self, priority):
-        return ListenerFacade.create(Listener(priority))
+        return ListenerFacade.from_object(Listener(priority), error=lambda _: None, info=lambda _: None)
 
 
 if __name__ == "__main__":

--- a/utest/output/test_listeners.py
+++ b/utest/output/test_listeners.py
@@ -224,8 +224,8 @@ class TestListenerPriority(unittest.TestCase):
     def _create_listener_from_object(self, priority):
         return ListenerFacade.from_object(
             Listener(priority),
-            error=lambda _: None,
-            info=lambda _: None,
+            lambda _: None,
+            lambda _: None,
         )
 
 

--- a/utest/output/test_listeners.py
+++ b/utest/output/test_listeners.py
@@ -5,7 +5,7 @@ from robot.errors import DataError
 from robot.model import BodyItem
 from robot.output import LOGGER
 from robot.output.listenerfacade import ListenerFacade
-from robot.output.listeners import Listeners
+from robot.output.listeners import Listeners, create_listener_facade
 from robot.running.outputcapture import OutputCapturer
 from robot.utils import DotDict
 from robot.utils.asserts import assert_equal, assert_raises_with_msg
@@ -198,8 +198,17 @@ class TestListenerPriority(unittest.TestCase):
     def test_invalid_priority(self):
         assert_raises_with_msg(
             DataError,
+            "Taking listener 'Listener' into use failed: "
             "Invalid listener priority 'invalid'.",
             self._create_listener,
+            "invalid",
+        )
+
+    def test_invalid_priority_from_object(self):
+        assert_raises_with_msg(
+            DataError,
+            "Invalid listener priority 'invalid'.",
+            self._create_listener_from_object,
             "invalid",
         )
 
@@ -210,7 +219,14 @@ class TestListenerPriority(unittest.TestCase):
             assert_equal(type(listener.priority), type(expected))
 
     def _create_listener(self, priority):
-        return ListenerFacade.from_object(Listener(priority), error=lambda _: None, info=lambda _: None)
+        return create_listener_facade(Listener(priority))
+
+    def _create_listener_from_object(self, priority):
+        return ListenerFacade.from_object(
+            Listener(priority),
+            error=lambda _: None,
+            info=lambda _: None,
+        )
 
 
 if __name__ == "__main__":

--- a/utest/output/test_logger.py
+++ b/utest/output/test_logger.py
@@ -180,8 +180,7 @@ class TestLogger(unittest.TestCase):
 
     def test_verbose_console_output_is_automatically_registered(self):
         logger = Logger()
-        start_suite = logger._console.start_suite
-        assert_true(start_suite.__self__.__class__ is VerboseOutput)
+        assert_true(logger._console.listener.__class__ is VerboseOutput)
 
     def test_automatic_console_logger_can_be_disabled(self):
         logger = Logger()
@@ -212,7 +211,7 @@ class TestLogger(unittest.TestCase):
         logger = Logger()
         logger.register_console_logger(width=42)
         self._number_of_registered_loggers_should_be(1, logger)
-        assert_equal(logger._console.start_suite.__self__.writer.width, 42)
+        assert_equal(logger._console.listener.writer.width, 42)
 
     def test_unregister_logger(self):
         logger1, logger2, logger3 = LoggerMock(), LoggerMock(), LoggerMock()

--- a/utest/utils/test_importer_util.py
+++ b/utest/utils/test_importer_util.py
@@ -99,7 +99,8 @@ class TestImportByPath(unittest.TestCase):
         path = create_temp_file("test.py")
         os.chdir(path.parent)
         try:
-            self._import_and_verify(Path("test.py"), remove="test")
+            path = Path("test.py").resolve()
+            self._import_and_verify(path, remove="test")
             self._assert_imported_message("test", path)
         finally:
             os.chdir(orig_cwd)


### PR DESCRIPTION
This implements part 1 (of 4) of https://github.com/robotframework/robotframework/issues/5618#issuecomment-4386315850

The changes are rather large as I had to move the ListenerFacade into its own module to avoid a dependency conflict between logger and listener. This conflict (rather: its resolution) also prevented me to use your new `ListenerFacade.create()` method, but I might have also missed alternative approaches.

... more description will be added later

The PR also includes the changes of #5669 so tests passes on macOS (not related to this change)

---

## Review aid: ListenerFacade move/copy vs actual edits

This PR moves the old `ListenerFacade` implementation out of [src/robot/output/listeners.py](src/robot/output/listeners.py) into the new [src/robot/output/listenerfacade.py](src/robot/output/listenerfacade.py) to avoid a circular dependency.

### What stayed in `listeners.py`

- `Listeners`/`LibraryListeners` bookkeeping remains in `listeners.py`.
- The listener import logic (`split_args_from_name_or_path`, `Importer`, normalization) is now local helper `_import_listener()` to avoid importing `listeners.py` from the new `listenerfacade.py`.

### Call site change (`ListenerFacade.create()` → `create_listener_facade()`)

```diff
-                facade = ListenerFacade.create(listener, self._log_level, library)
+                facade = create_listener_facade(listener, self._log_level, library)
```

`create_listener_facade()` is a thin wrapper that:
- imports/instantiates a listener when given a string
- calls `ListenerFacade.from_object(...)` from the new module
- preserves the old error wrapping message (`Taking listener '<name>' into use failed: ...`)

### Functional deltas introduced during the move

These are the meaningful behavior/interface changes compared to the pre-move `ListenerFacade.create()` implementation:

- **API split:** importing/instantiating string listeners moved out of `ListenerFacade`.
  - `master`: `ListenerFacade.create(str|obj)` did import + version selection.
  - `this PR`: `create_listener_facade(str|obj)` imports, then `ListenerFacade.from_object(obj, ...)` does version selection.

- **Logger injection:** `ListenerMethod` no longer uses the global `LOGGER` directly.
  - Instead, `ListenerFacade.from_object(..., error_logger=LOGGER.error, info_logger=LOGGER.info)` passes logging callables into the facade, and `ListenerMethod` uses those.
  - Expected effect: same log output/semantics, but removes the dependency from `listenerfacade.py` back to `listeners.py` / `LOGGER`.

### Rough diff against master (using temp merged file)

The file [src/robot/output/listeners_tmp_sorted.py](src/robot/output/listeners_tmp_sorted.py) is a temporary merge of this PR’s [listenerfacade.py](src/robot/output/listenerfacade.py) back into `master`’s `listeners.py` at the original `class ListenerFacade` location so reviewers can see a “minimal noise” diff.

```diff
--- master/src/robot/output/listeners.py
+++ tmp/src/robot/output/listeners_tmp_sorted.py
@@ -99,14 +99,26 @@
         self._listeners[-1] = remaining
 
 
+
+# TEMP: merged back from src/robot/output/listenerfacade.py for diffing
 class ListenerFacade(LoggerApi, ABC):
 
-    def __init__(self, listener, name, log_level, library=None):
+    def __init__(
+        self,
+        listener,
+        name,
+        error_logger: Callable[[str], object],
+        info_logger: Callable[[str], object],
+        log_level,
+        library=None,
+    ):
         self.listener = listener
         self.name = name
         self._is_logged = log_level.is_logged
         self.library = library
         self.priority = self._get_priority(listener)
+        self._error_logger = error_logger
+        self._info_logger = info_logger
@@ -121,35 +133,35 @@
             raise DataError(f"Invalid listener priority '{priority}'.")
 
     @classmethod
-    def create(
+    def from_object(
         cls,
-        listener: "str | object",
+        listener: object,
+        error_logger: Callable[[str], object],
+        info_logger: Callable[[str], object],
         log_level: "LogLevel | SettableLevel" = "INFO",
         library: object = None,
+        name: str | None = None,
     ) -> "ListenerFacade":
         if isinstance(log_level, str):
             log_level = LogLevel(log_level)
-        try:
-            return cls._import_listener(listener, log_level, library)
-        except DataError as err:
-            name = listener if isinstance(listener, str) else type_name(listener)
-            raise DataError(f"Taking listener '{name}' into use failed: {err}")
-
-    @classmethod
-    def _import_listener(cls, listener, log_level, library=None) -> "ListenerFacade":
-        if isinstance(listener, str):
-            name, args = split_args_from_name_or_path(listener)
-            importer = Importer("listener", logger=LOGGER)
-            listener = importer.import_class_or_module(
-                os.path.normpath(name),
-                instantiate_with_args=args,
+        name = name or getattr(listener, "__name__", None) or type_name(listener)
+        if cls._get_version(listener) == 2:
+            return ListenerV2Facade(
+                listener,
+                name,
+                error_logger,
+                info_logger,
+                log_level,
+                library,
             )
-        else:
-            # Modules have `__name__`, with others better to use `type_name`.
-            name = getattr(listener, "__name__", None) or type_name(listener)
-        if cls._get_version(listener) == 2:
-            return ListenerV2Facade(listener, name, log_level, library)
-        return ListenerV3Facade(listener, name, log_level, library)
+        return ListenerV3Facade(
+            listener,
+            name,
+            error_logger,
+            info_logger,
+            log_level,
+            library,
+        )
@@ -166,8 +178,8 @@
         for method_name in self._get_method_names(name):
             method = getattr(self.listener, method_name, None)
             if method:
-                return ListenerMethod(method, self.name)
-        return fallback or ListenerMethod(None, self.name)
+                return ListenerMethod(method, self.name, self._error_logger, self._info_logger)
+        return fallback or ListenerMethod(None, self.name, self._error_logger, self._info_logger)
@@ -182,8 +194,16 @@
 
 class ListenerV3Facade(ListenerFacade):
 
-    def __init__(self, listener, name, log_level, library=None):
-        super().__init__(listener, name, log_level, library)
+    def __init__(
+        self,
+        listener,
+        name,
+        error_logger: Callable[[str], object],
+        info_logger: Callable[[str], object],
+        log_level,
+        library=None,
+    ):
+        super().__init__(listener, name, error_logger, info_logger, log_level, library)
@@ -283,8 +303,16 @@
 
 class ListenerV2Facade(ListenerFacade):
 
-    def __init__(self, listener, name, log_level, library=None):
-        super().__init__(listener, name, log_level, library)
+    def __init__(
+        self,
+        listener,
+        name,
+        error_logger: Callable[[str], object],
+        info_logger: Callable[[str], object],
+        log_level,
+        library=None,
+    ):
+        super().__init__(listener, name, error_logger, info_logger, log_level, library)
@@ -594,7 +622,6 @@
         return attrs
 
     def _message_attributes(self, msg):
-        # Timestamp in our legacy format.
         ts = msg.timestamp.isoformat(" ", timespec="milliseconds").replace("-", "")
         return {
             "timestamp": ts,
@@ -609,9 +636,17 @@
 
 class ListenerMethod:
 
-    def __init__(self, method, name):
+    def __init__(
+        self,
+        method,
+        name,
+        error_logger: Callable[[str], object],
+        info_logger: Callable[[str], object],
+    ):
         self.method = method
         self.listener_name = name
+        self._error_logger = error_logger
+        self._info_logger = info_logger
@@ -619,11 +654,11 @@
                 self.method(*args)
         except Exception:
             message, details = get_error_details()
-            LOGGER.error(
+            self._error_logger(
                 f"Calling method '{self.method.__name__}' of listener "
                 f"'{self.listener_name}' failed: {message}"
             )
-            LOGGER.info(f"Details:\n{details}")
+            self._info_logger(f"Details:\n{details}")
 
     def __bool__(self):
         return self.method is not None
```

If you want the raw moved-region diff, compare:
- `master: src/robot/output/listeners.py` from `class ListenerFacade` onwards
- `this branch: src/robot/output/listenerfacade.py`