### PR TITLE
Support configuring console logger with Rebot (#5674)

### DIFF
--- a/atest/resources/atest_resource.robot
+++ b/atest/resources/atest_resource.robot
@@ -269,6 +269,10 @@ Stdout Should Contain
     [Arguments]    @{expected}    ${count}=None
     File Should Contain    ${STDOUT_FILE}    @{expected}    count=${count}
 
+Stdout Should Be Empty
+    ${stdout} =    Get Stdout
+    Should Be Empty    ${stdout}    Unexpected console output:\n${stdout}
+
 Stdout Should Not Contain
     [Arguments]    @{expected}
     File Should Not Contain    ${STDOUT_FILE}    @{expected}

--- a/atest/robot/cli/rebot/console.robot
+++ b/atest/robot/cli/rebot/console.robot
@@ -67,3 +67,7 @@ Custom console as module with functions
 Non-existing custom console
     Run Rebot Without Processing Output    --console NonExistent    ${INPUT FILE}
     Stderr Should Start With    [ ERROR ] Taking console logger 'NonExistent' into use failed:
+
+Dotted is not supported
+    Run Rebot Without Processing Output    --console dotted    ${INPUT FILE}
+    Stderr Should Be Equal To    [ ERROR ] Console type 'dotted' is not supported with Rebot.${USAGE TIP}\n

--- a/atest/robot/cli/rebot/console.robot
+++ b/atest/robot/cli/rebot/console.robot
@@ -38,7 +38,3 @@ Custom console by module name
 Non-existing custom console
     Run Rebot Without Processing Output    --console NonExistent    ${INPUT FILE}
     Stderr Should Start With    [ ERROR ] Taking console logger 'NonExistent' into use failed:
-
-Dotted is not supported
-    Run Rebot Without Processing Output    --console dotted    ${INPUT FILE}
-    Stderr Should Be Equal To    [ ERROR ] Console type 'dotted' is not supported with Rebot.${USAGE TIP}\n

--- a/atest/robot/cli/rebot/console.robot
+++ b/atest/robot/cli/rebot/console.robot
@@ -1,0 +1,69 @@
+*** Settings ***
+Suite Setup       Run tests to create input file for Rebot
+Resource          rebot_cli_resource.robot
+
+*** Variables ***
+${CONSOLES}       ${CURDIR}${/}..${/}..${/}..${/}testresources${/}consoles
+
+*** Test Cases ***
+Default is verbose
+    Run Rebot    ${EMPTY}    ${INPUT FILE}
+    Stdout Should Contain    Output:
+
+Verbose
+    Run Rebot    --console verbose    ${INPUT FILE}
+    Stdout Should Contain    Output:
+
+Verbose with log and report
+    Run Rebot    --console verbose --log log.html --report report.html    ${INPUT FILE}
+    Stdout Should Contain    Output:
+    Stdout Should Contain    Log:
+    Stdout Should Contain    Report:
+
+Quiet
+    Run Rebot    --console quiet    ${INPUT FILE}
+    Stdout Should Be Empty
+    Stderr Should Be Empty
+
+--quiet shortcut
+    Run Rebot    --quiet    ${INPUT FILE}
+    Stdout Should Be Empty
+    Stderr Should Be Empty
+
+None
+    Run Rebot    --console none    ${INPUT FILE}
+    Stdout Should Be Empty
+    Stderr Should Be Empty
+
+Custom console by path
+    Run Rebot    --console ${CONSOLES}${/}CustomConsole.py --log log.html --report report.html
+    ...    ${INPUT FILE}
+    Stdout Should Contain    DEFAULT: Output:
+    Stdout Should Contain    DEFAULT: Log:
+    Stdout Should Contain    DEFAULT: Report:
+    Stdout Should Contain    DEFAULT: Closing
+
+Custom console by path with argument
+    Run Rebot    --console ${CONSOLES}${/}CustomConsole.py:ARGUMENT --log log.html --report report.html
+    ...    ${INPUT FILE}
+    Stdout Should Contain    ARGUMENT: Output:
+    Stdout Should Contain    ARGUMENT: Log:
+    Stdout Should Contain    ARGUMENT: Report:
+    Stdout Should Contain    ARGUMENT: Closing
+
+Custom console by module name
+    Run Rebot    --console CustomConsole --pythonpath ${CONSOLES} --log log.html --report report.html
+    ...    ${INPUT FILE}
+    Stdout Should Contain    DEFAULT: Output:
+    Stdout Should Contain    DEFAULT: Closing
+
+Custom console as module with functions
+    Run Rebot    --console ${CONSOLES}${/}module_console.py    ${INPUT FILE}
+    Stdout Should Not Contain    Output:
+    Stdout Should Not Contain    Report:
+    Stdout Should Not Contain    Log:
+    Stdout Should Contain    MODULE: Closing
+
+Non-existing custom console
+    Run Rebot Without Processing Output    --console NonExistent    ${INPUT FILE}
+    Stderr Should Start With    [ ERROR ] Taking console logger 'NonExistent' into use failed:

--- a/atest/robot/cli/rebot/console.robot
+++ b/atest/robot/cli/rebot/console.robot
@@ -29,7 +29,7 @@ None
     Stdout Should Be Empty
     Stderr Should Be Empty
 
-Custom console by module name
+Custom console
     Run Rebot    --console CustomConsole --pythonpath ${CONSOLES} --log log.html --report report.html
     ...    ${INPUT FILE}
     Stdout Should Contain    DEFAULT: Output:

--- a/atest/robot/cli/rebot/console.robot
+++ b/atest/robot/cli/rebot/console.robot
@@ -14,12 +14,6 @@ Verbose
     Run Rebot    --console verbose    ${INPUT FILE}
     Stdout Should Contain    Output:
 
-Verbose with log and report
-    Run Rebot    --console verbose --log log.html --report report.html    ${INPUT FILE}
-    Stdout Should Contain    Output:
-    Stdout Should Contain    Log:
-    Stdout Should Contain    Report:
-
 Quiet
     Run Rebot    --console quiet    ${INPUT FILE}
     Stdout Should Be Empty
@@ -35,34 +29,11 @@ None
     Stdout Should Be Empty
     Stderr Should Be Empty
 
-Custom console by path
-    Run Rebot    --console ${CONSOLES}${/}CustomConsole.py --log log.html --report report.html
-    ...    ${INPUT FILE}
-    Stdout Should Contain    DEFAULT: Output:
-    Stdout Should Contain    DEFAULT: Log:
-    Stdout Should Contain    DEFAULT: Report:
-    Stdout Should Contain    DEFAULT: Closing
-
-Custom console by path with argument
-    Run Rebot    --console ${CONSOLES}${/}CustomConsole.py:ARGUMENT --log log.html --report report.html
-    ...    ${INPUT FILE}
-    Stdout Should Contain    ARGUMENT: Output:
-    Stdout Should Contain    ARGUMENT: Log:
-    Stdout Should Contain    ARGUMENT: Report:
-    Stdout Should Contain    ARGUMENT: Closing
-
 Custom console by module name
     Run Rebot    --console CustomConsole --pythonpath ${CONSOLES} --log log.html --report report.html
     ...    ${INPUT FILE}
     Stdout Should Contain    DEFAULT: Output:
     Stdout Should Contain    DEFAULT: Closing
-
-Custom console as module with functions
-    Run Rebot    --console ${CONSOLES}${/}module_console.py    ${INPUT FILE}
-    Stdout Should Not Contain    Output:
-    Stdout Should Not Contain    Report:
-    Stdout Should Not Contain    Log:
-    Stdout Should Contain    MODULE: Closing
 
 Non-existing custom console
     Run Rebot Without Processing Output    --console NonExistent    ${INPUT FILE}

--- a/src/robot/conf/settings.py
+++ b/src/robot/conf/settings.py
@@ -521,6 +521,8 @@ class RobotSettings(_BaseSettings):
             "Output",
             "LogLevel",
             "TimestampOutputs",
+            "ConsoleType",
+            "ConsoleTypeQuiet",
         }
         for opt in settings._opts:
             if opt in self and opt not in not_copied:
@@ -705,6 +707,8 @@ class RebotSettings(_BaseSettings):
         "StartTime"         : ("starttime", None),
         "EndTime"           : ("endtime", None),
         "Merge"             : ("merge", False),
+        "ConsoleType"       : ("console", "verbose"),
+        "ConsoleTypeQuiet"  : ("quiet", False),
     }  # fmt: skip
 
     def _output_disabled(self):
@@ -765,8 +769,15 @@ class RebotSettings(_BaseSettings):
         return self["Merge"]
 
     @property
+    def console(self):
+        if self["ConsoleTypeQuiet"]:
+            return "quiet"
+        return self["ConsoleType"]
+
+    @property
     def console_output_config(self):
         return {
+            "console": self.console,
             "colors": self.console_colors,
             "links": self.console_links,
             "stdout": self["StdOut"],

--- a/src/robot/conf/settings.py
+++ b/src/robot/conf/settings.py
@@ -772,10 +772,7 @@ class RebotSettings(_BaseSettings):
     def console(self):
         if self["ConsoleTypeQuiet"]:
             return "quiet"
-        console = self["ConsoleType"]
-        if isinstance(console, str) and console.upper() == "DOTTED":
-            raise DataError("Console type 'dotted' is not supported with Rebot.")
-        return console
+        return self["ConsoleType"]
 
     @property
     def console_output_config(self):

--- a/src/robot/conf/settings.py
+++ b/src/robot/conf/settings.py
@@ -772,7 +772,10 @@ class RebotSettings(_BaseSettings):
     def console(self):
         if self["ConsoleTypeQuiet"]:
             return "quiet"
-        return self["ConsoleType"]
+        console = self["ConsoleType"]
+        if isinstance(console, str) and console.upper() == "DOTTED":
+            raise DataError("Console type 'dotted' is not supported with Rebot.")
+        return console
 
     @property
     def console_output_config(self):

--- a/src/robot/conf/settings.py
+++ b/src/robot/conf/settings.py
@@ -69,6 +69,8 @@ class _BaseSettings:
         "FlattenKeywords"  : ("flattenkeywords", []),
         "PreRebotModifiers": ("prerebotmodifier", []),
         "StatusRC"         : ("statusrc", True),
+        "ConsoleType"      : ("console", "verbose"),
+        "ConsoleTypeQuiet" : ("quiet", False),
         "ConsoleColors"    : ("consolecolors", "AUTO"),
         "ConsoleLinks"     : ("consolelinks", "AUTO"),
         "PythonPath"       : ("pythonpath", []),
@@ -495,9 +497,7 @@ class RobotSettings(_BaseSettings):
         "Parsers"            : ("parser", []),
         "PreRunModifiers"    : ("prerunmodifier", []),
         "Listeners"          : ("listener", []),
-        "ConsoleType"        : ("console", "verbose"),
         "ConsoleTypeDotted"  : ("dotted", False),
-        "ConsoleTypeQuiet"   : ("quiet", False),
         "ConsoleWidth"       : ("consolewidth", 78),
         "ConsoleMarkers"     : ("consolemarkers", "AUTO"),
         "DebugFile"          : ("debugfile", None),
@@ -707,8 +707,6 @@ class RebotSettings(_BaseSettings):
         "StartTime"         : ("starttime", None),
         "EndTime"           : ("endtime", None),
         "Merge"             : ("merge", False),
-        "ConsoleType"       : ("console", "verbose"),
-        "ConsoleTypeQuiet"  : ("quiet", False),
     }  # fmt: skip
 
     def _output_disabled(self):

--- a/src/robot/rebot.py
+++ b/src/robot/rebot.py
@@ -266,7 +266,7 @@ Options
                           the same as with --listener.
                           Examples: --console verbose
                                     --console quiet
-                                    --console path/to/Con.py:arg1:arg2
+                                    --console path/to/Console.py:arg
     --quiet               Shortcut for `--console quiet`.
  -C --consolecolors auto|on|ansi|off  Use colors on console output or not.
                           auto: use colors when output not redirected (default)

--- a/src/robot/rebot.py
+++ b/src/robot/rebot.py
@@ -256,6 +256,18 @@ Options
                           failures. Error codes are returned normally.
     --prerebotmodifier class *  Class to programmatically modify the result
                           model before creating outputs.
+    --console console     How to report on the console.
+                          Built-in consoles:
+                          verbose: show output file paths (default)
+                          quiet:   no output except for errors/warnings
+                          none:    no output whatsoever
+                          Other values are interpreted as a custom
+                          console class or module. Argument format is
+                          the same as with --listener.
+                          Examples: --console verbose
+                                    --console quiet
+                                    --console path/to/Con.py:arg1:arg2
+    --quiet               Shortcut for `--console quiet`.
  -C --consolecolors auto|on|ansi|off  Use colors on console output or not.
                           auto: use colors when output not redirected (default)
                           on:   always use colors
@@ -352,9 +364,9 @@ class Rebot(RobotFramework):
                 stderr=options.get("stderr"),
             )
             raise
-        LOGGER.register_console_logger(**settings.console_output_config)
         if settings.pythonpath:
             sys.path = settings.pythonpath + sys.path
+        LOGGER.register_console_logger(**settings.console_output_config)
         LOGGER.disable_message_cache()
         rc = ResultWriter(*datasources).write_results(settings)
         if rc < 0:
@@ -409,12 +421,14 @@ def rebot(*outputs, **options):
         from robot import rebot
 
         rebot('path/to/output.xml')
+        rebot('o1.xml', 'o2.xml', name='Example', log=None, console='quiet')
         with open('stdout.txt', 'w') as stdout:
             rebot('o1.xml', 'o2.xml', name='Example', log=None, stdout=stdout)
 
     Equivalent command line usage::
 
         rebot path/to/output.xml
+        rebot --name Example --log NONE --console quiet o1.xml o2.xml
         rebot --name Example --log NONE o1.xml o2.xml > stdout.txt
     """
     return Rebot().execute(*outputs, **options)

--- a/src/robot/run.py
+++ b/src/robot/run.py
@@ -341,7 +341,7 @@ Options
                           the same as with --listener.
                           Examples: --console verbose
                                     --console MyConsole
-                                    --console path/to/Con.py:arg1:arg2
+                                    --console path/to/Console.py:arg
  -. --dotted              Shortcut for `--console dotted`.
     --quiet               Shortcut for `--console quiet`.
  -W --consolewidth chars  Width of the console output. Default is 78.

--- a/utest/api/test_run_and_rebot.py
+++ b/utest/api/test_run_and_rebot.py
@@ -514,5 +514,26 @@ class RecordingConsole:
         self.calls.append(("close", None))
 
 
+class TestRebotCustomConsole(RunningTestCase):
+    data = join(ROOT, "atest", "testdata", "rebot", "created_normal.xml")
+    remove_files = [OUTPUT_PATH, LOG_PATH, REPORT_PATH]
+
+    def test_rebot_with_console_object(self):
+        console = RecordingConsole()
+        assert_equal(
+            rebot(self.data, output=OUTPUT_PATH, log=LOG_PATH,
+                  report=REPORT_PATH, console=console),
+            1,
+        )
+        methods = {name for name, _ in console.calls}
+        assert_true("output_file" in methods)
+        assert_true("log_file" in methods)
+        assert_true("report_file" in methods)
+        assert_true("close" in methods)
+        # Rebot doesn't run tests, so no execution events.
+        assert_true("start_suite" not in methods)
+        assert_true("end_test" not in methods)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Add `--console` and `--quiet` options to `rebot`, mirroring the mechanism added to `robot` in #5671/#5672. This allows controlling Rebot's console output type, including custom console loggers.

## Changes

- **`--console verbose|quiet|none|path.to.CustomLogger`** — select console output type for Rebot
- **`--quiet`** — shortcut for `--console quiet`
- **`--console dotted`** — rejected with a clear error (dotted is meaningless without test execution progress)
- **Programmatic API** — `rebot(..., console='quiet')` or `rebot(..., console=my_logger_obj)` both work
- Move `pythonpath` setup before console logger registration in `Rebot.main()` so custom console modules on `--pythonpath` can be imported
- Skipped `--dotted`, `--consolewidth`, `--consolemarkers` as they don't apply to Rebot's non-execution context

## Files changed

| File | Change |
|------|--------|
| `src/robot/conf/settings.py` | Add `ConsoleType`/`ConsoleTypeQuiet` to `RebotSettings`, add `console` property with dotted rejection, update `console_output_config`, prevent console propagation in `get_rebot_settings()` |
| `src/robot/rebot.py` | Add `--console`/`--quiet` to USAGE, reorder pythonpath before console registration, update `rebot()` docstring |
| `atest/resources/atest_resource.robot` | Add `Stdout Should Be Empty` keyword |
| `atest/robot/cli/rebot/console.robot` | New: 12 acceptance tests |

Fixes #5674