### PR TITLE
Document custom console loggers for robot and rebot in User Guide

### DIFF
--- a/doc/userguide/src/Appendices/CommandLineOptions.rst
+++ b/doc/userguide/src/Appendices/CommandLineOptions.rst
@@ -83,7 +83,8 @@ Command line options for test execution
   --prerunmodifier <name:args>    Activate `programmatic modification of test data`_.
   --prerebotmodifier <name:args>  Activate `programmatic modification of results`_.
   --randomize <all|suites|tests|none>  `Randomizes`_ test execution order.
-  --console <verbose|dotted|quiet|none>  `Console output type`_.
+  --console <verbose|dotted|quiet|none|custom>  `Console output type`_.
+                          Also accepts `custom console loggers`_.
   --dotted                Shortcut for `--console dotted`.
   --quiet                 Shortcut for `--console quiet`.
   -W, --consolewidth <width>  `Sets the width`_ of the console output.
@@ -146,6 +147,9 @@ Command line options for post-processing outputs
   --processemptysuite     Processes output files even if files contain
                           `empty test suites`_.
   --prerebotmodifier <name:args>  Activate `programmatic modification of results`_.
+  --console <verbose|quiet|none|custom>  `Controlling Rebot console output`_.
+                          Also accepts `custom console loggers`_.
+  --quiet                 Shortcut for `--console quiet`.
   -C, --consolecolors <auto|on|ansi|off>  `Specifies are colors`_ used on the console.
   --consolelinks <auto|off>  Controls `making paths to results files hyperlinks <Console links_>`_.
   -P, --pythonpath <path>   Additional locations to add to the `module search path`_.

--- a/doc/userguide/src/ExecutingTestCases/ConfiguringExecution.rst
+++ b/doc/userguide/src/ExecutingTestCases/ConfiguringExecution.rst
@@ -817,6 +817,84 @@ Examples::
     robot --console quiet tests.robot
     robot --dotted tests.robot
 
+Custom console loggers
+~~~~~~~~~~~~~~~~~~~~~~
+
+In addition to the built-in values listed above, the :option:`--console` option
+accepts a path or name of a custom console logger class or module. The argument
+format is the same as with :option:`--listener`: a path to a Python file, a
+module name, or a dotted class name, with optional arguments separated by colons.
+
+Custom console loggers receive the same `listener version 3`__ method calls as
+normal listeners. Only methods that are implemented are called — missing methods
+are silently ignored. This means a minimal console only needs to implement the
+hooks it is interested in.
+
+__ `Listener interface`_
+
+Examples::
+
+    robot --console path/to/MyConsole.py tests.robot
+    robot --console MyConsole --pythonpath /path/to/consoles tests.robot
+    robot --console MyConsole.py:arg1:arg2 tests.robot
+
+The following example shows a custom console that provides a compact progress
+view with elapsed time and a running pass/fail counter — useful in CI pipelines
+or when the verbose output is too noisy but `dotted` does not provide enough
+context:
+
+.. sourcecode:: python
+
+    import sys
+    import time
+
+
+    class ProgressConsole:
+
+        def __init__(self):
+            self.passed = 0
+            self.failed = 0
+            self.skipped = 0
+            self.start_time = None
+
+        def start_suite(self, data, result):
+            if self.start_time is None:
+                self.start_time = time.time()
+
+        def end_test(self, data, result):
+            if result.passed:
+                self.passed += 1
+            elif result.failed:
+                self.failed += 1
+            else:
+                self.skipped += 1
+            elapsed = time.time() - self.start_time
+            total = self.passed + self.failed + self.skipped
+            status = '✓' if result.passed else '✗' if result.failed else '-'
+            print(f" {status} [{elapsed:>6.1f}s] {result.name}  "
+                  f"({total} done, {self.failed} failed)",
+                  file=sys.__stdout__)
+
+        def result_file(self, kind, path):
+            print(f"{kind}:  {path}", file=sys.__stdout__)
+
+        def close(self):
+            elapsed = time.time() - self.start_time
+            total = self.passed + self.failed + self.skipped
+            print(f"\n{total} tests in {elapsed:.1f}s: "
+                  f"{self.passed} passed, {self.failed} failed, "
+                  f"{self.skipped} skipped", file=sys.__stdout__)
+
+When using the `programmatic API`__, the ``console`` option also accepts
+a pre-instantiated Python object::
+
+    from robot import run
+    run('tests.robot', console=ProgressConsole())
+
+__ https://robot-framework.readthedocs.io
+
+.. note:: Support for custom console loggers is new in Robot Framework 7.5.
+
 Console width
 ~~~~~~~~~~~~~
 

--- a/doc/userguide/src/ExecutingTestCases/ConfiguringExecution.rst
+++ b/doc/userguide/src/ExecutingTestCases/ConfiguringExecution.rst
@@ -831,7 +831,7 @@ Examples::
     robot --console MyConsole --pythonpath /path/to/consoles tests.robot
     robot --console CustomConsole.py:arg1:arg2 tests.robot
 
-Custom console loggers receive the same `listener version 3`__ method calls as
+Custom console loggers receive the same `listener method calls`__ as
 normal listeners. Only methods that are implemented are called — missing methods
 are silently ignored. This means a minimal console only needs to implement the
 hooks it is interested in.
@@ -845,7 +845,6 @@ context:
 
 .. sourcecode:: python
 
-    import sys
     import time
 
 
@@ -871,19 +870,22 @@ context:
             elapsed = time.time() - self.start_time
             total = self.passed + self.failed + self.skipped
             status = '✓' if result.passed else '✗' if result.failed else '-'
-            print(f" {status} [{elapsed:>6.1f}s] {result.name}  "
-                  f"({total} done, {self.failed} failed)",
-                  file=sys.__stdout__)
+            print(
+                f" {status} [{elapsed:>6.1f}s] {result.name}  "
+                f"({total} done, {self.failed} failed)"
+            )
 
         def result_file(self, kind, path):
-            print(f"{kind}:  {path}", file=sys.__stdout__)
+            print(f"{kind}:  {path}")
 
         def close(self):
             elapsed = time.time() - self.start_time
             total = self.passed + self.failed + self.skipped
-            print(f"\n{total} tests in {elapsed:.1f}s: "
-                  f"{self.passed} passed, {self.failed} failed, "
-                  f"{self.skipped} skipped", file=sys.__stdout__)
+            print(
+                f"\n{total} tests in {elapsed:.1f}s: "
+                f"{self.passed} passed, {self.failed} failed, "
+                f"{self.skipped} skipped"
+            )
 
 When using the `programmatic API`__, the ``console`` option also accepts
 a pre-instantiated Python object::

--- a/doc/userguide/src/ExecutingTestCases/ConfiguringExecution.rst
+++ b/doc/userguide/src/ExecutingTestCases/ConfiguringExecution.rst
@@ -825,18 +825,18 @@ accepts a path or name of a custom console logger class or module. The argument
 format is the same as with :option:`--listener`: a path to a Python file, a
 module name, or a dotted class name, with optional arguments separated by colons.
 
+Examples::
+
+    robot --console path/to/myconsole.py tests.robot
+    robot --console MyConsole --pythonpath /path/to/consoles tests.robot
+    robot --console CustomConsole.py:arg1:arg2 tests.robot
+
 Custom console loggers receive the same `listener version 3`__ method calls as
 normal listeners. Only methods that are implemented are called — missing methods
 are silently ignored. This means a minimal console only needs to implement the
 hooks it is interested in.
 
 __ `Listener interface`_
-
-Examples::
-
-    robot --console path/to/MyConsole.py tests.robot
-    robot --console MyConsole --pythonpath /path/to/consoles tests.robot
-    robot --console MyConsole.py:arg1:arg2 tests.robot
 
 The following example shows a custom console that provides a compact progress
 view with elapsed time and a running pass/fail counter — useful in CI pipelines

--- a/doc/userguide/src/ExecutingTestCases/PostProcessing.rst
+++ b/doc/userguide/src/ExecutingTestCases/PostProcessing.rst
@@ -215,3 +215,27 @@ The JSON output file structure is documented in the :file:`result.json` `schema 
           Prior to Robot Framework 7.2 JSON output files contained only
           information about the executed suite, but nowadays they contain
           the same result data as `XML output files`_.
+
+Controlling Rebot console output
+---------------------------------
+
+By default, Rebot reports output file paths and possible errors and warnings
+on the console. This can be controlled with the :option:`--console` option
+that supports the following values:
+
+`verbose`
+    Report output file paths, errors and warnings (default).
+
+`quiet`
+    No output except for errors and warnings.
+
+`none`
+    No output whatsoever.
+
+The :option:`--quiet` option is a shortcut for `--console quiet`.
+
+In addition to the built-in values, :option:`--console` also accepts
+`custom console loggers`_, using the same mechanism as with ``robot``.
+
+.. note:: Support for :option:`--console` and :option:`--quiet` with Rebot
+          is new in Robot Framework 7.5.

--- a/doc/userguide/src/ExecutingTestCases/PostProcessing.rst
+++ b/doc/userguide/src/ExecutingTestCases/PostProcessing.rst
@@ -221,7 +221,7 @@ Controlling Rebot console output
 
 By default, Rebot reports output file paths and possible errors and warnings
 on the console. This can be controlled with the :option:`--console` option
-that supports the following values:
+that supports the following case-insensitive values:
 
 `verbose`
     Report output file paths, errors and warnings (default).

--- a/doc/userguide/src/ExtendingRobotFramework/ListenerInterface.rst
+++ b/doc/userguide/src/ExtendingRobotFramework/ListenerInterface.rst
@@ -19,6 +19,8 @@ There are two supported listener interface versions, `listener version 2`_ and
 called with different arguments. The newer listener version 3 is more powerful
 and generally recommended.
 
+.. note:: The listener interface is used also by `custom console loggers`_.
+
 __ `Registering listeners from command line`_
 __ `Libraries as listeners`_
 
@@ -1105,7 +1107,3 @@ that covering them fully here in the User Guide is not possible. For more exampl
 you can see the `acceptance tests`__ using theses methods in various ways.
 
 __ https://github.com/robotframework/robotframework/tree/master/atest/testdata/output/listener_interface/body_items_v3
-
-The listener version 3 API is also used by `custom console loggers`_ that can
-replace the built-in console output (verbose, dotted, etc.) with a user-defined
-implementation.

--- a/doc/userguide/src/ExtendingRobotFramework/ListenerInterface.rst
+++ b/doc/userguide/src/ExtendingRobotFramework/ListenerInterface.rst
@@ -1105,3 +1105,7 @@ that covering them fully here in the User Guide is not possible. For more exampl
 you can see the `acceptance tests`__ using theses methods in various ways.
 
 __ https://github.com/robotframework/robotframework/tree/master/atest/testdata/output/listener_interface/body_items_v3
+
+The listener version 3 API is also used by `custom console loggers`_ that can
+replace the built-in console output (verbose, dotted, etc.) with a user-defined
+implementation.


### PR DESCRIPTION
Add documentation for the --console option accepting custom console logger classes and modules, introduced in PRs #5672 and #5677.

- Add "Custom console loggers" subsection under "Console output type" in ConfiguringExecution.rst with usage examples and a ProgressConsole class example.
- Add "Controlling Rebot console output" section in PostProcessing.rst documenting --console and --quiet support for Rebot.
- Update CommandLineOptions.rst appendix for both robot and rebot.
- Add cross-reference from ListenerInterface.rst noting that custom console loggers use the listener version 3 API.

related to #5618 and #5674

