### PR TITLE
Add interactive step debugger to Dialogs library

### DIFF
--- a/atest/robot/standard_libraries/dialogs/debug.robot
+++ b/atest/robot/standard_libraries/dialogs/debug.robot
@@ -1,0 +1,26 @@
+*** Settings ***
+Documentation     Acceptance tests for the interactive step debugger
+...               (`Debug` keyword in the Dialogs library). Driven
+...               non-interactively via the FakeDebuggerDialog test
+...               library, so these run on CI like normal atests.
+Suite Setup       Run Tests    ${EMPTY}    standard_libraries/dialogs/debug.robot
+Resource          atest_resource.robot
+
+*** Test Cases ***
+Continue resumes immediately
+    Check Test Case    ${TESTNAME}
+
+Step In stops on the very next body item
+    Check Test Case    ${TESTNAME}
+
+Step Over skips nested user keyword body
+    Check Test Case    ${TESTNAME}
+
+Step Out runs to the caller
+    Check Test Case    ${TESTNAME}
+
+Multiple Debug calls each open the dialog
+    Check Test Case    ${TESTNAME}
+
+Abort ends the run
+    Check Test Case    ${TESTNAME}

--- a/atest/robot/standard_libraries/dialogs/dialogs.robot
+++ b/atest/robot/standard_libraries/dialogs/dialogs.robot
@@ -87,3 +87,15 @@ Garbage Collection In Thread Should Not Cause Problems
 
 Timeout can close dialog
     Check Test Case    ${TESTNAME}
+
+Debug Continue
+    Check Test Case    ${TESTNAME}
+
+Debug Step In
+    Check Test Case    ${TESTNAME}
+
+Debug Step Over Skips Nested Keyword
+    Check Test Case    ${TESTNAME}
+
+Debug Abort Terminates Run
+    Check Test Case    ${TESTNAME}

--- a/atest/testdata/standard_libraries/dialogs/debug.robot
+++ b/atest/testdata/standard_libraries/dialogs/debug.robot
@@ -1,0 +1,56 @@
+*** Settings ***
+Documentation     Non-interactive acceptance tests for the `Debug` keyword.
+...               The real Tk dialog is replaced with a scripted fake by
+...               `FakeDebuggerDialog` so these can run unattended on CI.
+Library           Dialogs
+Library           FakeDebuggerDialog
+Suite Teardown    Reset Debugger
+
+*** Test Cases ***
+Continue resumes immediately
+    Script Debugger Actions    CONTINUE
+    Debug    Continue test
+    Log    after debug
+    Debugger Open Count Should Be    1
+
+Step In stops on the very next body item
+    Script Debugger Actions    STEP_IN    CONTINUE
+    Debug    Step in test
+    Log    next sibling 1
+    Log    next sibling 2
+    Debugger Open Count Should Be    2
+
+Step Over skips nested user keyword body
+    Script Debugger Actions    STEP_OVER    CONTINUE
+    Debug    Step over test
+    Nested User Keyword
+    Log    after nested
+    Debugger Open Count Should Be    2
+
+Step Out runs to the caller
+    Script Debugger Actions    STEP_OUT    CONTINUE
+    Run Inner With Debug
+    Log    after caller
+    Debugger Open Count Should Be    2
+
+Multiple Debug calls each open the dialog
+    Script Debugger Actions    CONTINUE    CONTINUE    CONTINUE
+    Debug    First
+    Debug    Second
+    Debug    Third
+    Debugger Open Count Should Be    3
+
+Abort ends the run
+    [Documentation]    FAIL    Test execution aborted from debugger.
+    Script Debugger Actions    ABORT
+    Debug    Abort here
+    Log    should not be reached
+
+*** Keywords ***
+Nested User Keyword
+    Log    inside nested 1
+    Log    inside nested 2
+
+Run Inner With Debug
+    Debug    Inside inner
+    Log    inner step after debug

--- a/atest/testdata/standard_libraries/dialogs/dialogs.robot
+++ b/atest/testdata/standard_libraries/dialogs/dialogs.robot
@@ -163,3 +163,28 @@ Timeout can close dialog
     [Documentation]    FAIL Test timeout 1 second exceeded.
     [Timeout]    1 second
     Pause Execution    Wait for timeout.
+
+Debug Continue
+    Debug    Verify Step In / Step Over / Step Out / Continue / Abort buttons exist,\nthen press <C> for Continue.
+
+Debug Step In
+    Debug    Press <I> for Step In. The dialog should open again on the next Log.
+    Log    First sibling after Debug
+    Log    Second sibling
+    Debug    Then press <C> to finish.
+
+Debug Step Over Skips Nested Keyword
+    Debug    Press <O> for Step Over.
+    Debug Nested Helper
+    Log    After nested helper - dialog should open here.
+    Debug    Press <C> to finish.
+
+Debug Abort Terminates Run
+    [Documentation]  FAIL Test execution aborted from debugger.
+    Debug    Press <A> to Abort. The whole run will stop.
+    Log    Should not be reached.
+
+*** Keywords ***
+Debug Nested Helper
+    Log    Inside nested helper
+    Log    Still inside nested helper

--- a/atest/testresources/testlibs/FakeDebuggerDialog.py
+++ b/atest/testresources/testlibs/FakeDebuggerDialog.py
@@ -1,0 +1,112 @@
+"""Test library that swaps the real Tk dialog used by the ``Debug``
+keyword for a scripted fake so that ``standard_libraries/dialogs``
+acceptance tests can run non-interactively on CI.
+
+Usage from a Robot test:
+
+| Library    FakeDebuggerDialog
+|
+| *** Test Cases ***
+| Step in and continue
+|     Script Debugger Actions    STEP_IN    CONTINUE
+|     Debug                       Pause here
+|     Some Keyword
+|     Debugger Open Count Should Be    2
+"""
+
+from robot.libraries import _debugger
+from robot.libraries._debugger import _DebugController
+
+
+class _ScriptedFakeDialog:
+
+    def __init__(self, controller, action):
+        self._controller = controller
+        self._action = action
+
+    def show(self):
+        return self._action
+
+
+class _Recorder:
+
+    def __init__(self):
+        self.actions = []
+        self.calls = []
+
+    def factory(self, message, stack, variables, kind):
+        self.calls.append(
+            {"message": message, "kind": kind, "stack": list(stack)}
+        )
+        if not self.actions:
+            action = _debugger.CONTINUE
+        else:
+            action = self.actions.pop(0)
+        return _ScriptedFakeDialog(self, action)
+
+
+class FakeDebuggerDialog:
+    """Robot library exposing scripting helpers for the debugger dialog."""
+
+    ROBOT_LIBRARY_SCOPE = "GLOBAL"
+
+    _ACTIONS = {
+        "STEP_IN": _debugger.STEP_IN,
+        "STEP_OVER": _debugger.STEP_OVER,
+        "STEP_OUT": _debugger.STEP_OUT,
+        "CONTINUE": _debugger.CONTINUE,
+        "ABORT": _debugger.ABORT,
+    }
+
+    def __init__(self):
+        self._recorder = _Recorder()
+        self._installed = False
+
+    def script_debugger_actions(self, *actions):
+        """Set the sequence of actions the next dialog opens will return.
+
+        ``actions`` is a list of strings, one per pause: ``STEP_IN``,
+        ``STEP_OVER``, ``STEP_OUT``, ``CONTINUE`` or ``ABORT``.
+        """
+        self._install_factory()
+        self._recorder.actions = [self._resolve(a) for a in actions]
+        self._recorder.calls = []
+
+    def _resolve(self, name):
+        try:
+            return self._ACTIONS[name.upper()]
+        except KeyError:
+            raise ValueError(
+                f"Unknown debugger action '{name}'. "
+                f"Expected one of: {', '.join(self._ACTIONS)}."
+            )
+
+    def _install_factory(self):
+        if self._installed:
+            return
+        _DebugController.instance()._dialog_factory = self._recorder.factory
+        self._installed = True
+
+    def debugger_open_count_should_be(self, expected):
+        """Assert how many times the (fake) debugger dialog has opened."""
+        actual = len(self._recorder.calls)
+        expected = int(expected)
+        if actual != expected:
+            raise AssertionError(
+                f"Expected debugger dialog to open {expected} times, "
+                f"got {actual}. Calls: {self._recorder.calls}"
+            )
+
+    def get_debugger_call_messages(self):
+        """Return the list of headline messages from each dialog open."""
+        return [call["message"] for call in self._recorder.calls]
+
+    def reset_debugger(self):
+        """Reset both the recorder state and the controller singleton.
+
+        Call this from Suite Teardown so other tests aren't affected.
+        """
+        self._recorder.actions = []
+        self._recorder.calls = []
+        _DebugController.reset_instance()
+        self._installed = False

--- a/src/robot/libraries/Dialogs.py
+++ b/src/robot/libraries/Dialogs.py
@@ -18,19 +18,34 @@
 ``Dialogs`` is Robot Framework's standard library that provides means
 for pausing the test or task execution and getting input from users.
 
-Long lines in the provided messages are wrapped automatically. If you want
-to wrap lines manually, you can add newlines using the ``\\n`` character
-sequence.
+In addition to the simple `Pause Execution` dialog and the various
+input/selection dialogs, the library also provides an interactive
+`Debug` keyword which opens a step debugger with Step In / Step Over /
+Step Out / Continue / Abort controls, plus live keyword-stack and
+variables panels. See the `Debug` keyword's own documentation for full
+details and the explicit non-goals (no reverse execution, no DAP
+server, no Python-level stepping).
+
+All dialogs require a graphical display. Setting the
+``ROBOT_NO_DIALOGS`` environment variable makes the `Debug` keyword
+fail fast with a clear error instead of hanging when a stray call is
+hit on headless CI.
+
+Long lines in the provided messages are wrapped automatically. If you
+want to wrap lines manually, you can add newlines using the ``\\n``
+character sequence.
 """
 
 from robot.version import get_version
 
+from ._debugger import _DebugController
 from .dialogs_py import (
     InputDialog, MessageDialog, MultipleSelectionDialog, PassFailDialog, SelectionDialog
 )
 
 __version__ = get_version()
 __all__ = [
+    "debug",
     "execute_manual_step",
     "get_selection_from_user",
     "get_selections_from_user",
@@ -45,6 +60,56 @@ def pause_execution(message: str = "Execution paused. Press OK to continue."):
     ``message`` is the message shown in the dialog.
     """
     MessageDialog(message).show()
+
+
+def debug(message: str = "Debugger paused."):
+    """Pauses execution and opens an interactive step debugger dialog.
+
+    Unlike `Pause Execution`, which only blocks until the user clicks
+    ``Ok``, this keyword opens a debugger window with controls to:
+
+    - **Step In** — stop on the very next body item (any depth), so the
+      user can drill into the next keyword call, FOR iteration, IF
+      branch, etc.
+    - **Step Over** — run the next sibling body item to completion and
+      stop before the one after it (or after returning from the current
+      scope).
+    - **Step Out** — run the rest of the current scope and stop after
+      returning to the caller.
+    - **Continue** — resume normal execution until the next ``Debug``
+      keyword is hit.
+    - **Abort** — gracefully end the entire run (same effect as Ctrl-C
+      handled by ``STOP_SIGNAL_MONITOR``).
+
+    The dialog also shows the live keyword stack and the variables
+    visible at the current scope (read-only).
+
+    ``message`` is the header text shown in the initial dialog.
+
+    Example:
+    | Some Keyword
+    | Debug    Inspect state before the API call
+    | Other Keyword
+
+    *Non-goals (deliberate):*
+
+    - This keyword does **not** support stepping backward / reverse
+      execution. Library keywords typically cause irreversible side
+      effects (network calls, browser interactions, file I/O), so true
+      time-travel debugging is not possible in the general case.
+    - This keyword does **not** open a DAP (Debug Adapter Protocol)
+      session. For IDE-integrated breakpoint debugging in VS Code or
+      IntelliJ, use the external ``RobotCode`` extension.
+    - This keyword does **not** step into Python code inside library
+      keywords. Use ``pdb`` / ``debugpy`` for Python-level debugging.
+
+    *Headless environments:* the dialog requires a graphical display.
+    On Linux/macOS without ``DISPLAY`` (or ``WAYLAND_DISPLAY``) — or
+    on any platform with ``ROBOT_NO_DIALOGS`` set to a truthy value —
+    the keyword fails fast with a clear error; remove the call from
+    the test or guard it behind a tag before running on headless CI.
+    """
+    _DebugController.instance().pause(message)
 
 
 def execute_manual_step(message: str, default_error: str = ""):

--- a/src/robot/libraries/_debugger.py
+++ b/src/robot/libraries/_debugger.py
@@ -1,0 +1,287 @@
+#  Copyright 2008-2015 Nokia Networks
+#  Copyright 2016-     Robot Framework Foundation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Interactive step-debugger backing the ``Debug`` keyword in Dialogs.
+
+This module is internal. Public surface is the ``Debug`` keyword in
+``robot.libraries.Dialogs``. The implementation is split into two pieces:
+
+* :class:`_DebugController` — singleton holding the step state machine
+  (paused depth + step mode), opens a UI dialog when paused, and decides
+  on each subsequent step whether to pause again.
+* :class:`_DebugListener` — minimal :class:`LoggerApi` subclass that
+  forwards every ``start_body_item`` event to the controller. Registered
+  lazily through ``LOGGER.register_logger`` the first time the user
+  activates the debugger so that simply importing the ``Dialogs`` library
+  has no side effects.
+
+Stepping semantics use stack depth tracked via
+``EXECUTION_CONTEXTS.current.steps``:
+
+* ``STEP_IN``  — stop on the very next body item, any depth.
+* ``STEP_OVER`` — stop when ``depth <= paused_depth`` (next sibling or
+  after returning to a shallower scope).
+* ``STEP_OUT`` — stop when ``depth < paused_depth`` (only after returning
+  from the current scope).
+* ``CONTINUE`` — never stop until the user hits another ``Debug`` keyword.
+* ``ABORT`` — raise ``ExecutionFailed(..., exit=True)`` to gracefully end
+  the run.
+
+The controller is deliberately UI-agnostic. The dialog factory is
+injectable so unit tests can drive the state machine without Tk.
+The Variables panel is read-only — to inspect a value at a pause
+point, bind it to a variable (or call ``Log`` / ``Log Variables``)
+before the ``Debug`` call.
+"""
+
+from robot.errors import ExecutionFailed
+from robot.output.loggerapi import LoggerApi
+
+
+CONTINUE = "CONTINUE"
+STEP_IN = "STEP_IN"
+STEP_OVER = "STEP_OVER"
+STEP_OUT = "STEP_OUT"
+ABORT = "ABORT"
+
+_VALID_ACTIONS = frozenset((CONTINUE, STEP_IN, STEP_OVER, STEP_OUT, ABORT))
+
+
+class _DebugController:
+    """Singleton state machine for the interactive step debugger.
+
+    Use :meth:`instance` to access the shared instance. Tests can create
+    additional instances directly and inject a fake ``dialog_factory`` to
+    avoid opening Tk windows.
+    """
+
+    _instance = None
+
+    def __init__(self, dialog_factory=None):
+        self._mode = CONTINUE
+        self._paused_depth = 0
+        self._listener = None
+        self._listener_registered = False
+        self._dialog_factory = dialog_factory
+        self._in_dialog = False
+
+    @classmethod
+    def instance(cls):
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def reset_instance(cls):
+        """Test hook: drop the cached singleton."""
+        if cls._instance is not None and cls._instance._listener_registered:
+            try:
+                from robot.output.logger import LOGGER
+
+                LOGGER.unregister_logger(cls._instance._listener)
+            except Exception:
+                pass
+        cls._instance = None
+
+    def pause(self, message):
+        """Open the debugger dialog from inside the ``Debug`` keyword.
+
+        ``message`` is shown in the dialog header. This call blocks until
+        the user picks an action.
+        """
+        self._ensure_listener()
+        self._open_dialog(message=message, kind="paused")
+
+    def on_start_body_item(self, data, result):
+        if self._mode == CONTINUE:
+            return
+        if self._in_dialog:
+            return
+        depth = self._current_depth()
+        if self._should_stop(depth):
+            self._open_dialog(
+                message=self._format_step_message(data, result),
+                kind="step",
+            )
+
+    def _should_stop(self, depth):
+        if self._mode == STEP_IN:
+            return True
+        if self._mode == STEP_OVER:
+            return depth <= self._paused_depth
+        if self._mode == STEP_OUT:
+            return depth < self._paused_depth
+        return False
+
+    def _open_dialog(self, message, kind):
+        snapshot = self._snapshot()
+        depth = snapshot["depth"]
+        dialog_factory = self._dialog_factory or self._default_dialog_factory
+        self._in_dialog = True
+        try:
+            dialog = dialog_factory(
+                message=message,
+                stack=snapshot["stack"],
+                variables=snapshot["variables"],
+                kind=kind,
+            )
+            action = dialog.show()
+        finally:
+            self._in_dialog = False
+        self._handle_action(action, depth)
+
+    def _handle_action(self, action, depth):
+        if action not in _VALID_ACTIONS:
+            action = CONTINUE
+        if action == STEP_IN:
+            self._mode = STEP_IN
+            self._paused_depth = depth
+        elif action == STEP_OVER:
+            self._mode = STEP_OVER
+            self._paused_depth = depth
+        elif action == STEP_OUT:
+            self._mode = STEP_OUT
+            self._paused_depth = depth
+        elif action == CONTINUE:
+            self._mode = CONTINUE
+            self._paused_depth = 0
+        elif action == ABORT:
+            self._mode = CONTINUE
+            self._paused_depth = 0
+            raise ExecutionFailed(
+                "Test execution aborted from debugger.",
+                exit=True,
+            )
+
+    def _snapshot(self):
+        ctx = self._current_context()
+        return {
+            "depth": self._current_depth(ctx),
+            "stack": self._gather_stack(ctx),
+            "variables": self._gather_variables(ctx),
+        }
+
+    @staticmethod
+    def _current_context():
+        from robot.running.context import EXECUTION_CONTEXTS
+
+        return EXECUTION_CONTEXTS.current
+
+    def _current_depth(self, ctx=None):
+        if ctx is None:
+            ctx = self._current_context()
+        if ctx is None:
+            return 0
+        return len(ctx.steps)
+
+    def _gather_stack(self, ctx):
+        if ctx is None:
+            return []
+        frames = []
+        for data, result, implementation in ctx.steps:
+            frames.append(self._format_frame(data, result, implementation))
+        return frames
+
+    def _gather_variables(self, ctx):
+        if ctx is None:
+            return {}
+        try:
+            variables = ctx.variables.as_dict(decoration=True)
+        except Exception:
+            return {}
+        return {name: self._format_value(value) for name, value in variables.items()}
+
+    @staticmethod
+    def _format_value(value):
+        try:
+            text = repr(value)
+        except Exception as err:
+            return f"<unrepresentable: {err}>"
+        if len(text) > 200:
+            text = text[:197] + "..."
+        return text
+
+    @staticmethod
+    def _format_frame(data, result, implementation):
+        kind = getattr(result, "type", "") or ""
+        name = _DebugController._body_item_label(data, result, implementation)
+        if kind:
+            return f"{kind}: {name}"
+        return name
+
+    def _format_step_message(self, data, result):
+        kind = getattr(result, "type", "") or "STEP"
+        name = _DebugController._body_item_label(data, result, None)
+        return f"Stepping into {kind}: {name}"
+
+    @staticmethod
+    def _body_item_label(data, result, implementation):
+        """Best-effort short label for a body item / result pair.
+
+        Avoids reading `.name` on result objects because that property
+        is deprecated on control-structure result classes (For, While,
+        Return, If, Try, etc.) and emits a UserWarning every time it is
+        touched in Robot Framework 7.x. ``str(data)`` is the public,
+        non-deprecated way to get a human-readable representation of
+        any body item.
+        """
+        if implementation is not None:
+            full_name = getattr(implementation, "full_name", None)
+            if full_name:
+                return full_name
+        try:
+            text = str(data)
+        except Exception:
+            text = ""
+        if text:
+            return text
+        return type(result).__name__
+
+    def _ensure_listener(self):
+        if self._listener_registered:
+            return
+        from robot.output.logger import LOGGER
+
+        self._listener = _DebugListener(self)
+        LOGGER.register_logger(self._listener)
+        self._listener_registered = True
+
+    @staticmethod
+    def _default_dialog_factory(message, stack, variables, kind):
+        from .dialogs_debugger import DebuggerDialog
+
+        return DebuggerDialog(
+            message=message,
+            stack=stack,
+            variables=variables,
+            kind=kind,
+        )
+
+
+class _DebugListener(LoggerApi):
+    """Minimal logger that fires the debugger predicate on every step.
+
+    Inherits :class:`LoggerApi` so every concrete ``start_*`` callback
+    funnels through :meth:`start_body_item` by default. Errors raised
+    here are surfaced to the runner (``LOGGER`` does not swallow logger
+    exceptions), so the controller must not raise except for an
+    intentional :class:`ExecutionFailed` from ``ABORT``.
+    """
+
+    def __init__(self, controller):
+        self._controller = controller
+
+    def start_body_item(self, data, result):
+        self._controller.on_start_body_item(data, result)

--- a/src/robot/libraries/dialogs_debugger.py
+++ b/src/robot/libraries/dialogs_debugger.py
@@ -1,0 +1,246 @@
+#  Copyright 2008-2015 Nokia Networks
+#  Copyright 2016-     Robot Framework Foundation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Tk dialog UI for the interactive step debugger.
+
+The dialog is a Tk Toplevel with:
+
+* A message label at the top describing the pause reason.
+* A two-pane middle area with a keyword stack on the left and a variables
+  table on the right.
+* A footer row with five buttons (Step In, Step Over, Step Out, Continue,
+  Abort) and matching keyboard shortcuts (I, O, U, C, A; Esc = Continue).
+
+The class mirrors ``dialogs_py.TkDialog`` style — same modal
+``show()`` poll loop using ``time.sleep`` + ``update``, same logo icon,
+same WINDOWS taskbar workaround.
+
+Used only by ``_debugger._DebugController``. Imported lazily so that
+``import robot.libraries.Dialogs`` does not pull in Tk at module-load
+time.
+"""
+
+import os
+import time
+import tkinter as tk
+from importlib.resources import read_binary
+from tkinter import ttk
+
+from robot.utils import WINDOWS
+
+from . import _debugger
+
+
+if WINDOWS:
+    from ctypes import windll
+
+    windll.shell32.SetCurrentProcessExplicitAppUserModelID("robot.dialogs")
+
+
+_BUTTON_SPECS = (
+    ("Step In", _debugger.STEP_IN, ("i", "I")),
+    ("Step Over", _debugger.STEP_OVER, ("o", "O")),
+    ("Step Out", _debugger.STEP_OUT, ("u", "U")),
+    ("Continue", _debugger.CONTINUE, ("c", "C")),
+    ("Abort", _debugger.ABORT, ("a", "A")),
+)
+
+
+def check_display_available():
+    """Raise a clear error if a graphical display is not available.
+
+    * If ``ROBOT_NO_DIALOGS`` is set to a truthy value (e.g. ``1``,
+      ``true``, ``yes``), always refuse to open the dialog. Useful for
+      CI runs where we want any stray ``Debug`` keyword to fail fast
+      rather than hang waiting for a click.
+    * On POSIX, also refuse if neither ``DISPLAY`` nor
+      ``WAYLAND_DISPLAY`` are set.
+    * On Windows the GUI is always available in an interactive session,
+      so we trust ``tk.Tk()`` to surface its own ``TclError`` otherwise.
+    """
+    if _truthy(os.environ.get("ROBOT_NO_DIALOGS")):
+        raise RuntimeError(
+            "Cannot open Robot Framework debugger: ROBOT_NO_DIALOGS is set. "
+            "Remove the `Debug` keyword or unset the env var to run "
+            "interactively."
+        )
+    if WINDOWS:
+        return
+    if os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"):
+        return
+    raise RuntimeError(
+        "Cannot open Robot Framework debugger: no graphical display "
+        "available. Set DISPLAY (X11) or WAYLAND_DISPLAY (Wayland), or "
+        "remove the `Debug` keyword from the test before running headlessly."
+    )
+
+
+def _truthy(value):
+    if value is None:
+        return False
+    return value.strip().lower() not in ("", "0", "false", "no", "off", "none")
+
+
+class DebuggerDialog(tk.Toplevel):
+    """Modal Tk dialog driving the step-debugger UX.
+
+    Constructor parameters mirror the ``dialog_factory`` contract in
+    ``_DebugController``. ``show()`` returns one of the action constants
+    from ``_debugger`` (``STEP_IN``, ``STEP_OVER``, ``STEP_OUT``,
+    ``CONTINUE``, ``ABORT``).
+    """
+
+    font = (None, 11)
+    mono_font = ("Courier", 10)
+    padding = 8 if WINDOWS else 12
+
+    def __init__(self, message, stack, variables, kind="paused"):
+        check_display_available()
+        super().__init__(self._get_root())
+        self._result = None
+        self._closed = False
+        self._initialize_dialog()
+        self._build_body(message, stack, variables)
+        self._build_buttons()
+        self._finalize_dialog()
+
+    @staticmethod
+    def _get_root():
+        root = tk.Tk()
+        root.withdraw()
+        try:
+            icon = tk.PhotoImage(master=root, data=read_binary("robot", "logo.png"))
+            root.iconphoto(True, icon)
+        except Exception:
+            pass
+        return root
+
+    def _initialize_dialog(self):
+        self.withdraw()
+        self.title("Robot Framework Debugger")
+        self.configure(padx=self.padding, pady=self.padding)
+        self.protocol("WM_DELETE_WINDOW", self._on_continue)
+        self.bind("<Escape>", self._on_continue)
+
+    def _build_body(self, message, stack, variables):
+        header = tk.Label(
+            self,
+            text=message,
+            anchor=tk.W,
+            justify=tk.LEFT,
+            font=self.font,
+            wraplength=600,
+        )
+        header.pack(fill=tk.X, pady=(0, self.padding))
+
+        panes = tk.Frame(self)
+        panes.pack(fill=tk.BOTH, expand=True)
+
+        self._build_stack_panel(panes, stack)
+        self._build_variables_panel(panes, variables)
+
+    def _build_stack_panel(self, parent, stack):
+        frame = tk.LabelFrame(parent, text="Keyword stack")
+        frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=(0, self.padding))
+        listbox = tk.Listbox(frame, font=self.mono_font, activestyle="none")
+        scrollbar = tk.Scrollbar(frame, orient=tk.VERTICAL, command=listbox.yview)
+        listbox.configure(yscrollcommand=scrollbar.set)
+        for index, frame_text in enumerate(stack):
+            listbox.insert(tk.END, f"{index}: {frame_text}")
+        if stack:
+            listbox.see(tk.END)
+            listbox.selection_set(tk.END)
+        listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+
+    def _build_variables_panel(self, parent, variables):
+        frame = tk.LabelFrame(parent, text="Variables")
+        frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        tree = ttk.Treeview(
+            frame,
+            columns=("value",),
+            show="tree headings",
+            height=12,
+        )
+        tree.heading("#0", text="Name")
+        tree.heading("value", text="Value")
+        tree.column("#0", width=180, stretch=False)
+        tree.column("value", width=320, stretch=True)
+        scrollbar = ttk.Scrollbar(frame, orient=tk.VERTICAL, command=tree.yview)
+        tree.configure(yscrollcommand=scrollbar.set)
+        for name in sorted(variables):
+            tree.insert("", tk.END, text=name, values=(variables[name],))
+        tree.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+
+    def _build_buttons(self):
+        frame = tk.Frame(self, pady=self.padding)
+        frame.pack(fill=tk.X)
+        for label, action, shortcuts in _BUTTON_SPECS:
+            button = tk.Button(
+                frame,
+                text=label,
+                width=12,
+                font=self.font,
+                command=self._make_choice(action),
+            )
+            button.pack(side=tk.LEFT, padx=self.padding // 2)
+            for char in shortcuts:
+                self.bind(char, self._make_choice(action))
+
+    def _make_choice(self, action):
+        def callback(event=None):
+            self._result = action
+            self._closed = True
+
+        return callback
+
+    def _on_continue(self, event=None):
+        self._result = _debugger.CONTINUE
+        self._closed = True
+
+    def _finalize_dialog(self):
+        self.update()
+        screen_width = self.winfo_screenwidth()
+        screen_height = self.winfo_screenheight()
+        width = max(self.winfo_reqwidth(), screen_width // 2)
+        height = max(self.winfo_reqheight(), screen_height // 2)
+        width = min(width, screen_width - 40)
+        height = min(height, screen_height - 40)
+        x = (screen_width - width) // 2
+        y = (screen_height - height) // 2
+        self.geometry(f"{width}x{height}+{x}+{y}")
+        self.lift()
+        self.deiconify()
+        self.focus_force()
+
+    def show(self):
+        """Run the dialog modally and return the chosen action.
+
+        Uses the same ``time.sleep`` + ``update`` poll loop as the
+        existing Dialogs library so that Robot Framework timeouts and
+        signal handlers can still interrupt a paused debugger.
+        """
+        try:
+            while not self._closed:
+                time.sleep(0.1)
+                self.update()
+        finally:
+            try:
+                self.destroy()
+                self.update()
+            except tk.TclError:
+                pass
+        return self._result

--- a/utest/running/test_debug_controller.py
+++ b/utest/running/test_debug_controller.py
@@ -1,0 +1,296 @@
+"""Unit tests for the interactive step-debugger controller.
+
+These tests exercise the state machine in ``robot.libraries._debugger``
+without opening any Tk windows. A fake dialog factory is injected and
+the controller's depth lookup is patched to point at a synthetic
+execution context stub so we can simulate arbitrary stack sequences.
+"""
+
+import unittest
+
+from robot.errors import ExecutionFailed
+from robot.libraries._debugger import (
+    ABORT, CONTINUE, STEP_IN, STEP_OUT, STEP_OVER, _DebugController, _DebugListener,
+)
+
+
+class _FakeDialog:
+    """Returns a scripted action when ``show()`` is called."""
+
+    def __init__(self, action):
+        self._action = action
+
+    def show(self):
+        return self._action
+
+
+class _ScriptedDialogFactory:
+    """Pop one ``_FakeDialog`` per ``__call__`` from a scripted queue.
+
+    Used as the ``dialog_factory`` so tests can deterministically drive
+    the controller through a sequence of pauses without Tk.
+    """
+
+    def __init__(self, actions):
+        self._actions = list(actions)
+        self.calls = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        if not self._actions:
+            raise AssertionError("Dialog opened more times than scripted.")
+        return _FakeDialog(self._actions.pop(0))
+
+
+class _StubVariables:
+
+    def as_dict(self, decoration=True):
+        return {"${X}": 1}
+
+
+class _StubContext:
+
+    def __init__(self, depth=0):
+        self.steps = [(None, None, None)] * depth
+        self.variables = _StubVariables()
+
+
+def _make_controller(actions, depth_supplier=None):
+    """Build a controller wired to a scripted dialog and depth supplier."""
+    factory = _ScriptedDialogFactory(actions)
+    controller = _DebugController(dialog_factory=factory)
+    if depth_supplier is None:
+        depth_supplier = lambda ctx=None: 0  # noqa: E731
+    controller._current_depth = depth_supplier  # type: ignore[assignment]
+    controller._current_context = staticmethod(lambda: _StubContext(0))  # noqa
+    controller._gather_stack = lambda ctx: []  # type: ignore[assignment]
+    controller._gather_variables = lambda ctx: {}  # type: ignore[assignment]
+    return controller, factory
+
+
+class TestStepPredicate(unittest.TestCase):
+    """Pure unit tests on ``_should_stop`` — no dialog interaction."""
+
+    def setUp(self):
+        self.controller = _DebugController()
+
+    def test_continue_never_stops(self):
+        self.controller._mode = CONTINUE
+        self.controller._paused_depth = 5
+        for depth in range(0, 10):
+            self.assertFalse(self.controller._should_stop(depth))
+
+    def test_step_in_always_stops(self):
+        self.controller._mode = STEP_IN
+        self.controller._paused_depth = 5
+        for depth in range(0, 10):
+            self.assertTrue(self.controller._should_stop(depth))
+
+    def test_step_over_stops_at_or_above_paused_depth(self):
+        self.controller._mode = STEP_OVER
+        self.controller._paused_depth = 5
+        self.assertTrue(self.controller._should_stop(5))
+        self.assertTrue(self.controller._should_stop(4))
+        self.assertTrue(self.controller._should_stop(0))
+        self.assertFalse(self.controller._should_stop(6))
+        self.assertFalse(self.controller._should_stop(99))
+
+    def test_step_out_stops_only_above_paused_depth(self):
+        self.controller._mode = STEP_OUT
+        self.controller._paused_depth = 5
+        self.assertTrue(self.controller._should_stop(4))
+        self.assertTrue(self.controller._should_stop(0))
+        self.assertFalse(self.controller._should_stop(5))
+        self.assertFalse(self.controller._should_stop(6))
+        self.assertFalse(self.controller._should_stop(99))
+
+
+class TestHandleAction(unittest.TestCase):
+    """Verify state transitions chosen by the user via the dialog."""
+
+    def setUp(self):
+        self.controller = _DebugController()
+
+    def test_unknown_action_falls_back_to_continue(self):
+        self.controller._mode = STEP_IN
+        self.controller._paused_depth = 7
+        self.controller._handle_action(None, depth=3)
+        self.assertEqual(self.controller._mode, CONTINUE)
+        self.assertEqual(self.controller._paused_depth, 0)
+
+    def test_step_in_records_depth(self):
+        self.controller._handle_action(STEP_IN, depth=3)
+        self.assertEqual(self.controller._mode, STEP_IN)
+        self.assertEqual(self.controller._paused_depth, 3)
+
+    def test_step_over_records_depth(self):
+        self.controller._handle_action(STEP_OVER, depth=4)
+        self.assertEqual(self.controller._mode, STEP_OVER)
+        self.assertEqual(self.controller._paused_depth, 4)
+
+    def test_step_out_records_depth(self):
+        self.controller._handle_action(STEP_OUT, depth=5)
+        self.assertEqual(self.controller._mode, STEP_OUT)
+        self.assertEqual(self.controller._paused_depth, 5)
+
+    def test_continue_resets_state(self):
+        self.controller._mode = STEP_OVER
+        self.controller._paused_depth = 9
+        self.controller._handle_action(CONTINUE, depth=2)
+        self.assertEqual(self.controller._mode, CONTINUE)
+        self.assertEqual(self.controller._paused_depth, 0)
+
+    def test_abort_raises_execution_failed(self):
+        with self.assertRaises(ExecutionFailed) as cm:
+            self.controller._handle_action(ABORT, depth=2)
+        self.assertTrue(cm.exception.exit)
+        self.assertEqual(self.controller._mode, CONTINUE)
+        self.assertEqual(self.controller._paused_depth, 0)
+
+
+class TestEndToEndStepping(unittest.TestCase):
+    """Drive `pause()` + subsequent `on_start_body_item` events.
+
+    Each test fixes the depth visible to the controller at every call,
+    scripts the dialog actions, and asserts how many extra pauses are
+    triggered as the simulated execution proceeds.
+    """
+
+    def _run(self, *, paused_depth, actions, event_depths):
+        """Helper: pause at ``paused_depth`` then replay event depths.
+
+        Returns the number of dialog opens after the initial pause.
+        """
+        current_depth = paused_depth
+
+        def depth_supplier(ctx=None):
+            return current_depth
+
+        controller, factory = _make_controller(actions, depth_supplier)
+        controller.pause("paused")
+        for depth in event_depths:
+            current_depth = depth
+            controller.on_start_body_item(data=None, result=None)
+        return len(factory.calls) - 1
+
+    def test_continue_stops_only_on_explicit_pause(self):
+        extra_pauses = self._run(
+            paused_depth=5,
+            actions=[CONTINUE],
+            event_depths=[3, 4, 5, 6, 7, 8, 5],
+        )
+        self.assertEqual(extra_pauses, 0)
+
+    def test_step_in_stops_on_very_next_event(self):
+        extra_pauses = self._run(
+            paused_depth=5,
+            actions=[STEP_IN, CONTINUE],
+            event_depths=[6, 7, 8],
+        )
+        self.assertEqual(extra_pauses, 1)
+
+    def test_step_over_skips_deeper_calls(self):
+        extra_pauses = self._run(
+            paused_depth=5,
+            actions=[STEP_OVER, CONTINUE],
+            event_depths=[6, 7, 8, 5],
+        )
+        self.assertEqual(extra_pauses, 1)
+
+    def test_step_over_stops_after_returning_to_shallower(self):
+        extra_pauses = self._run(
+            paused_depth=5,
+            actions=[STEP_OVER, CONTINUE],
+            event_depths=[6, 7, 4],
+        )
+        self.assertEqual(extra_pauses, 1)
+
+    def test_step_out_ignores_same_and_deeper_depths(self):
+        extra_pauses = self._run(
+            paused_depth=5,
+            actions=[STEP_OUT, CONTINUE],
+            event_depths=[5, 6, 5, 7, 5, 4],
+        )
+        self.assertEqual(extra_pauses, 1)
+
+    def test_chained_step_in_pauses_every_event(self):
+        extra_pauses = self._run(
+            paused_depth=5,
+            actions=[STEP_IN, STEP_IN, STEP_IN, CONTINUE],
+            event_depths=[6, 7, 7, 6, 5],
+        )
+        self.assertEqual(extra_pauses, 3)
+
+    def test_step_in_then_step_over_at_new_depth(self):
+        extra_pauses = self._run(
+            paused_depth=5,
+            actions=[STEP_IN, STEP_OVER, CONTINUE],
+            event_depths=[6, 7, 8, 6, 7],
+        )
+        self.assertEqual(extra_pauses, 2)
+
+
+class TestFormatValue(unittest.TestCase):
+    """The variables panel formatter must be robust to weird values."""
+
+    def test_long_value_is_truncated(self):
+        formatted = _DebugController._format_value("x" * 500)
+        self.assertTrue(formatted.endswith("..."))
+        self.assertLessEqual(len(formatted), 210)
+
+    def test_unrepresentable_value_does_not_crash(self):
+        class _Bad:
+            def __repr__(self):
+                raise RuntimeError("nope")
+
+        formatted = _DebugController._format_value(_Bad())
+        self.assertTrue(formatted.startswith("<unrepresentable"), formatted)
+
+
+class TestReentrancy(unittest.TestCase):
+    """Verify the controller cannot recurse into a second dialog while
+    one is already open. Should not normally happen (the dialog blocks
+    the runner thread), but the guard protects against custom dialog
+    implementations that run nested event loops calling back into RF.
+    """
+
+    def test_reentrant_event_is_ignored(self):
+        controller, factory = _make_controller([CONTINUE])
+        controller._in_dialog = True
+        controller._mode = STEP_IN
+        controller._paused_depth = 0
+        controller.on_start_body_item(data=None, result=None)
+        self.assertEqual(len(factory.calls), 0)
+
+
+class TestListenerForwarding(unittest.TestCase):
+    """``_DebugListener.start_body_item`` must forward to the controller."""
+
+    def test_forwarding(self):
+        captured = []
+
+        class _Recorder:
+            def on_start_body_item(self, data, result):
+                captured.append((data, result))
+
+        listener = _DebugListener(_Recorder())
+        listener.start_body_item("d", "r")
+        self.assertEqual(captured, [("d", "r")])
+
+    def test_keyword_callbacks_funnel_through_body_item(self):
+        captured = []
+
+        class _Recorder:
+            def on_start_body_item(self, data, result):
+                captured.append(result)
+
+        listener = _DebugListener(_Recorder())
+        listener.start_user_keyword(data="d", implementation="i", result="r")
+        listener.start_library_keyword(data="d2", implementation="i", result="r2")
+        listener.start_for(data="d3", result="r3")
+        listener.start_if_branch(data="d4", result="r4")
+        self.assertEqual(captured, ["r", "r2", "r3", "r4"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a new `Debug` keyword to the Dialogs standard library. Unlike
`Pause Execution`, which only blocks on a single OK button, `Debug`
opens an in-process debugger dialog with:

- **Step In / Step Over / Step Out / Continue / Abort** buttons (with
  `I` / `O` / `U` / `C` / `A` keyboard shortcuts).
- A live **keyword stack** panel.
- A read-only **variables** panel.

The existing `Pause Execution` keyword is deliberately untouched, so
this is purely additive — no behavior changes for existing tests.