### PR TITLE
Add "Get Variable Type" keyword to BuiltIn library

### DIFF
--- a/atest/robot/standard_libraries/builtin/get_variable_type.robot
+++ b/atest/robot/standard_libraries/builtin/get_variable_type.robot
@@ -1,0 +1,34 @@
+*** Settings ***
+Suite Setup       Run Tests    ${EMPTY}    standard_libraries/builtin/get_variable_type.robot
+Resource          atest_resource.robot
+
+*** Test Cases ***
+String
+    Check Test Case    ${TESTNAME}
+
+Integer
+    Check Test Case    ${TESTNAME}
+
+Float
+    Check Test Case    ${TESTNAME}
+
+Boolean
+    Check Test Case    ${TESTNAME}
+
+List
+    Check Test Case    ${TESTNAME}
+
+Dictionary
+    Check Test Case    ${TESTNAME}
+
+Tuple
+    Check Test Case    ${TESTNAME}
+
+Set
+    Check Test Case    ${TESTNAME}
+
+None
+    Check Test Case    ${TESTNAME}
+
+Custom object
+    Check Test Case    ${TESTNAME}

--- a/atest/testdata/standard_libraries/builtin/get_variable_type.robot
+++ b/atest/testdata/standard_libraries/builtin/get_variable_type.robot
@@ -1,0 +1,54 @@
+*** Settings ***
+Library         Collections
+
+*** Variables ***
+${STRING}       hello
+${INTEGER}      ${42}
+${FLOAT}        ${1.5}
+${BOOLEAN}      ${True}
+
+*** Test Cases ***
+String
+    ${type} =    Get Variable Type    ${STRING}
+    Should Be Equal    ${type}    string
+
+Integer
+    ${type} =    Get Variable Type    ${INTEGER}
+    Should Be Equal    ${type}    integer
+
+Float
+    ${type} =    Get Variable Type    ${FLOAT}
+    Should Be Equal    ${type}    float
+
+Boolean
+    ${type} =    Get Variable Type    ${BOOLEAN}
+    Should Be Equal    ${type}    boolean
+
+List
+    ${value} =    Create List    1    2
+    ${type} =    Get Variable Type    ${value}
+    Should Be Equal    ${type}    list
+
+Dictionary
+    ${value} =    Create Dictionary    a=1
+    ${type} =    Get Variable Type    ${value}
+    Should Be Equal    ${type}    dictionary
+
+Tuple
+    ${value} =    Evaluate    (1, 2)
+    ${type} =    Get Variable Type    ${value}
+    Should Be Equal    ${type}    tuple
+
+Set
+    ${value} =    Evaluate    {1, 2}
+    ${type} =    Get Variable Type    ${value}
+    Should Be Equal    ${type}    set
+
+None
+    ${type} =    Get Variable Type    ${NONE}
+    Should Be Equal    ${type}    none
+
+Custom object
+    ${value} =    Evaluate    object()
+    ${type} =    Get Variable Type    ${value}
+    Should Be Equal    ${type}    object

--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -1841,6 +1841,53 @@ class _Variables(_BuiltInBase):
         except VariableError:
             return self._variables.replace_scalar(default)
 
+    def get_variable_type(self, item: object) -> str:
+        """Returns the runtime type of the given ``item``.
+
+        The returned type name is normalized to be Robot Framework friendly.
+
+        Examples:
+        | ${type} = | Get Variable Type | ${value} |
+        | Should Be Equal | ${type} | string |
+
+        The returned value is one of the following:
+
+        | = Python type = | = Returned value = |
+        | ``str``         | ``string``         |
+        | ``int``         | ``integer``        |
+        | ``float``       | ``float``          |
+        | ``bool``        | ``boolean``        |
+        | ``list``        | ``list``           |
+        | ``dict``        | ``dictionary``     |
+        | ``tuple``       | ``tuple``          |
+        | ``set``         | ``set``            |
+        | ``NoneType``    | ``none``           |
+
+        Custom objects return ``object``.
+
+        This keyword checks the actual runtime Python type of the value, not
+        the Robot Framework variable syntax used to access it.
+        """
+        if item is None:
+            return "none"
+        if isinstance(item, bool):
+            return "boolean"
+        if isinstance(item, str):
+            return "string"
+        if isinstance(item, int):
+            return "integer"
+        if isinstance(item, float):
+            return "float"
+        if isinstance(item, list):
+            return "list"
+        if isinstance(item, dict):
+            return "dictionary"
+        if isinstance(item, tuple):
+            return "tuple"
+        if isinstance(item, set):
+            return "set"
+        return "object"
+
     def log_variables(self, level: logger.LogLevel = "INFO"):
         """Logs all variables in the current scope with given log level."""
         variables = self.get_variables()


### PR DESCRIPTION
## Summary

Adds a new BuiltIn keyword `Get Variable Type` that returns the runtime type of a value using Robot Framework friendly type names.

## Motivation

Robot Framework currently lacks a direct BuiltIn keyword for inspecting the runtime type of a value. Users typically rely on Python evaluation syntax:

```robot
${type}=    Evaluate    type($value).__name__
```

While functional, this mixes Python-specific syntax into test data, reduces readability for non-Python users, and is less discoverable than a dedicated keyword.

The new keyword offers a cleaner, more self-documenting alternative:

```robot
${type}=    Get Variable Type    ${value}
```

This is particularly useful for dynamic test data handling, building reusable and generic keywords, debugging variables, and implementing type-aware logic in keyword-driven and data-driven automation.

## Implementation

* Added `Get Variable Type` keyword in `src/robot/libraries/BuiltIn.py`
* Returns normalized, user-friendly type names:

  * `string`
  * `integer`
  * `float`
  * `boolean`
  * `list`
  * `dictionary`
  * `tuple`
  * `set`
  * `none`
* Returns `object` for custom classes and other unsupported types
* Properly handles `bool` before `int` because `bool` is a subclass of `int` in Python

## Tests

Added acceptance tests covering:

* String values
* Integer values
* Float values
* Boolean values
* Lists
* Dictionaries
* Tuples
* Sets
* None values
* Custom objects

## Files Changed

* `src/robot/libraries/BuiltIn.py`
* `atest/testdata/standard_libraries/builtin/get_variable_type.robot`
* `atest/robot/standard_libraries/builtin/get_variable_type.robot`

## Related Issues

No existing issue found.

Thank you for your review and feedback.
