### PR TITLE
Docstring perf

### DIFF
--- a/src/robot/running/docstring.py
+++ b/src/robot/running/docstring.py
@@ -1,0 +1,191 @@
+#  Copyright 2008-2015 Nokia Networks
+#  Copyright 2016-     Robot Framework Foundation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import textwrap
+from collections.abc import Generator
+from dataclasses import dataclass, field
+
+
+# TODO: Add slots=True when RF drops Python 3.8 support — @dataclass(slots=True)
+#       requires 3.10+ and eliminates per-instance __dict__ overhead, which matters
+#       at 100k+ keyword scale.
+@dataclass
+class ParsedDocString:
+    doc: str
+    args: "dict[str, str]" = field(default_factory=dict)
+    returns: str = ""
+
+
+# Headers are matched case-insensitively — 'args:' and 'Args:' are equivalent.
+_ARGS_HEADERS = frozenset({"args:", "arguments:", "parameters:"})
+# Minimum indent to recognise an arg entry (2 supports both 2-space and 4-space
+# indented arg lists). Maximum is 4 (standard Google style).
+_MIN_ARG_INDENT = 2
+_MAX_ARG_INDENT = 4
+_RETURNS_HEADERS = frozenset({"returns:", "yields:"})
+
+
+def parse_docstring(doc: str) -> ParsedDocString:
+    """Always returns a ParsedDocString — never raises."""
+    try:
+        return _parse(doc)
+    except (TypeError, AttributeError):
+        return ParsedDocString(doc="", args={}, returns="")
+
+
+def _parse(doc: str) -> ParsedDocString:
+    lines = doc.splitlines()
+    doc_parts = []
+    args: dict[str, str] = {}
+    returns = ""
+    for header, body in _iter_sections(lines):
+        if header is None:
+            doc_parts.append("\n".join(body))
+        elif header.lower() in _ARGS_HEADERS:
+            args = _parse_args(body)
+        elif header.lower() in _RETURNS_HEADERS:
+            returns = _parse_returns(body)
+        else:
+            # Unrecognised section: reassemble and preserve in doc. The header's
+            # trailing whitespace is normalised by rstrip() in _is_section_boundary,
+            # and the final doc is rstrip'd, so trailing whitespace is not fully preserved.
+            doc_parts.append(header + "\n" + "\n".join(body))
+    assembled = "\n".join(doc_parts).lstrip("\n").rstrip()
+    # Each prose part ends with the blank lines that separate it from the next
+    # section, so joining parts with "\n" naturally produces the correct "\n\n"
+    # paragraph separator between them without any special-casing.
+    return ParsedDocString(doc=assembled, args=args, returns=returns)
+
+
+def _iter_sections(
+    lines: "list[str]",
+) -> "Generator[tuple[str | None, list[str]], None, None]":
+    """Yields (header | None, body_lines) pairs — pure grouping, no classification."""
+    header, body = None, []
+    for line in lines:
+        boundary = _is_section_boundary(line)
+        if boundary:
+            yield header, body
+            header, body = boundary, []
+        elif header is not None and _ends_section_body(line):
+            # A line with indent < 2 inside a section body ends the section
+            # and starts a new prose group (e.g. a Robot Framework Tags: line).
+            yield header, body
+            header, body = None, [line]
+        else:
+            body.append(line)
+    yield header, body
+
+
+def _is_section_boundary(line: str) -> str:
+    if not line or line[0] in (" ", "\t"):
+        return ""
+    stripped = line.rstrip()
+    if stripped.endswith(":"):
+        return stripped
+    return ""
+
+
+def _ends_section_body(line: str) -> bool:
+    """Return True if a non-empty line has less than 2 spaces of leading indent."""
+    if not line:
+        return False
+    first = line[0]
+    if first not in (" ", "\t"):
+        return True  # 0 indent
+    return len(line) == 1 or line[1] not in (" ", "\t")  # exactly 1 indent char
+
+
+def _bare_arg_name(raw: str) -> str:
+    """Return the bare identifier from a decorated arg name token.
+
+    Strips Python-style asterisks (*args, **kwargs) and RF variable markers
+    (${name}, @{varargs}, &{kwargs}), returning just the identifier.
+    """
+    if len(raw) >= 3 and raw[0] in "$@&" and raw[1] == "{" and raw[-1] == "}":
+        return raw[2:-1]
+    return raw.lstrip("*")
+
+
+def _iter_arg_entries(
+    lines: "list[str]",
+) -> "Generator[tuple[str, str, list[str]], None, None]":
+    name = None
+    inline_parts: list[str] = []
+    raw_body: list[str] = []
+    in_block = False
+
+    for line in lines:
+        if not line:
+            if name is not None:
+                if in_block:
+                    raw_body.append(line)
+                else:
+                    # Blank line mid-inline-description: promote to block so the
+                    # paragraph break is preserved rather than silently dropped.
+                    in_block = True
+                    raw_body = []
+            continue
+        indent = len(line) - len(line.lstrip())
+        if _MIN_ARG_INDENT <= indent <= _MAX_ARG_INDENT:
+            lstripped = line.lstrip()
+            before, sep, after = lstripped.rstrip().partition(":")
+            # Google style: colon must be followed by a space or end of line.
+            # This rejects URLs ("https://") and key:value pairs.
+            if sep and (not after or after[0] == " "):
+                raw_name = before.partition("(")[0].rstrip()
+                is_rf_var = (
+                    len(raw_name) >= 3
+                    and raw_name[0] in "$@&"
+                    and raw_name[1] == "{"
+                    and raw_name[-1] == "}"
+                )
+                bare = _bare_arg_name(raw_name)
+                if is_rf_var and bare.strip() or not is_rf_var and bare.isidentifier():
+                    if name is not None:
+                        yield name, " ".join(inline_parts), raw_body
+                    name = bare
+                    first = after.strip()
+                    inline_parts = [first] if first else []
+                    raw_body = []
+                    in_block = not first
+                    continue
+        if name is not None:
+            if in_block:
+                raw_body.append(line)
+            else:
+                inline_parts.append(line.strip())
+
+    if name is not None:
+        yield name, " ".join(inline_parts), raw_body
+
+
+def _build_arg_desc(inline_text: str, raw_body: "list[str]") -> str:
+    if not raw_body:
+        return inline_text
+    block = textwrap.dedent("\n".join(raw_body)).strip()
+    if not inline_text:
+        return block
+    return (inline_text + "\n\n" + block) if block else inline_text
+
+
+def _parse_args(lines: "list[str]") -> "dict[str, str]":
+    return {
+        name: _build_arg_desc(inline_text, raw_body)
+        for name, inline_text, raw_body in _iter_arg_entries(lines)
+    }
+
+
+def _parse_returns(lines: "list[str]") -> str:
+    return textwrap.dedent("\n".join(lines)).strip()

--- a/utest/perf/bench_docstring.py
+++ b/utest/perf/bench_docstring.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python
+"""Performance benchmark for ``parse_docstring`` in a Robot Framework context.
+
+Three phases are measured for each of three docstring styles:
+
+  direct    — calls ``parse_docstring(doc)`` N times in a tight loop.
+              Isolates the parser itself with no RF overhead.
+
+  libdoc    — calls ``LibraryDocumentation(path)`` on a generated library.
+              This is the *only* RF execution phase that actually calls
+              ``parse_docstring`` (via KeywordImplementation.update_docs).
+
+  rf_import  — imports the library via RF's own ``TestLibrary.from_name``
+              (the same path used during test execution). Confirms that
+              ``parse_docstring`` is NOT called during library import — that
+              only happens in the libdoc phase.
+
+Three docstring styles:
+
+  prose_only      — plain multi-line prose, no structured sections.
+  args_only       — Google-style Args section only.
+  full_structured — Google-style Args + Returns sections.
+
+Usage::
+
+    python utest/perf/bench_docstring.py [N] [-r RUNS] [--baseline]
+
+``N`` is the number of keywords per library variant (default: 10 000).
+``-r RUNS`` repeats every measurement RUNS times and reports
+min / max / mean / median / stdev across all runs (default: 1).
+"""
+import cProfile
+import importlib.util
+import inspect
+import io
+import pstats
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Make sure the in-tree 'robot' package is used regardless of cwd.
+# ---------------------------------------------------------------------------
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SRC = str(_REPO_ROOT / "src")
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+from robot.libdocpkg import LibraryDocumentation  # noqa: E402
+from robot.running.testlibraries import TestLibrary  # noqa: E402
+
+try:
+    from robot.running.docstring import parse_docstring, ParsedDocString  # noqa: E402
+    _PARSE_AVAILABLE = True
+except ImportError:
+    _PARSE_AVAILABLE = False
+
+    class ParsedDocString:  # type: ignore[no-redef]
+        def __init__(self, doc="", args=None, returns=""):
+            self.doc = doc
+            self.args = args if args is not None else {}
+            self.returns = returns
+
+    def parse_docstring(doc):  # type: ignore[no-redef]
+        return ParsedDocString(doc=doc)
+
+try:
+    import robot.running.keywordimplementation as _kw_impl  # noqa: E402
+    _KW_IMPL_HAS_PARSE = hasattr(_kw_impl, "parse_docstring")
+except ImportError:
+    _kw_impl = None  # type: ignore[assignment]
+    _KW_IMPL_HAS_PARSE = False
+
+_STYLES = ("prose_only", "args_only", "full_structured")
+_PROFILE_TOP_N = 15
+
+
+# ---------------------------------------------------------------------------
+# Library generation
+# ---------------------------------------------------------------------------
+
+def _write_library(path: Path, n: int, style: str) -> None:
+    """Write a synthetic Python library with *n* keyword functions to *path*."""
+    buf = io.StringIO()
+    buf.write("# Auto-generated benchmark library — do not edit\n\n")
+    for i in range(n):
+        buf.write(f"def keyword_{i:05d}(param_a, param_b):\n")
+        buf.write(f'    """Keyword {i:05d}.\n\n')
+        if style == "prose_only":
+            buf.write(f"    Longer description for keyword {i:05d}.\n")
+            buf.write("    This spans multiple lines to be realistic.\n")
+        elif style == "args_only":
+            buf.write("    Args:\n")
+            buf.write(f"        param_a: First parameter for keyword {i:05d}.\n")
+            buf.write(f"        param_b: Second parameter for keyword {i:05d}.\n")
+        else:  # full_structured
+            buf.write("    Args:\n")
+            buf.write(f"        param_a: First parameter for keyword {i:05d}.\n")
+            buf.write(f"        param_b: Second parameter for keyword {i:05d}.\n\n")
+            buf.write("    Returns:\n")
+            buf.write(f"        The result of keyword {i:05d}.\n")
+        buf.write('    """\n')
+        buf.write("    pass\n\n")
+    path.write_text(buf.getvalue(), encoding="utf-8")
+
+
+def _load_docstrings(lib_path: Path, n: int) -> "list[str]":
+    """Import *lib_path* with importlib and extract each keyword's cleaned docstring.
+
+    Using ``inspect.getdoc`` mirrors what RF itself uses internally
+    (``inspect.getdoc(self.method)`` in ``librarykeyword.py``), so the
+    docstrings passed to ``parse_docstring`` in the *direct* phase are
+    byte-for-byte identical to what RF would pass.
+    """
+    module_name = lib_path.stem
+    spec = importlib.util.spec_from_file_location(module_name, lib_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return [
+        inspect.getdoc(getattr(mod, f"keyword_{i:05d}")) or ""
+        for i in range(n)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Measurement helpers
+# ---------------------------------------------------------------------------
+
+class _Result:
+    """Holds the timing/memory outcome of one measured call."""
+    __slots__ = ("elapsed", "peak_mb", "profile")
+
+    def __init__(self, elapsed: float, peak_mb: float, profile: cProfile.Profile):
+        self.elapsed = elapsed
+        self.peak_mb = peak_mb
+        self.profile = profile
+
+
+class _Stats:
+    """Aggregated results from one or more runs of the same measurement."""
+    __slots__ = (
+        "t_min", "t_max", "t_mean", "t_median", "t_stdev",
+        "m_min", "m_max", "m_mean", "m_median", "m_stdev",
+        "median_profile",
+    )
+
+    def __init__(self, results: "list[_Result]"):
+        times = [r.elapsed for r in results]
+        mems = [r.peak_mb for r in results]
+        n = len(results)
+        self.t_min = min(times)
+        self.t_max = max(times)
+        self.t_mean = sum(times) / n
+        self.t_median = statistics.median(times)
+        self.t_stdev = statistics.stdev(times) if n > 1 else 0.0
+        self.m_min = min(mems)
+        self.m_max = max(mems)
+        self.m_mean = sum(mems) / n
+        self.m_median = statistics.median(mems)
+        self.m_stdev = statistics.stdev(mems) if n > 1 else 0.0
+        # Profile from the run whose elapsed time is closest to the median.
+        self.median_profile = min(
+            results, key=lambda r: abs(r.elapsed - self.t_median)
+        ).profile
+
+
+def _measure(fn) -> _Result:
+    """Run *fn()* once, capturing wall-clock time, peak tracemalloc, and cProfile."""
+    pr = cProfile.Profile()
+    tracemalloc.start()
+    t0 = time.perf_counter()
+    pr.enable()
+    fn()
+    pr.disable()
+    elapsed = time.perf_counter() - t0
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return _Result(elapsed=elapsed, peak_mb=peak / 1_048_576, profile=pr)
+
+
+def _measure_many(fn, runs: int = 1) -> _Stats:
+    """Run *fn* ``runs`` times and return aggregated statistics."""
+    return _Stats([_measure(fn) for _ in range(runs)])
+
+
+# ---------------------------------------------------------------------------
+# Benchmark scenarios
+# ---------------------------------------------------------------------------
+
+def _noop_parse(doc: str) -> ParsedDocString:
+    """Baseline no-op: returns immediately without parsing."""
+    return ParsedDocString(doc=doc, args={}, returns="")
+
+
+def _run_direct(docstrings: "list[str]", parse_fn=None) -> None:
+    if parse_fn is None:
+        parse_fn = parse_docstring
+    for doc in docstrings:
+        parse_fn(doc)
+
+
+def _run_libdoc(lib_path: Path) -> None:
+    LibraryDocumentation(str(lib_path))
+
+
+def _run_rf_import(lib_path: Path) -> None:
+    """Import the library via RF's own TestLibrary.from_name — no parse_docstring."""
+    # Passing the absolute path string mirrors how RF resolves library paths at
+    # runtime.  parse_docstring is NOT called here; that only happens in libdoc.
+    TestLibrary.from_name(str(lib_path))
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+_SEP = 72
+
+def _section(title: str) -> None:
+    print(f"\n{'=' * _SEP}")
+    print(f"  {title}")
+    print(f"{'=' * _SEP}")
+
+
+def _profile_text(pr: cProfile.Profile, top: int = _PROFILE_TOP_N) -> str:
+    buf = io.StringIO()
+    ps = pstats.Stats(pr, stream=buf).sort_stats("cumulative")
+    ps.print_stats(top)
+    return buf.getvalue()
+
+
+def _print_filtered_profile(pr: cProfile.Profile) -> None:
+    """Print only lines that mention robot/docstring/keyword symbols."""
+    lines = _profile_text(pr).splitlines()
+    for line in lines:
+        lo = line.lower()
+        if (
+            line.strip().startswith("ncalls")          # column header
+            or "docstring" in lo
+            or "/robot/" in lo
+            or "libdoc" in lo
+            or "keyword" in lo
+            or line.strip().startswith("{built-in")    # built-in calls
+        ):
+            print(f"  {line}")
+
+
+def _print_entry(phase: str, style: str, s: _Stats, runs: int) -> None:
+    """Print one benchmark entry — single row when runs==1, two-line block otherwise."""
+    if runs == 1:
+        print(f"  {phase:<14}  {style:<18}  {s.t_median:>8.3f}s  {s.m_median:>8.2f} MB")
+    else:
+        print(f"  {phase} / {style}")
+        print(
+            f"    time:  median={s.t_median:.3f}s  min={s.t_min:.3f}s  "
+            f"max={s.t_max:.3f}s  mean={s.t_mean:.3f}s  stdev={s.t_stdev:.3f}s"
+        )
+        print(
+            f"    mem:   median={s.m_median:.2f}MB  min={s.m_min:.2f}MB  "
+            f"max={s.m_max:.2f}MB  mean={s.m_mean:.2f}MB  stdev={s.m_stdev:.2f}MB"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    args = sys.argv[1:]
+    baseline = "--baseline" in args or not _PARSE_AVAILABLE
+    args = [a for a in args if a != "--baseline"]
+    runs = 1
+    if "-r" in args:
+        idx = args.index("-r")
+        runs = int(args[idx + 1])
+        args = args[:idx] + args[idx + 2:]
+    n = int(args[0]) if args else 10_000
+    if not _PARSE_AVAILABLE:
+        mode = "BASELINE (parse_docstring not found on this branch — stubs used)"
+    elif baseline:
+        mode = "BASELINE (parse_docstring replaced with no-op)"
+    else:
+        mode = "NORMAL"
+
+    print(f"\nDocstring benchmark  \u2014  {n:,} keywords per library variant")
+    print(f"Mode: {mode}")
+    print(f"Runs per measurement: {runs}")
+    print(f"Python {sys.version.split()[0]}  |  robot src: {_SRC}")
+
+    with tempfile.TemporaryDirectory(prefix="rf_bench_") as tmpdir:
+        tmp = Path(tmpdir)
+
+        # ------------------------------------------------------------------
+        # Build library files and pre-extract cleaned docstring samples.
+        # ------------------------------------------------------------------
+        lib_paths: dict[str, Path] = {}
+        doc_lists: dict[str, list[str]] = {}
+        print("\nGenerating library files ...", end="", flush=True)
+        for style in _STYLES:
+            p = tmp / f"bench_{style}.py"
+            _write_library(p, n, style)
+            lib_paths[style] = p
+            doc_lists[style] = _load_docstrings(p, n)
+        print(" done.")
+
+        # ------------------------------------------------------------------
+        # Results table
+        # ------------------------------------------------------------------
+        _section("Timing and memory results")
+        if runs == 1:
+            hdr = f"  {'Phase':<14}  {'Style':<18}  {'Time':>9}  {'Peak RAM':>10}"
+            print(hdr)
+            print(f"  {'-'*14}  {'-'*18}  {'-'*9}  {'-'*10}")
+        else:
+            print(f"  Showing: median / min / max / mean / stdev  ({runs} runs per measurement)")
+
+        all_results: list[tuple[str, str, _Stats]] = []
+
+        for style in _STYLES:
+            lib_path = lib_paths[style]
+
+            parse_fn = _noop_parse if baseline else parse_docstring
+
+            # 1. Direct parse (isolates parse_docstring only)
+            s = _measure_many(
+                lambda docs=doc_lists[style], fn=parse_fn: _run_direct(docs, fn), runs
+            )
+            _print_entry("direct", style, s, runs)
+            all_results.append(("direct", style, s))
+
+            # 2. libdoc (the only RF path that calls parse_docstring)
+            if baseline and _KW_IMPL_HAS_PARSE:
+                _kw_impl.parse_docstring = _noop_parse
+            try:
+                s = _measure_many(lambda p=lib_path: _run_libdoc(p), runs)
+            finally:
+                if _KW_IMPL_HAS_PARSE:
+                    _kw_impl.parse_docstring = parse_docstring  # always restore
+            _print_entry("libdoc", style, s, runs)
+            all_results.append(("libdoc", style, s))
+
+            # 3. RF library import (no parse_docstring — only in libdoc)
+            s = _measure_many(lambda p=lib_path: _run_rf_import(p), runs)
+            _print_entry("rf_import", style, s, runs)
+            all_results.append(("rf_import", style, s))
+
+        print(
+            "\n  NOTE: rf_import confirms that parse_docstring is NOT called during\n"
+            "        RF library loading — only during the libdoc phase."
+        )
+
+        # ------------------------------------------------------------------
+        # cProfile detail
+        # ------------------------------------------------------------------
+        _section(f"cProfile  (top {_PROFILE_TOP_N} by cumulative time, from median run)")
+        for phase, style, stats in all_results:
+            print(f"\n  --- {phase} / {style} ---")
+            _print_filtered_profile(stats.median_profile)
+
+    print("\nDone.\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/utest/running/test_docstring.py
+++ b/utest/running/test_docstring.py
@@ -1,0 +1,887 @@
+import unittest
+
+from robot.running.docstring import parse_docstring, ParsedDocString
+from robot.utils.asserts import assert_equal
+
+
+class TestPlainDocstring(unittest.TestCase):
+
+    def test_no_sections_returns_doc_unchanged(self):
+        doc = "Does something useful."
+        result = parse_docstring(doc)
+        assert_equal(
+            result, ParsedDocString(doc="Does something useful.", args={}, returns="")
+        )
+
+    def test_empty_string(self):
+        result = parse_docstring("")
+        assert_equal(result, ParsedDocString(doc="", args={}, returns=""))
+
+    def test_multiline_plain_docstring(self):
+        doc = """\
+First line.
+
+More detail here."""
+        result = parse_docstring(doc)
+        assert_equal(
+            result,
+            ParsedDocString(
+                doc=doc,
+                args={},
+                returns="",
+            ),
+        )
+
+    def test_leading_blank_line_stripped(self):
+        doc = """\
+
+Summary."""
+        result = parse_docstring(doc)
+        assert_equal(result.doc, "Summary.")
+
+
+class TestArgsSection(unittest.TestCase):
+
+    def test_single_inline_arg(self):
+        doc = """\
+Summary line.
+
+Args:
+    name: The name to use.
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.doc, "Summary line.")
+        assert_equal(result.args, {"name": "The name to use."})
+        assert_equal(result.returns, "")
+
+    def test_multiple_inline_args(self):
+        doc = """\
+Summary.
+
+Args:
+    first: First argument.
+    second: Second argument.
+"""
+        result = parse_docstring(doc)
+        assert_equal(
+            result.args,
+            {"first": "First argument.", "second": "Second argument."},
+        )
+
+    def test_duplicate_arg_name_last_wins(self):
+        doc = """\
+Summary.
+
+Args:
+    name: First occurrence.
+    name: Second occurrence.
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.args, {"name": "Second occurrence."})
+
+    def test_block_format_arg(self):
+        doc = """\
+Summary.
+
+Args:
+    name:
+        Description on next line.
+"""
+        result = parse_docstring(doc)
+        assert_equal(
+            result.args,
+            {"name": "Description on next line."},
+        )
+
+    def test_multiline_arg_description(self):
+        doc = """\
+Summary.
+
+Args:
+    name: First line of description
+        that continues here.
+"""
+        result = parse_docstring(doc)
+        assert_equal(
+            result.args,
+            {"name": "First line of description that continues here."},
+        )
+
+    def test_inline_arg_with_blank_line_preserves_paragraph_break(self):
+        doc = """\
+Summary.
+
+Args:
+    name: First paragraph.
+
+        Second paragraph.
+"""
+        result = parse_docstring(doc)
+        assert_equal(
+            result.args,
+            {"name": "First paragraph.\n\nSecond paragraph."},
+        )
+
+    def test_deep_indented_code_block_in_arg_description(self):
+        doc = """\
+Summary.
+
+Args:
+    name:
+        Some doc here. With example:
+
+               def example():
+                   pass
+
+        And more doc here.
+
+    name2: Some other doc.
+"""
+        result = parse_docstring(doc)
+        assert_equal(
+            result.args,
+            {
+                "name": """\
+Some doc here. With example:
+
+       def example():
+           pass
+
+And more doc here.""",
+                "name2": "Some other doc.",
+            },
+        )
+        assert_equal(result.returns, "")
+        assert_equal(result.doc, "Summary.")
+
+    def test_second_arg_with_smaller_indent_than_first_is_still_detected(self):
+        doc = """\
+Summary.
+
+Args:
+    name:
+        Some doc here.
+
+   name2: Some other doc.
+"""
+        result = parse_docstring(doc)
+        assert_equal(
+            result.args,
+            {"name": "Some doc here.", "name2": "Some other doc."},
+        )
+
+    def test_deeply_indented_name_colon_is_not_a_new_arg(self):
+        doc = """\
+Summary.
+
+Args:
+    name:
+        Some doc here.
+
+        name2: still doc of "name" arg, not new arg.
+"""
+        result = parse_docstring(doc)
+        assert_equal(
+            result.args,
+            {
+                "name": """Some doc here.
+
+name2: still doc of "name" arg, not new arg."""
+            },
+        )
+
+    def test_block_arg_body_with_inconsistent_indentation(self):
+        doc = """\
+Summary.
+
+Args:
+    name:
+        Some doc here.
+
+      And more doc here.
+
+    name2: Some other doc.
+"""
+        result = parse_docstring(doc)
+        assert_equal(
+            result.args,
+            {
+                "name": """Some doc here.
+
+And more doc here.""",
+                "name2": "Some other doc.",
+            },
+        )
+
+    def test_arguments_header_accepted(self):
+        doc = """\
+Summary.
+
+Arguments:
+    name: The name.
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.args, {"name": "The name."})
+
+    def test_parameters_header_accepted(self):
+        doc = """\
+Summary.
+
+Parameters:
+    name: The name.
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.args, {"name": "The name."})
+
+    def test_lowercase_args_recognised(self):
+        doc = """\
+Summary.
+
+args:
+    name: value.
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.doc, "Summary.")
+        assert_equal(result.args, {"name": "value."})
+        assert_equal(result.returns, "")
+
+    def test_args_with_colon_in_description(self):
+        doc = """\
+Summary.
+
+Args:
+    url: https://example.com is the target.
+"""
+        result = parse_docstring(doc)
+        assert_equal(
+            result.args,
+            {"url": "https://example.com is the target."},
+        )
+
+
+class TestReturnsSection(unittest.TestCase):
+
+    def test_returns_section(self):
+        doc = """\
+Summary.
+
+Returns:
+    The result value.
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.doc, "Summary.")
+        assert_equal(result.args, {})
+        assert_equal(result.returns, "The result value.")
+
+    def test_yields_header_goes_into_returns(self):
+        doc = """\
+Summary.
+
+Yields:
+    One item at a time.
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.returns, "One item at a time.")
+
+    def test_multiline_returns(self):
+        doc = """\
+Summary.
+
+Returns:
+    First line of return description
+    that continues here.
+"""
+        result = parse_docstring(doc)
+        assert_equal(
+            result.returns,
+            """\
+First line of return description
+that continues here.""",
+        )
+
+    def test_multiple_returns_sections_last_wins(self):
+        doc = """\
+Summary.
+
+Returns:
+    First return.
+
+Returns:
+    Second return.
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.returns, "Second return.")
+
+    def test_multiple_args_sections_last_wins(self):
+        doc = """\
+Summary.
+
+Args:
+    x: First occurrence.
+
+Args:
+    y: Second occurrence.
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.args, {"y": "Second occurrence."})
+
+
+class TestArgsAndReturnsTogether(unittest.TestCase):
+
+    def test_args_and_returns(self):
+        doc = """\
+Summary.
+
+Args:
+    name: The name.
+
+Returns:
+    The result.
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.doc, "Summary.")
+        assert_equal(result.args, {"name": "The name."})
+        assert_equal(result.returns, "The result.")
+
+    def test_prose_before_sections_preserved(self):
+        doc = """\
+First line.
+
+Longer description paragraph
+spanning two lines.
+
+Args:
+    x: Something.
+"""
+        result = parse_docstring(doc)
+        assert_equal(
+            result.doc,
+            """\
+First line.
+
+Longer description paragraph
+spanning two lines.""",
+        )
+
+    def test_returns_before_args(self):
+        doc = """\
+Summary.
+
+Returns:
+    The result.
+
+Args:
+    x: Something.
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.doc, "Summary.")
+        assert_equal(result.args, {"x": "Something."})
+        assert_equal(result.returns, "The result.")
+
+
+class TestMalformedInput(unittest.TestCase):
+
+    def test_section_header_with_no_entries(self):
+        doc = """\
+Summary.
+
+Args:
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.doc, "Summary.")
+        assert_equal(result.args, {})
+        assert_equal(result.returns, "")
+
+    def test_section_header_not_at_line_start_is_prose(self):
+        doc = """\
+Summary.
+
+    Args:
+    name: value.
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.doc, doc.rstrip())
+        assert_equal(result.args, {})
+
+    def test_one_space_indented_line_not_parsed_as_arg(self):
+        doc = """\
+Summary.
+
+Args:
+ name: One-space indent.
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.args, {})
+
+    def test_one_space_indented_line_in_section_body_ends_section(self):
+        doc = """\
+Summary.
+
+Args:
+    name:
+        Some doc here.
+
+ Something here, what happens now?
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.args, {"name": "Some doc here."})
+        assert_equal(
+            result.doc,
+            """\
+Summary.
+
+ Something here, what happens now?""",
+        )
+
+    def test_two_space_indented_line_in_section_body_absorbed_into_arg_description(
+        self,
+    ):
+        doc = """\
+Summary.
+
+Args:
+    name:
+        Some doc here.
+
+  Something here, what happens now?
+"""
+        result = parse_docstring(doc)
+        assert_equal(
+            result.args,
+            {"name": "Some doc here.\n\nSomething here, what happens now?"},
+        )
+        assert_equal(result.doc, "Summary.")
+
+    def test_url_in_arg_description_not_parsed_as_new_arg(self):
+        doc = """\
+Summary.
+
+Args:
+    name: See docs at
+    https://example.com for details.
+"""
+        result = parse_docstring(doc)
+        assert_equal(
+            result.args,
+            {"name": "See docs at https://example.com for details."},
+        )
+        assert_equal(result.doc, "Summary.")
+
+    def test_tab_indented_header_is_prose_not_section(self):
+        doc = """\
+\tArgs:
+\tname: value.
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.args, {})
+        assert_equal(
+            result.doc,
+            """\
+\tArgs:
+\tname: value.""",
+        )
+        assert_equal(result.returns, "")
+
+    def test_returns_with_no_content(self):
+        doc = """\
+Summary.
+
+Returns:
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.doc, "Summary.")
+        assert_equal(result.args, {})
+        assert_equal(result.returns, "")
+
+    def test_never_raises_on_garbage_input(self):
+        for bad in [
+            "Args:\n    : no name.\n",
+            "Args:\n    no_colon_here\n",
+            "Returns:\n    \n    \n",
+        ]:
+            result = parse_docstring(bad)
+            assert_equal(result, ParsedDocString(doc="", args={}, returns=""))
+
+    def test_none_input_does_not_raise(self):
+        result = parse_docstring(None)
+        assert_equal(result, ParsedDocString(doc="", args={}, returns=""))
+
+    def test_over_indented_arg_not_parsed(self):
+        doc = """\
+Summary.
+
+Args:
+     name: Five-space indent.
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.args, {})
+
+    def test_args_section_with_no_summary(self):
+        doc = "Args:\n    name: value.\n"
+        result = parse_docstring(doc)
+        assert_equal(result.doc, "")
+        assert_equal(result.args, {"name": "value."})
+
+
+class TestArgsTypeAnnotations(unittest.TestCase):
+
+    def test_simple_type_annotation_stripped(self):
+        doc = """\
+Summary.
+
+Args:
+    name (str): The name to use.
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.doc, "Summary.")
+        assert_equal(
+            result.args,
+            {"name": "The name to use."},
+        )
+        assert_equal(result.returns, "")
+
+    def test_nested_parens_in_type_annotation_stripped(self):
+        doc = """\
+Summary.
+
+Args:
+    name (Union(int, str)): The name.
+    other (Optional(str)): Optional value.
+"""
+        result = parse_docstring(doc)
+        assert_equal(
+            result.args,
+            {"name": "The name.", "other": "Optional value."},
+        )
+
+
+class TestTwoSpaceIndent(unittest.TestCase):
+
+    def test_two_space_indented_multiple_args(self):
+        doc = """\
+Summary.
+
+Args:
+  first: First argument.
+  second: Second argument.
+"""
+        result = parse_docstring(doc)
+        assert_equal(
+            result.args,
+            {"first": "First argument.", "second": "Second argument."},
+        )
+
+    def test_two_space_indented_multiline_arg_continuation(self):
+        doc = """\
+Summary.
+
+Args:
+  name:   First line of description
+    that continues here.
+"""
+        result = parse_docstring(doc)
+        assert_equal(
+            result.args,
+            {"name": "First line of description that continues here."},
+        )
+
+    def test_two_space_indented_returns(self):
+        doc = """\
+Summary.
+
+Returns:
+  The result value.
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.returns, "The result value.")
+
+
+class TestArgsStarredNames(unittest.TestCase):
+
+    def test_mixed_regular_and_starred_args(self):
+        doc = """\
+Summary.
+
+Args:
+    name: The name.
+    *args: Extra positional args.
+    **kwargs: Extra keyword args.
+"""
+        result = parse_docstring(doc)
+        assert_equal(
+            result.args,
+            {
+                "name": "The name.",
+                "args": "Extra positional args.",
+                "kwargs": "Extra keyword args.",
+            },
+        )
+        assert_equal(result.doc, "Summary.")
+
+
+class TestRobotFrameworkVariableSyntax(unittest.TestCase):
+
+    def test_mixed_rf_variable_syntax(self):
+        doc = """\
+Summary ${name} in doc.
+
+Args:
+    ${name}: The name
+      with some extra spaces in the description.
+    @{varargs}: Extra positional args.
+    &{kwargs}: Extra keyword args.
+
+    With some other lines in the description.
+"""
+        kwargs_doc = """\
+Extra keyword args.
+
+With some other lines in the description."""
+        result = parse_docstring(doc)
+        assert_equal(
+            result.args,
+            {
+                "name": "The name with some extra spaces in the description.",
+                "varargs": "Extra positional args.",
+                "kwargs": kwargs_doc,
+            },
+        )
+        assert_equal(result.doc, "Summary ${name} in doc.")
+
+    def test_empty_rf_variable_not_parsed_as_arg(self):
+        for bad in ["${}:  desc", "@{}: desc", "&{}: desc"]:
+            doc = f"Args:\n    {bad}\n"
+            result = parse_docstring(doc)
+            assert_equal(result.args, {}, msg=f"Expected no args for: {bad!r}")
+
+    def test_list_and_dict_variables_with_spaces_in_name(self):
+        doc = """\
+Summary.
+
+Args:
+    @{my list}: The items.
+    &{my  dict has spaces}: The mapping.
+"""
+        result = parse_docstring(doc)
+        assert_equal(
+            result.args,
+            {"my list": "The items.", "my  dict has spaces": "The mapping."},
+        )
+
+    def test_variable_with_only_spaces_is_ignored(self):
+        doc = """\
+Summary.
+
+Args:
+    ${   }: The value.
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.args, {})
+
+
+class TestSpecialStrings(unittest.TestCase):
+
+    def test_emoji_in_summary_passes_through(self):
+        doc = "Does something useful 👨‍👩‍👦."
+        result = parse_docstring(doc)
+        assert_equal(result.doc, "Does something useful 👨‍👩‍👦.")
+
+    def test_emoji_in_arg_description(self):
+        doc = """\
+Summary.
+
+Args:
+    mood: The current mood 😍.
+"""
+        result = parse_docstring(doc)
+        assert_equal(
+            result.args,
+            {"mood": "The current mood 😍."},
+        )
+
+    def test_fullwidth_colon_in_description_not_confused_with_arg_separator(self):
+        doc = """\
+Summary.
+
+Args:
+    name: Description with fullwidth colon：here.
+"""
+        result = parse_docstring(doc)
+        assert_equal(
+            result.args,
+            {"name": "Description with fullwidth colon\uff1ahere."},
+        )
+
+
+class TestReturnsCodeBlock(unittest.TestCase):
+
+    def test_returns_with_blank_line_separated_code_block(self):
+        doc = """\
+Summary.
+
+Returns:
+    A dict mapping keys to the corresponding table row data
+    fetched. For example:
+
+    {b'Serak': ('Rigel VII', 'Preparer'),
+     b'Zim': ('Irk', 'Invader')}
+
+    Returned keys are always bytes.
+"""
+        result = parse_docstring(doc)
+        expected = """\
+A dict mapping keys to the corresponding table row data
+fetched. For example:
+
+{b'Serak': ('Rigel VII', 'Preparer'),
+ b'Zim': ('Irk', 'Invader')}
+
+Returned keys are always bytes."""
+        assert_equal(result.returns, expected)
+
+    def test_trailing_blank_lines_in_returns_stripped(self):
+        doc = """\
+Summary.
+
+Returns:
+    The result.
+
+
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.returns, "The result.")
+
+
+class TestUnrecognisedSections(unittest.TestCase):
+
+    def test_raises_section_preserved_in_doc_and_does_not_corrupt_args(self):
+        doc = """\
+Summary.
+
+Args:
+    x: Something.
+
+Raises:
+    ValueError: If bad.
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.args, {"x": "Something."})
+        assert_equal(
+            result.doc,
+            """\
+Summary.
+
+Raises:
+    ValueError: If bad.""",
+        )
+
+    def test_custom_section_preserved_in_doc(self):
+        doc = """\
+Summary.
+
+Note:
+    This is an important note.
+
+Returns:
+    The result.
+"""
+        result = parse_docstring(doc)
+        assert_equal(
+            result.doc,
+            """\
+Summary.
+
+Note:
+    This is an important note.""",
+        )
+        assert_equal(result.returns, "The result.")
+
+    def test_unrecognised_section_between_recognised_sections(self):
+        doc = """\
+Summary.
+
+Args:
+    x: Something.
+
+Raises:
+    ValueError: If bad.
+
+Returns:
+    The result.
+"""
+        result = parse_docstring(doc)
+        assert_equal(result.args, {"x": "Something."})
+        assert_equal(result.returns, "The result.")
+        assert_equal(
+            result.doc,
+            """\
+Summary.
+
+Raises:
+    ValueError: If bad.""",
+        )
+
+
+class TestRobotFrameworkTags(unittest.TestCase):
+
+    def test_tags_line_with_surrounding_prose_preserved(self):
+        doc = """\
+Summary line.
+
+More details here.
+Tags: tag1, tag2"""
+        result = parse_docstring(doc)
+        assert_equal(
+            result,
+            ParsedDocString(
+                doc="""\
+Summary line.
+
+More details here.
+Tags: tag1, tag2""",
+                args={},
+                returns="",
+            ),
+        )
+
+    def test_tags_line_with_args_section(self):
+        doc = """\
+Summary line.
+
+Args:
+    x: The input.
+
+Tags: kw1, kw2"""
+        result = parse_docstring(doc)
+        assert_equal(result.args, {"x": "The input."})
+        assert_equal(result.returns, "")
+        assert_equal(
+            result.doc,
+            """\
+Summary line.
+
+Tags: kw1, kw2""",
+        )
+
+    def test_tags_alone_on_line_is_unrecognised_section_body_goes_to_doc(self):
+        doc = """\
+Summary.
+
+Tags:
+    tag1    tag2"""
+        result = parse_docstring(doc)
+        assert_equal(result.args, {})
+        assert_equal(result.returns, "")
+        assert_equal(
+            result.doc,
+            """\
+Summary.
+
+Tags:
+    tag1    tag2""",
+        )
+
+
+if __name__ == "__main__":
+    # TODO: Add library that contains 10 000 keywords and see how performance is affected.
+    unittest.main()


### PR DESCRIPTION
There is simple performance script and I made some measurements. 
1. form docstring 
```
  Showing: median / min / max / mean / stdev  (10 runs per measurement)
  direct / prose_only
    time:  median=0.033s  min=0.033s  max=0.034s  mean=0.033s  stdev=0.001s
    mem:   median=0.00MB  min=0.00MB  max=0.01MB  mean=0.00MB  stdev=0.00MB
  libdoc / prose_only
    time:  median=3.004s  min=2.962s  max=3.024s  mean=3.001s  stdev=0.020s
    mem:   median=21.77MB  min=21.42MB  max=33.74MB  mean=22.92MB  stdev=3.81MB
  rf_import / prose_only
    time:  median=0.662s  min=0.606s  max=0.723s  mean=0.669s  stdev=0.033s
    mem:   median=14.27MB  min=13.33MB  max=14.92MB  mean=14.05MB  stdev=0.66MB
  direct / args_only
    time:  median=0.102s  min=0.102s  max=0.105s  mean=0.103s  stdev=0.001s
    mem:   median=0.01MB  min=0.01MB  max=0.01MB  mean=0.01MB  stdev=0.00MB
  libdoc / args_only
    time:  median=3.405s  min=3.350s  max=3.460s  mean=3.403s  stdev=0.038s
    mem:   median=24.73MB  min=24.73MB  max=39.61MB  mean=26.90MB  stdev=4.59MB
  rf_import / args_only
    time:  median=0.705s  min=0.617s  max=0.738s  mean=0.682s  stdev=0.051s
    mem:   median=13.54MB  min=13.53MB  max=16.77MB  mean=14.15MB  stdev=1.29MB
  direct / full_structured
    time:  median=0.158s  min=0.157s  max=0.161s  mean=0.159s  stdev=0.001s
    mem:   median=0.01MB  min=0.01MB  max=0.02MB  mean=0.01MB  stdev=0.00MB
  libdoc / full_structured
    time:  median=3.848s  min=3.679s  max=3.912s  mean=3.842s  stdev=0.064s
    mem:   median=25.47MB  min=25.47MB  max=40.64MB  mean=27.76MB  stdev=4.81MB
  rf_import / full_structured
    time:  median=0.647s  min=0.634s  max=0.789s  mean=0.699s  stdev=0.075s
    mem:   median=13.94MB  min=13.94MB  max=18.55MB  mean=14.41MB  stdev=1.46MB
 ```
 1. from master
 ```
   Showing: median / min / max / mean / stdev  (10 runs per measurement)
  direct / prose_only
    time:  median=0.004s  min=0.004s  max=0.005s  mean=0.004s  stdev=0.000s
    mem:   median=0.00MB  min=0.00MB  max=0.00MB  mean=0.00MB  stdev=0.00MB
  libdoc / prose_only
    time:  median=2.835s  min=2.746s  max=2.860s  mean=2.825s  stdev=0.037s
    mem:   median=21.00MB  min=20.65MB  max=32.93MB  mean=22.15MB  stdev=3.79MB
  rf_import / prose_only
    time:  median=0.637s  min=0.625s  max=0.678s  mean=0.638s  stdev=0.015s
    mem:   median=13.50MB  min=12.56MB  max=14.16MB  mean=13.29MB  stdev=0.66MB
  direct / args_only
    time:  median=0.004s  min=0.004s  max=0.004s  mean=0.004s  stdev=0.000s
    mem:   median=0.00MB  min=0.00MB  max=0.00MB  mean=0.00MB  stdev=0.00MB
  libdoc / args_only
    time:  median=3.131s  min=3.085s  max=3.204s  mean=3.131s  stdev=0.036s
    mem:   median=20.69MB  min=20.69MB  max=35.57MB  mean=22.86MB  stdev=4.59MB
  rf_import / args_only
    time:  median=0.688s  min=0.591s  max=0.704s  mean=0.653s  stdev=0.052s
    mem:   median=12.77MB  min=12.77MB  max=16.00MB  mean=13.38MB  stdev=1.29MB
  direct / full_structured
    time:  median=0.004s  min=0.004s  max=0.004s  mean=0.004s  stdev=0.000s
    mem:   median=0.00MB  min=0.00MB  max=0.00MB  mean=0.00MB  stdev=0.00MB
  libdoc / full_structured
    time:  median=3.514s  min=3.490s  max=3.897s  mean=3.557s  stdev=0.122s
    mem:   median=21.10MB  min=21.10MB  max=36.28MB  mean=23.39MB  stdev=4.81MB
  rf_import / full_structured
    time:  median=0.691s  min=0.604s  max=0.770s  mean=0.688s  stdev=0.075s
    mem:   median=13.18MB  min=13.18MB  max=17.79MB  mean=13.64MB  stdev=1.46MB
```

No idea is this good way to test perf or would be there be a better way. But now there is starting point to discuss. 