### PR TITLE
Document that console loggers should treat passed objects as read-only

### DIFF
--- a/doc/userguide/src/ExecutingTestCases/ConfiguringExecution.rst
+++ b/doc/userguide/src/ExecutingTestCases/ConfiguringExecution.rst
@@ -837,9 +837,10 @@ hooks it is interested in.
 
 __ `Listener interface`_
 
-.. note:: Console loggers should treat the ``result`` objects passed as read-only.
-   Currently live objects are passed so modifications would take effect, but this
-   behaviour may change without notice.
+.. note:: Console loggers should treat the ``data`` and ``result`` objects passed
+   to their methods as read-only. Currently live objects are passed so modifications
+   would take effect, but this behaviour may change without notice. Use the
+   `Listener interface`_ if you need to legitimately modify them.
 
    Support for custom console loggers is new in Robot Framework 7.5.
 

--- a/doc/userguide/src/ExecutingTestCases/ConfiguringExecution.rst
+++ b/doc/userguide/src/ExecutingTestCases/ConfiguringExecution.rst
@@ -837,7 +837,11 @@ hooks it is interested in.
 
 __ `Listener interface`_
 
-.. note:: Support for custom console loggers is new in Robot Framework 7.5.
+.. note:: Console loggers should treat the ``result`` objects passed as read-only.
+   Currently live objects are passed so modifications would take effect, but this
+   behaviour may change without notice.
+
+   Support for custom console loggers is new in Robot Framework 7.5.
 
 Example
 '''''''


### PR DESCRIPTION
Document current behaviour and advise users to not modify passed data or result objects 

related to #5618