### PR TITLE
DateTime: Convert docs to Markdown and use Args/Returns syntax

### DIFF
--- a/src/robot/libraries/DateTime.py
+++ b/src/robot/libraries/DateTime.py
@@ -15,139 +15,152 @@
 
 """A library for handling date and time values.
 
-``DateTime`` is a Robot Framework standard library that supports creating and
-converting date and time values (e.g. `Get Current Date`, `Convert Time`),
-as well as doing simple calculations with them (e.g. `Subtract Time From Date`,
-`Add Time To Time`). It supports dates and times in various formats, and can
+`DateTime` is a Robot Framework standard library that supports creating and
+converting date and time values (e.g. [Get Current Date], [Convert Time]),
+as well as doing simple calculations with them (e.g. [Subtract Time From Date],
+[Add Time To Time]). It supports dates and times in various formats, and can
 also be used by other libraries programmatically.
 
-== Table of contents ==
+## Table of contents
 
 %TOC%
 
-= Terminology =
+## Terminology
 
-In the context of this library, ``date`` and ``time`` generally have the following
+In the context of this library, `date` and `time` generally have the following
 meanings:
 
-- ``date``: An entity with both date and time components but without any
-   time zone information. For example, ``2014-06-11 10:07:42``.
-- ``time``: A time interval. For example, ``1 hour 20 minutes`` or ``01:20:00``.
+- `date`: An entity with both date and time components but without any
+  time zone information. For example, `2014-06-11 10:07:42`.
+- `time`: A time interval. For example, `1 hour 20 minutes` or `01:20:00`.
 
 This terminology differs from what Python's standard
-[http://docs.python.org/library/datetime.html|datetime] module uses.
+[datetime](http://docs.python.org/library/datetime.html) module uses.
 Basically its
-[http://docs.python.org/library/datetime.html#datetime-objects|datetime] and
-[http://docs.python.org/library/datetime.html#timedelta-objects|timedelta]
-objects match ``date`` and ``time`` as defined by this library.
+[datetime](http://docs.python.org/library/datetime.html#datetime-objects) and
+[timedelta](http://docs.python.org/library/datetime.html#timedelta-objects)
+objects match `date` and `time` as defined by this library.
 
-= Date formats =
+## Date formats
 
-Dates can be given to and received from keywords in `timestamp`, `custom
-timestamp`, `Python datetime` and `epoch time` formats. These formats are
+Dates can be given to and received from keywords in [Timestamp], [Custom
+timestamp], [Python datetime] and [Epoch time] formats. These formats are
 discussed thoroughly in subsequent sections.
 
 Input format is determined automatically based on the given date except when
 using custom timestamps, in which case it needs to be given using
-``date_format`` argument. Default result format is timestamp, but it can
-be overridden using ``result_format`` argument.
+`date_format` argument. Default result format is timestamp, but it can
+be overridden using `result_format` argument.
 
-== Timestamp ==
+### Timestamp
 
 If a date is given as a string, it is always considered to be a timestamp.
-If no custom formatting is given using ``date_format`` argument, the timestamp
-is expected to be in [http://en.wikipedia.org/wiki/ISO_8601|ISO 8601] like
-format ``YYYY-MM-DD hh:mm:ss.mil``, where any non-digit character can be used
+If no custom formatting is given using `date_format` argument, the timestamp
+is expected to be in [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) like
+format `YYYY-MM-DD hh:mm:ss.mil`, where any non-digit character can be used
 as a separator or separators can be omitted altogether. Additionally,
 only the date part is mandatory, all possibly missing time components are
 considered to be zeros.
 
-Dates can also be returned in the same ``YYYY-MM-DD hh:mm:ss.mil`` format by
-using ``timestamp`` value with ``result_format`` argument. This is also the
+Dates can also be returned in the same `YYYY-MM-DD hh:mm:ss.mil` format by
+using `timestamp` value with `result_format` argument. This is also the
 default format that keywords returning dates use. Milliseconds can be excluded
-using ``exclude_millis`` as explained in `Millisecond handling` section.
+using `exclude_millis` as explained in [Millisecond handling] section.
 
 Examples:
-| ${date1} =      | Convert Date | 2014-06-11 10:07:42.000 |
-| ${date2} =      | Convert Date | 20140611 100742         | result_format=timestamp |
-| Should Be Equal | ${date1}     | ${date2}                |
-| ${date} =       | Convert Date | 20140612 12:57          | exclude_millis=yes |
-| Should Be Equal | ${date}      | 2014-06-12 12:57:00     |
 
-== Custom timestamp ==
+```robotframework
+${date1} =      Convert Date    2014-06-11 10:07:42.000
+${date2} =      Convert Date    20140611 100742    result_format=timestamp
+Should Be Equal    ${date1}    ${date2}
+${date} =       Convert Date    20140612 12:57    exclude_millis=yes
+Should Be Equal    ${date}    2014-06-12 12:57:00
+```
+
+### Custom timestamp
 
 It is possible to use custom timestamps in both input and output.
 The custom format is same as accepted by Python's
-[http://docs.python.org/library/datetime.html#strftime-strptime-behavior|
-datetime.strptime] function. For example, the default timestamp discussed
-in the previous section would match ``%Y-%m-%d %H:%M:%S.%f``.
+[datetime.strptime](http://docs.python.org/library/datetime.html#strftime-strptime-behavior)
+function. For example, the default timestamp discussed
+in the previous section would match `%Y-%m-%d %H:%M:%S.%f`.
 
 When using a custom timestamp in input, it must be specified using
-``date_format`` argument. The actual input value must be a string that matches
+`date_format` argument. The actual input value must be a string that matches
 the specified format exactly. When using a custom timestamp in output, it must
-be given using ``result_format`` argument.
+be given using `result_format` argument.
 
 Examples:
-| ${date} =       | Convert Date | 28.05.2014 12:05        | date_format=%d.%m.%Y %H:%M |
-| Should Be Equal | ${date}      | 2014-05-28 12:05:00.000 |
-| ${date} =       | Convert Date | ${date}                 | result_format=%d.%m.%Y |
-| Should Be Equal | ${date}      | 28.05.2014              |
 
-== Python datetime ==
+```robotframework
+${date} =       Convert Date    28.05.2014 12:05    date_format=%d.%m.%Y %H:%M
+Should Be Equal    ${date}    2014-05-28 12:05:00.000
+${date} =       Convert Date    ${date}    result_format=%d.%m.%Y
+Should Be Equal    ${date}    28.05.2014
+```
+
+### Python datetime
 
 Python's standard
-[https://docs.python.org/library/datetime.html#datetime.datetime|datetime]
+[datetime](https://docs.python.org/library/datetime.html#datetime.datetime)
 objects can be used both in input and output. In input, they are recognized
-automatically, and in output it is possible to get them by using the ``datetime``
-value with the ``result_format`` argument.
+automatically, and in output it is possible to get them by using the `datetime`
+value with the `result_format` argument.
 
 One nice benefit with datetime objects is that they have different time
 components available as attributes that can be easily accessed using the
 extended variable syntax.
 
 Examples:
-| ${datetime} = | Convert Date | 2014-06-11 10:07:42.123 | datetime |
-| Should Be Equal As Integers | ${datetime.year}        | 2014   |
-| Should Be Equal As Integers | ${datetime.month}       | 6      |
-| Should Be Equal As Integers | ${datetime.day}         | 11     |
-| Should Be Equal As Integers | ${datetime.hour}        | 10     |
-| Should Be Equal As Integers | ${datetime.minute}      | 7      |
-| Should Be Equal As Integers | ${datetime.second}      | 42     |
-| Should Be Equal As Integers | ${datetime.microsecond} | 123000 |
 
-== Python date ==
+```robotframework
+${datetime} =    Convert Date    2014-06-11 10:07:42.123    datetime
+Should Be Equal As Integers    ${datetime.year}        2014
+Should Be Equal As Integers    ${datetime.month}       6
+Should Be Equal As Integers    ${datetime.day}         11
+Should Be Equal As Integers    ${datetime.hour}        10
+Should Be Equal As Integers    ${datetime.minute}      7
+Should Be Equal As Integers    ${datetime.second}      42
+Should Be Equal As Integers    ${datetime.microsecond}    123000
+```
 
-Python's standard [https://docs.python.org/library/datetime.html#datetime.date|date]
+### Python date
+
+Python's standard [date](https://docs.python.org/library/datetime.html#datetime.date)
 objects are automatically recognized in input starting from Robot Framework 7.0.
-They are not supported in output, but ``datetime`` objects can be converted
-to ``date`` objects if needed:
+They are not supported in output, but `datetime` objects can be converted
+to `date` objects if needed:
 
-| ${datetime} = | Convert Date | 2023-12-18 11:10:42 | datetime |
-| Log | ${datetime.date()} | # The time part is ignored. |
+```robotframework
+${datetime} =    Convert Date    2023-12-18 11:10:42    datetime
+Log    ${datetime.date()}    # The time part is ignored.
+```
 
-== Epoch time ==
+### Epoch time
 
 Epoch time is the time in seconds since the
-[http://en.wikipedia.org/wiki/Unix_time|UNIX epoch] i.e. 00:00:00.000 (UTC)
+[UNIX epoch](http://en.wikipedia.org/wiki/Unix_time) i.e. 00:00:00.000 (UTC)
 January 1, 1970. To give a date as an epoch time, it must be given as a number
 (integer or float), not as a string. To return a date as an epoch time,
-it is possible to use ``epoch`` value with ``result_format`` argument.
+it is possible to use `epoch` value with `result_format` argument.
 Epoch times are returned as floating point numbers.
 
 Notice that epoch times are independent on time zones and thus same
 around the world at a certain time. For example, epoch times returned
-by `Get Current Date` are not affected by the ``time_zone`` argument.
+by [Get Current Date] are not affected by the `time_zone` argument.
 What local time a certain epoch time matches then depends on the time zone.
 
 Following examples demonstrate using epoch times. They are tested in Finland,
 and due to the reasons explained above they would fail on other time zones.
 
-| ${date} =       | Convert Date | ${1000000000}           |
-| Should Be Equal | ${date}      | 2001-09-09 04:46:40.000 |
-| ${date} =       | Convert Date | 2014-06-12 13:27:59.279 | epoch |
-| Should Be Equal | ${date}      | ${1402568879.279}       |
+```robotframework
+${date} =       Convert Date    ${1000000000}
+Should Be Equal    ${date}    2001-09-09 04:46:40.000
+${date} =       Convert Date    2014-06-12 13:27:59.279    epoch
+Should Be Equal    ${date}    ${1402568879.279}
+```
 
-== Earliest supported date ==
+### Earliest supported date
 
 The earliest date that is supported depends on the date format and to some
 extent on the platform:
@@ -157,151 +170,169 @@ extent on the platform:
 - Epoch time supports 1970 and above on Windows.
 - On other platforms epoch time supports 1900 and above or even earlier.
 
-= Time formats =
+## Time formats
 
 Similarly as dates, times can be given to and received from keywords in
-various different formats. Supported formats are `number`, `time string`
-(verbose and compact), `timer string` and `Python timedelta`.
+various different formats. Supported formats are [Number], [Time string]
+(verbose and compact), [Timer string] and [Python timedelta].
 
 Input format for time is always determined automatically based on the input.
 Result format is number by default, but it can be customised using
-``result_format`` argument.
+`result_format` argument.
 
-== Number ==
+### Number
 
 Time given as a number is interpreted to be seconds. It can be given
 either as an integer or a float, or it can be a string that can be converted
 to a number.
 
-To return a time as a number, ``result_format`` argument must have value
-``number``, which is also the default. Returned number is always a float.
+To return a time as a number, `result_format` argument must have value
+`number`, which is also the default. Returned number is always a float.
 
 Examples:
-| ${time} =       | Convert Time | 3.14    |
-| Should Be Equal | ${time}      | ${3.14} |
-| ${time} =       | Convert Time | ${time} | result_format=number |
-| Should Be Equal | ${time}      | ${3.14} |
 
-== Time string ==
+```robotframework
+${time} =       Convert Time    3.14
+Should Be Equal    ${time}    ${3.14}
+${time} =       Convert Time    ${time}    result_format=number
+Should Be Equal    ${time}    ${3.14}
+```
 
-Time strings are strings in format like ``1 minute 42 seconds`` or ``1min 42s``.
+### Time string
+
+Time strings are strings in format like `1 minute 42 seconds` or `1min 42s`.
 The basic idea of this format is having first a number and then a text
 specifying what time that number represents. Numbers can be either
 integers or floating point numbers, the whole format is case and space
 insensitive, and it is possible to add a minus prefix to specify negative
 times. The available time specifiers are:
 
-- ``weeks``, ``week``, ``w`` (new in RF 7.1)
-- ``days``, ``day``, ``d``
-- ``hours``, ``hour``, ``h``
-- ``minutes``, ``minute``, ``mins``, ``min``, ``m``
-- ``seconds``, ``second``, ``secs``, ``sec``, ``s``
-- ``milliseconds``, ``millisecond``, ``millis``, ``ms``
-- ``microseconds``, ``microsecond``, ``us``, ``μs`` (new in RF 6.0)
-- ``nanoseconds``, ``nanosecond``, ``ns`` (new in RF 6.0)
+- `weeks`, `week`, `w` (new in RF 7.1)
+- `days`, `day`, `d`
+- `hours`, `hour`, `h`
+- `minutes`, `minute`, `mins`, `min`, `m`
+- `seconds`, `second`, `secs`, `sec`, `s`
+- `milliseconds`, `millisecond`, `millis`, `ms`
+- `microseconds`, `microsecond`, `us`, `μs` (new in RF 6.0)
+- `nanoseconds`, `nanosecond`, `ns` (new in RF 6.0)
 
-When returning a time string, it is possible to select between ``verbose``
-and ``compact`` representations using ``result_format`` argument. The verbose
-format uses long specifiers ``week``, ``day``, ``hour``, ``minute``, ``second`` and
-``millisecond``, and adds ``s`` at the end when needed. The compact format uses
-shorter specifiers ``w``, ``d``, ``h``, ``min``, ``s`` and ``ms``, and even drops
+When returning a time string, it is possible to select between `verbose`
+and `compact` representations using `result_format` argument. The verbose
+format uses long specifiers `week`, `day`, `hour`, `minute`, `second` and
+`millisecond`, and adds `s` at the end when needed. The compact format uses
+shorter specifiers `w`, `d`, `h`, `min`, `s` and `ms`, and even drops
 the space between the number and the specifier.
 
 Examples:
-| ${time} =       | Convert Time | 1 minute 42 seconds |
-| Should Be Equal | ${time}      | ${102}              |
-| ${time} =       | Convert Time | 4200                | verbose |
-| Should Be Equal | ${time}      | 1 hour 10 minutes   |
-| ${time} =       | Convert Time | - 1.5 hours         | compact |
-| Should Be Equal | ${time}      | - 1h 30min          |
 
-== Timer string ==
+```robotframework
+${time} =       Convert Time    1 minute 42 seconds
+Should Be Equal    ${time}    ${102}
+${time} =       Convert Time    4200    verbose
+Should Be Equal    ${time}    1 hour 10 minutes
+${time} =       Convert Time    - 1.5 hours    compact
+Should Be Equal    ${time}    - 1h 30min
+```
 
-Timer string is a string given in timer like format ``hh:mm:ss.mil``. In this
+### Timer string
+
+Timer string is a string given in timer like format `hh:mm:ss.mil`. In this
 format both hour and millisecond parts are optional, leading and trailing
 zeros can be left out when they are not meaningful, and negative times can
 be represented by adding a minus prefix.
 
-To return a time as timer string, ``result_format`` argument must be given
-value ``timer``. Timer strings are by default returned in full ``hh:mm:ss.mil``
-format, but milliseconds can be excluded using ``exclude_millis`` as explained
-in `Millisecond handling` section.
+To return a time as timer string, `result_format` argument must be given
+value `timer`. Timer strings are by default returned in full `hh:mm:ss.mil`
+format, but milliseconds can be excluded using `exclude_millis` as explained
+in [Millisecond handling] section.
 
 Examples:
-| ${time} =       | Convert Time | 01:42        |
-| Should Be Equal | ${time}      | ${102}       |
-| ${time} =       | Convert Time | 01:10:00.123 |
-| Should Be Equal | ${time}      | ${4200.123}  |
-| ${time} =       | Convert Time | 102          | timer |
-| Should Be Equal | ${time}      | 00:01:42.000 |
-| ${time} =       | Convert Time | -101.567     | timer | exclude_millis=yes |
-| Should Be Equal | ${time}      | -00:01:42    |
 
-== Python timedelta ==
+```robotframework
+${time} =       Convert Time    01:42
+Should Be Equal    ${time}    ${102}
+${time} =       Convert Time    01:10:00.123
+Should Be Equal    ${time}    ${4200.123}
+${time} =       Convert Time    102    timer
+Should Be Equal    ${time}    00:01:42.000
+${time} =       Convert Time    -101.567    timer    exclude_millis=yes
+Should Be Equal    ${time}    -00:01:42
+```
+
+### Python timedelta
 
 Python's standard
-[http://docs.python.org/library/datetime.html#datetime.timedelta|timedelta]
+[timedelta](http://docs.python.org/library/datetime.html#datetime.timedelta)
 objects are also supported both in input and in output. In input they are
 recognized automatically, and in output it is possible to receive them by
-giving ``timedelta`` value to ``result_format`` argument.
+giving `timedelta` value to `result_format` argument.
 
 Examples:
-| ${timedelta} =  | Convert Time                 | 01:10:02.123 | timedelta |
-| Should Be Equal | ${timedelta.total_seconds()} | ${4202.123}  |
 
-= Millisecond handling =
+```robotframework
+${timedelta} =    Convert Time    01:10:02.123    timedelta
+Should Be Equal    ${timedelta.total_seconds()}    ${4202.123}
+```
+
+## Millisecond handling
 
 This library handles dates and times internally using the precision of the
-given input. With `timestamp`, `time string`, and `timer string` result
+given input. With [Timestamp], [Time string], and [Timer string] result
 formats seconds are, however, rounded to millisecond accuracy. Milliseconds
 may also be included even if there would be none.
 
 All keywords returning dates or times have an option to leave milliseconds out
-by giving a true value to ``exclude_millis`` argument. If the argument is given
+by giving a true value to `exclude_millis` argument. If the argument is given
 as a string, it is considered true unless it is empty or case-insensitively
-equal to ``false``, ``none`` or ``no``. Other argument types are tested using
-same [http://docs.python.org/library/stdtypes.html#truth|rules as in
-Python].
+equal to `false`, `none` or `no`. Other argument types are tested using
+same [rules as in Python](http://docs.python.org/library/stdtypes.html#truth).
 
 When milliseconds are excluded, seconds in returned dates and times are
-rounded to the nearest full second. With `timestamp` and `timer string`
+rounded to the nearest full second. With [Timestamp] and [Timer string]
 result formats, milliseconds will also be removed from the returned string
 altogether.
 
 Examples:
-| ${date} =       | Convert Date | 2014-06-11 10:07:42     |
-| Should Be Equal | ${date}      | 2014-06-11 10:07:42.000 |
-| ${date} =       | Convert Date | 2014-06-11 10:07:42.500 | exclude_millis=yes |
-| Should Be Equal | ${date}      | 2014-06-11 10:07:43     |
-| ${dt} =         | Convert Date | 2014-06-11 10:07:42.500 | datetime | exclude_millis=yes |
-| Should Be Equal | ${dt.second} | ${43}        |
-| Should Be Equal | ${dt.microsecond} | ${0}    |
-| ${time} =       | Convert Time | 102          | timer | exclude_millis=false |
-| Should Be Equal | ${time}      | 00:01:42.000 |       |
-| ${time} =       | Convert Time | 102.567      | timer | exclude_millis=true |
-| Should Be Equal | ${time}      | 00:01:43     |       |
 
-= Programmatic usage =
+```robotframework
+${date} =       Convert Date    2014-06-11 10:07:42
+Should Be Equal    ${date}    2014-06-11 10:07:42.000
+${date} =       Convert Date    2014-06-11 10:07:42.500    exclude_millis=yes
+Should Be Equal    ${date}    2014-06-11 10:07:43
+${dt} =         Convert Date    2014-06-11 10:07:42.500    datetime    exclude_millis=yes
+Should Be Equal    ${dt.second}    ${43}
+Should Be Equal    ${dt.microsecond}    ${0}
+${time} =       Convert Time    102    timer    exclude_millis=false
+Should Be Equal    ${time}    00:01:42.000
+${time} =       Convert Time    102.567    timer    exclude_millis=true
+Should Be Equal    ${time}    00:01:43
+```
+
+## Programmatic usage
 
 In addition to be used as normal library, this library is intended to
 provide a stable API for other libraries to use if they want to support
 same date and time formats as this library. All the provided keywords
 are available as functions that can be easily imported:
 
-| from robot.libraries.DateTime import convert_time
-|
-| def example_keyword(timeout):
-|     seconds = convert_time(timeout)
-|     # ...
+```python
+from robot.libraries.DateTime import convert_time
 
-Additionally, helper classes ``Date`` and ``Time`` can be used directly:
+def example_keyword(timeout):
+    seconds = convert_time(timeout)
+    # ...
+```
 
-| from robot.libraries.DateTime import Date, Time
-|
-| def example_keyword(date, interval):
-|     date = Date(date).convert('datetime')
-|     interval = Time(interval).convert('number')
-|     # ...
+Additionally, helper classes `Date` and `Time` can be used directly:
+
+```python
+from robot.libraries.DateTime import Date, Time
+
+def example_keyword(date, interval):
+    date = Date(date).convert('datetime')
+    interval = Time(interval).convert('number')
+    # ...
+```
 """
 
 import datetime
@@ -326,6 +357,8 @@ __all__ = [
     "subtract_time_from_time",
 ]
 
+ROBOT_LIBRARY_DOC_FORMAT = "Markdown"
+
 DateInput = Union[datetime.datetime, datetime.date, float, int, str]
 DateOutput = Union[datetime.datetime, float, str]
 DateFormat = Union[Literal["timestamp", "datetime", "epoch"], str]
@@ -342,28 +375,36 @@ def get_current_date(
 ) -> DateOutput:
     """Returns current local or UTC time with an optional increment.
 
-    Arguments:
-    - ``time_zone:``      Get the current time on this time zone. Currently only
-                          ``local`` (default) and ``UTC`` are supported.
-                          Has no effect if date is returned as an `epoch time`.
-    - ``increment:``      Optional time increment to add to the returned date in
-                          one of the supported `time formats`. Can be negative.
-    - ``result_format:``  Format of the returned date (see `date formats`).
-    - ``exclude_millis:`` When set to any true value, rounds and drops
-                          milliseconds as explained in `millisecond handling`.
+    Args:
+
+        time_zone: Get the current time on this time zone. Currently only
+            `local` (default) and `UTC` are supported. Has no effect if date
+            is returned as an [Epoch time].
+        increment: Optional time increment to add to the returned date in
+            one of the supported [Time formats]. Can be negative.
+        result_format: Format of the returned date (see [Date formats]).
+        exclude_millis: When set to any true value, rounds and drops
+            milliseconds as explained in [Millisecond handling].
+
+    Returns:
+
+        The current date in the requested format.
 
     Examples:
-    | ${date} =       | Get Current Date |
-    | Should Be Equal | ${date}          | 2014-06-12 20:00:58.946 |
-    | ${date} =       | Get Current Date | UTC                     |
-    | Should Be Equal | ${date}          | 2014-06-12 17:00:58.946 |
-    | ${date} =       | Get Current Date | increment=02:30:00      |
-    | Should Be Equal | ${date}          | 2014-06-12 22:30:58.946 |
-    | ${date} =       | Get Current Date | UTC                     | - 5 hours |
-    | Should Be Equal | ${date}          | 2014-06-12 12:00:58.946 |
-    | ${date} =       | Get Current Date | result_format=datetime  |
-    | Should Be Equal | ${date.year}     | ${2014}                 |
-    | Should Be Equal | ${date.month}    | ${6}                    |
+
+    ```robotframework
+    ${date} =       Get Current Date
+    Should Be Equal    ${date}    2014-06-12 20:00:58.946
+    ${date} =       Get Current Date    UTC
+    Should Be Equal    ${date}    2014-06-12 17:00:58.946
+    ${date} =       Get Current Date    increment=02:30:00
+    Should Be Equal    ${date}    2014-06-12 22:30:58.946
+    ${date} =       Get Current Date    UTC    - 5 hours
+    Should Be Equal    ${date}    2014-06-12 12:00:58.946
+    ${date} =       Get Current Date    result_format=datetime
+    Should Be Equal    ${date.year}    ${2014}
+    Should Be Equal    ${date.month}    ${6}
+    ```
     """
     if time_zone.upper() == "LOCAL" or result_format.upper() == "EPOCH":
         dt = datetime.datetime.now()
@@ -386,22 +427,30 @@ def convert_date(
     exclude_millis: bool = False,
     date_format: "str | None" = None,
 ) -> DateOutput:
-    """Converts between supported `date formats`.
+    """Converts between supported [Date formats].
 
-    Arguments:
-    - ``date:``           Date in one of the supported `date formats`.
-    - ``result_format:``  Format of the returned date.
-    - ``exclude_millis:`` When set to any true value, rounds and drops
-                          milliseconds as explained in `millisecond handling`.
-    - ``date_format:``    Specifies possible `custom timestamp` format.
+    Args:
+
+        date: Date in one of the supported [Date formats].
+        result_format: Format of the returned date.
+        exclude_millis: When set to any true value, rounds and drops
+            milliseconds as explained in [Millisecond handling].
+        date_format: Specifies possible [Custom timestamp] format.
+
+    Returns:
+
+        The converted date in the requested format.
 
     Examples:
-    | ${date} =       | Convert Date | 20140528 12:05:03.111   |
-    | Should Be Equal | ${date}      | 2014-05-28 12:05:03.111 |
-    | ${date} =       | Convert Date | ${date}                 | epoch |
-    | Should Be Equal | ${date}      | ${1401267903.111}       |
-    | ${date} =       | Convert Date | 5.28.2014 12:05         | exclude_millis=yes | date_format=%m.%d.%Y %H:%M |
-    | Should Be Equal | ${date}      | 2014-05-28 12:05:00     |
+
+    ```robotframework
+    ${date} =       Convert Date    20140528 12:05:03.111
+    Should Be Equal    ${date}    2014-05-28 12:05:03.111
+    ${date} =       Convert Date    ${date}    epoch
+    Should Be Equal    ${date}    ${1401267903.111}
+    ${date} =       Convert Date    5.28.2014 12:05    exclude_millis=yes    date_format=%m.%d.%Y %H:%M
+    Should Be Equal    ${date}    2014-05-28 12:05:00
+    ```
     """
     return Date(date, date_format).convert(result_format, millis=not exclude_millis)
 
@@ -411,21 +460,29 @@ def convert_time(
     result_format: TimeFormat = "number",
     exclude_millis: bool = False,
 ) -> TimeOutput:
-    """Converts between supported `time formats`.
+    """Converts between supported [Time formats].
 
-    Arguments:
-    - ``time:``           Time in one of the supported `time formats`.
-    - ``result_format:``  Format of the returned time.
-    - ``exclude_millis:`` When set to any true value, rounds and drops
-                          milliseconds as explained in `millisecond handling`.
+    Args:
+
+        time: Time in one of the supported [Time formats].
+        result_format: Format of the returned time.
+        exclude_millis: When set to any true value, rounds and drops
+            milliseconds as explained in [Millisecond handling].
+
+    Returns:
+
+        The converted time in the requested format.
 
     Examples:
-    | ${time} =       | Convert Time  | 10 seconds        |
-    | Should Be Equal | ${time}       | ${10}             |
-    | ${time} =       | Convert Time  | 1:00:01           | verbose |
-    | Should Be Equal | ${time}       | 1 hour 1 second   |
-    | ${time} =       | Convert Time  | ${3661.5} | timer | exclude_milles=yes |
-    | Should Be Equal | ${time}       | 01:01:02          |
+
+    ```robotframework
+    ${time} =       Convert Time    10 seconds
+    Should Be Equal    ${time}    ${10}
+    ${time} =       Convert Time    1:00:01    verbose
+    Should Be Equal    ${time}    1 hour 1 second
+    ${time} =       Convert Time    ${3661.5}    timer    exclude_milles=yes
+    Should Be Equal    ${time}    01:01:02
+    ```
     """
     return Time(time).convert(result_format, millis=not exclude_millis)
 
@@ -440,22 +497,30 @@ def subtract_date_from_date(
 ) -> TimeOutput:
     """Subtracts date from another date and returns time between.
 
-    Arguments:
-    - ``date1:``          Date to subtract another date from in one of the
-                          supported `date formats`.
-    - ``date2:``          Date that is subtracted in one of the supported
-                          `date formats`.
-    - ``result_format:``  Format of the returned time (see `time formats`).
-    - ``exclude_millis:`` When set to any true value, rounds and drops
-                          milliseconds as explained in `millisecond handling`.
-    - ``date1_format:``   Possible `custom timestamp` format of ``date1``.
-    - ``date2_format:``   Possible `custom timestamp` format of ``date2``.
+    Args:
 
-     Examples:
-    | ${time} =       | Subtract Date From Date | 2014-05-28 12:05:52     | 2014-05-28 12:05:10 |
-    | Should Be Equal | ${time}                 | ${42}                   |
-    | ${time} =       | Subtract Date From Date | 2014-05-28 12:05:52     | 2014-05-27 12:05:10 | verbose |
-    | Should Be Equal | ${time}                 | 1 day 42 seconds        |
+        date1: Date to subtract another date from in one of the
+            supported [Date formats].
+        date2: Date that is subtracted in one of the supported
+            [Date formats].
+        result_format: Format of the returned time (see [Time formats]).
+        exclude_millis: When set to any true value, rounds and drops
+            milliseconds as explained in [Millisecond handling].
+        date1_format: Possible [Custom timestamp] format of `date1`.
+        date2_format: Possible [Custom timestamp] format of `date2`.
+
+    Returns:
+
+        The time between the given dates in the requested format.
+
+    Examples:
+
+    ```robotframework
+    ${time} =       Subtract Date From Date    2014-05-28 12:05:52    2014-05-28 12:05:10
+    Should Be Equal    ${time}    ${42}
+    ${time} =       Subtract Date From Date    2014-05-28 12:05:52    2014-05-27 12:05:10    verbose
+    Should Be Equal    ${time}    1 day 42 seconds
+    ```
     """
     time = Date(date1, date1_format) - Date(date2, date2_format)
     return time.convert(result_format, millis=not exclude_millis)
@@ -470,21 +535,29 @@ def add_time_to_date(
 ) -> DateOutput:
     """Adds time to date and returns the resulting date.
 
-    Arguments:
-    - ``date:``           Date to add time to in one of the supported
-                          `date formats`.
-    - ``time:``           Time that is added in one of the supported
-                          `time formats`.
-    - ``result_format:``  Format of the returned date.
-    - ``exclude_millis:`` When set to any true value, rounds and drops
-                          milliseconds as explained in `millisecond handling`.
-    - ``date_format:``    Possible `custom timestamp` format of ``date``.
+    Args:
+
+        date: Date to add time to in one of the supported
+            [Date formats].
+        time: Time that is added in one of the supported
+            [Time formats].
+        result_format: Format of the returned date.
+        exclude_millis: When set to any true value, rounds and drops
+            milliseconds as explained in [Millisecond handling].
+        date_format: Possible [Custom timestamp] format of `date`.
+
+    Returns:
+
+        The resulting date in the requested format.
 
     Examples:
-    | ${date} =       | Add Time To Date | 2014-05-28 12:05:03.111 | 7 days       |
-    | Should Be Equal | ${date}          | 2014-06-04 12:05:03.111 |              |
-    | ${date} =       | Add Time To Date | 2014-05-28 12:05:03.111 | 01:02:03:004 |
-    | Should Be Equal | ${date}          | 2014-05-28 13:07:06.115 |
+
+    ```robotframework
+    ${date} =       Add Time To Date    2014-05-28 12:05:03.111    7 days
+    Should Be Equal    ${date}    2014-06-04 12:05:03.111
+    ${date} =       Add Time To Date    2014-05-28 12:05:03.111    01:02:03:004
+    Should Be Equal    ${date}    2014-05-28 13:07:06.115
+    ```
     """
     date = Date(date, date_format) + Time(time)
     return date.convert(result_format, millis=not exclude_millis)
@@ -499,21 +572,29 @@ def subtract_time_from_date(
 ) -> DateOutput:
     """Subtracts time from date and returns the resulting date.
 
-    Arguments:
-    - ``date:``           Date to subtract time from in one of the supported
-                          `date formats`.
-    - ``time:``           Time that is subtracted in one of the supported
-                         `time formats`.
-    - ``result_format:``  Format of the returned date.
-    - ``exclude_millis:`` When set to any true value, rounds and drops
-                          milliseconds as explained in `millisecond handling`.
-    - ``date_format:``    Possible `custom timestamp` format of ``date``.
+    Args:
+
+        date: Date to subtract time from in one of the supported
+            [Date formats].
+        time: Time that is subtracted in one of the supported
+            [Time formats].
+        result_format: Format of the returned date.
+        exclude_millis: When set to any true value, rounds and drops
+            milliseconds as explained in [Millisecond handling].
+        date_format: Possible [Custom timestamp] format of `date`.
+
+    Returns:
+
+        The resulting date in the requested format.
 
     Examples:
-    | ${date} =       | Subtract Time From Date | 2014-06-04 12:05:03.111 | 7 days |
-    | Should Be Equal | ${date}                 | 2014-05-28 12:05:03.111 |
-    | ${date} =       | Subtract Time From Date | 2014-05-28 13:07:06.115 | 01:02:03:004 |
-    | Should Be Equal | ${date}                 | 2014-05-28 12:05:03.111 |
+
+    ```robotframework
+    ${date} =       Subtract Time From Date    2014-06-04 12:05:03.111    7 days
+    Should Be Equal    ${date}    2014-05-28 12:05:03.111
+    ${date} =       Subtract Time From Date    2014-05-28 13:07:06.115    01:02:03:004
+    Should Be Equal    ${date}    2014-05-28 12:05:03.111
+    ```
     """
     date = Date(date, date_format) - Time(time)
     return date.convert(result_format, millis=not exclude_millis)
@@ -527,18 +608,26 @@ def add_time_to_time(
 ) -> TimeOutput:
     """Adds time to another time and returns the resulting time.
 
-    Arguments:
-    - ``time1:``          First time in one of the supported `time formats`.
-    - ``time2:``          Second time in one of the supported `time formats`.
-    - ``result_format:``  Format of the returned time.
-    - ``exclude_millis:`` When set to any true value, rounds and drops
-                          milliseconds as explained in `millisecond handling`.
+    Args:
+
+        time1: First time in one of the supported [Time formats].
+        time2: Second time in one of the supported [Time formats].
+        result_format: Format of the returned time.
+        exclude_millis: When set to any true value, rounds and drops
+            milliseconds as explained in [Millisecond handling].
+
+    Returns:
+
+        The sum of the given times in the requested format.
 
     Examples:
-    | ${time} =       | Add Time To Time | 1 minute          | 42       |
-    | Should Be Equal | ${time}          | ${102}            |
-    | ${time} =       | Add Time To Time | 3 hours 5 minutes | 01:02:03 | timer | exclude_millis=yes |
-    | Should Be Equal | ${time}          | 04:07:03          |
+
+    ```robotframework
+    ${time} =       Add Time To Time    1 minute    42
+    Should Be Equal    ${time}    ${102}
+    ${time} =       Add Time To Time    3 hours 5 minutes    01:02:03    timer    exclude_millis=yes
+    Should Be Equal    ${time}    04:07:03
+    ```
     """
     time = Time(time1) + Time(time2)
     return time.convert(result_format, millis=not exclude_millis)
@@ -552,26 +641,33 @@ def subtract_time_from_time(
 ) -> TimeOutput:
     """Subtracts time from another time and returns the resulting time.
 
-    Arguments:
-    - ``time1:``          Time to subtract another time from in one of
-                          the supported `time formats`.
-    - ``time2:``          Time to subtract in one of the supported `time formats`.
-    - ``result_format:``  Format of the returned time.
-    - ``exclude_millis:`` When set to any true value, rounds and drops
-                          milliseconds as explained in `millisecond handling`.
+    Args:
+
+        time1: Time to subtract another time from in one of
+            the supported [Time formats].
+        time2: Time to subtract in one of the supported [Time formats].
+        result_format: Format of the returned time.
+        exclude_millis: When set to any true value, rounds and drops
+            milliseconds as explained in [Millisecond handling].
+
+    Returns:
+
+        The difference between the given times in the requested format.
 
     Examples:
-    | ${time} =       | Subtract Time From Time | 00:02:30 | 100      |
-    | Should Be Equal | ${time}                 | ${50}    |
-    | ${time} =       | Subtract Time From Time | ${time}  | 1 minute | compact |
-    | Should Be Equal | ${time}                 | - 10s    |
+
+    ```robotframework
+    ${time} =       Subtract Time From Time    00:02:30    100
+    Should Be Equal    ${time}    ${50}
+    ${time} =       Subtract Time From Time    ${time}    1 minute    compact
+    Should Be Equal    ${time}    - 10s
+    ```
     """
     time = Time(time1) - Time(time2)
     return time.convert(result_format, millis=not exclude_millis)
 
 
 class Date:
-
     def __init__(
         self,
         date: DateInput,
@@ -671,7 +767,6 @@ class Date:
 
 
 class Time:
-
     def __init__(self, time: TimeInput):
         self.seconds = timestr_to_secs(time, round_to=None)
 

--- a/src/robot/libraries/DateTime.py
+++ b/src/robot/libraries/DateTime.py
@@ -21,11 +21,11 @@ as well as doing simple calculations with them (e.g. [Subtract Time From Date],
 [Add Time To Time]). It supports dates and times in various formats, and can
 also be used by other libraries programmatically.
 
-## Table of contents
+### Table of contents
 
 %TOC%
 
-## Terminology
+# Terminology
 
 In the context of this library, `date` and `time` generally have the following
 meanings:
@@ -41,7 +41,7 @@ Basically its
 [timedelta](http://docs.python.org/library/datetime.html#timedelta-objects)
 objects match `date` and `time` as defined by this library.
 
-## Date formats
+# Date formats
 
 Dates can be given to and received from keywords in [Timestamp], [Custom
 timestamp], [Python datetime] and [Epoch time] formats. These formats are
@@ -52,7 +52,7 @@ using custom timestamps, in which case it needs to be given using
 `date_format` argument. Default result format is timestamp, but it can
 be overridden using `result_format` argument.
 
-### Timestamp
+## Timestamp
 
 If a date is given as a string, it is always considered to be a timestamp.
 If no custom formatting is given using `date_format` argument, the timestamp
@@ -77,7 +77,7 @@ ${date} =       Convert Date    20140612 12:57    exclude_millis=yes
 Should Be Equal    ${date}    2014-06-12 12:57:00
 ```
 
-### Custom timestamp
+## Custom timestamp
 
 It is possible to use custom timestamps in both input and output.
 The custom format is same as accepted by Python's
@@ -99,7 +99,7 @@ ${date} =       Convert Date    ${date}    result_format=%d.%m.%Y
 Should Be Equal    ${date}    28.05.2014
 ```
 
-### Python datetime
+## Python datetime
 
 Python's standard
 [datetime](https://docs.python.org/library/datetime.html#datetime.datetime)
@@ -124,7 +124,7 @@ Should Be Equal As Integers    ${datetime.second}      42
 Should Be Equal As Integers    ${datetime.microsecond}    123000
 ```
 
-### Python date
+## Python date
 
 Python's standard [date](https://docs.python.org/library/datetime.html#datetime.date)
 objects are automatically recognized in input starting from Robot Framework 7.0.
@@ -136,7 +136,7 @@ ${datetime} =    Convert Date    2023-12-18 11:10:42    datetime
 Log    ${datetime.date()}    # The time part is ignored.
 ```
 
-### Epoch time
+## Epoch time
 
 Epoch time is the time in seconds since the
 [UNIX epoch](http://en.wikipedia.org/wiki/Unix_time) i.e. 00:00:00.000 (UTC)
@@ -160,7 +160,7 @@ ${date} =       Convert Date    2014-06-12 13:27:59.279    epoch
 Should Be Equal    ${date}    ${1402568879.279}
 ```
 
-### Earliest supported date
+## Earliest supported date
 
 The earliest date that is supported depends on the date format and to some
 extent on the platform:
@@ -170,7 +170,7 @@ extent on the platform:
 - Epoch time supports 1970 and above on Windows.
 - On other platforms epoch time supports 1900 and above or even earlier.
 
-## Time formats
+# Time formats
 
 Similarly as dates, times can be given to and received from keywords in
 various different formats. Supported formats are [Number], [Time string]
@@ -180,7 +180,7 @@ Input format for time is always determined automatically based on the input.
 Result format is number by default, but it can be customised using
 `result_format` argument.
 
-### Number
+## Number
 
 Time given as a number is interpreted to be seconds. It can be given
 either as an integer or a float, or it can be a string that can be converted
@@ -198,7 +198,7 @@ ${time} =       Convert Time    ${time}    result_format=number
 Should Be Equal    ${time}    ${3.14}
 ```
 
-### Time string
+## Time string
 
 Time strings are strings in format like `1 minute 42 seconds` or `1min 42s`.
 The basic idea of this format is having first a number and then a text
@@ -234,7 +234,7 @@ ${time} =       Convert Time    - 1.5 hours    compact
 Should Be Equal    ${time}    - 1h 30min
 ```
 
-### Timer string
+## Timer string
 
 Timer string is a string given in timer like format `hh:mm:ss.mil`. In this
 format both hour and millisecond parts are optional, leading and trailing
@@ -259,7 +259,7 @@ ${time} =       Convert Time    -101.567    timer    exclude_millis=yes
 Should Be Equal    ${time}    -00:01:42
 ```
 
-### Python timedelta
+## Python timedelta
 
 Python's standard
 [timedelta](http://docs.python.org/library/datetime.html#datetime.timedelta)
@@ -274,7 +274,7 @@ ${timedelta} =    Convert Time    01:10:02.123    timedelta
 Should Be Equal    ${timedelta.total_seconds()}    ${4202.123}
 ```
 
-## Millisecond handling
+# Millisecond handling
 
 This library handles dates and times internally using the precision of the
 given input. With [Timestamp], [Time string], and [Timer string] result
@@ -308,7 +308,7 @@ ${time} =       Convert Time    102.567    timer    exclude_millis=true
 Should Be Equal    ${time}    00:01:43
 ```
 
-## Programmatic usage
+# Programmatic usage
 
 In addition to be used as normal library, this library is intended to
 provide a stable API for other libraries to use if they want to support


### PR DESCRIPTION
## What

- Convert DateTime library and keyword documentation to Markdown.
- Add structured Args and Returns for all keywords.

## Why

DateTime-only part of #5709.

## Testing

- Libdoc: `MARKDOWN`, 8 keywords, all with Args and Returns docs