### PR TITLE
Process: Convert docs to Markdown and use Args/Returns syntax

### DIFF
--- a/src/robot/libraries/Process.py
+++ b/src/robot/libraries/Process.py
@@ -44,26 +44,30 @@ OnTimeout = Literal["continue", "terminate", "kill"]
 class ProcessResult:
     """An object containing process execution results in its attributes.
 
-    | = Attribute = |             = Explanation =               |
-    | rc            | Return code of the process as an integer. |
-    | stdout        | Contents of the standard output stream.   |
-    | stderr        | Contents of the standard error stream.    |
-    | stdout_path   | Path where stdout was redirected or ``None`` if not redirected. |
-    | stderr_path   | Path where stderr was redirected or ``None`` if not redirected. |
+    | Attribute | Explanation |
+    |-----------|-------------|
+    | rc | Return code of the process as an integer. |
+    | stdout | Contents of the standard output stream. |
+    | stderr | Contents of the standard error stream. |
+    | stdout_path | Path where stdout was redirected or `None` if not redirected. |
+    | stderr_path | Path where stderr was redirected or `None` if not redirected. |
 
     Example:
-    | ${result} =            | `Run Process`         | program               |
-    | `Should Be Equal     ` | ${result.rc}          | 0 | type=int          |
-    | `Should Match`         | ${result.stdout}      | Some t?xt*            |
-    | `Should Be Empty`      | ${result.stderr}      |                       |
-    | ${stdout} =            | `Get File`            | ${result.stdout_path} |
-    | `Should Be Equal`      | ${stdout}             | ${result.stdout}      |
-    | `File Should Be Empty` | ${result.stderr_path} |                       |
 
-    Notice that in ``stdout`` and ``stderr`` content possible trailing newline
-    is removed and ``\\r\\n`` converted to ``\\n`` automatically. If you
+    ```robotframework
+    ${result} =            Run Process         program
+    Should Be Equal        ${result.rc}          0    type=int
+    Should Match           ${result.stdout}      Some t?xt*
+    Should Be Empty        ${result.stderr}
+    ${stdout} =            Get File            ${result.stdout_path}
+    Should Be Equal        ${stdout}             ${result.stdout}
+    File Should Be Empty   ${result.stderr_path}
+    ```
+
+    Notice that in `stdout` and `stderr` content possible trailing newline
+    is removed and `\\r\\n` converted to `\\n` automatically. If you
     need to see the original process output, redirect it to a file using
-    `process configuration` and read it from there.
+    [process configuration] and read it from there.
     """
 
     def __init__(
@@ -165,7 +169,6 @@ class ProcessResult:
 
 
 class ProcessConfiguration:
-
     def __init__(
         self,
         cwd=None,
@@ -324,17 +327,20 @@ env:     {env}"""
 
 # Dummy argument converter for providing type documentation to Popen.
 def _popen_documentation(value):
-    """[https://docs.python.org/library/subprocess.html#popen-objects|subprocess.Popen] object.
+    """[subprocess.Popen](https://docs.python.org/library/subprocess.html#popen-objects) object.
 
-    Returned by `Start Process`. Can be used as a ``handle`` with keywords
-    like `Wait For Process` when working with multiple concurrent processes.
-    Attributes like ``pid`` and ``stdin`` can also be accessed directly.
+    Returned by [Start Process]. Can be used as a `handle` with keywords
+    like [Wait For Process] when working with multiple concurrent processes.
+    Attributes like `pid` and `stdin` can also be accessed directly.
 
     Examples:
-    | ${process} = | `Start Process` | ${command} |
-    | `Log` | PID: ${process.pid} |
-    | # Oher keywords |
-    | ${result} = | `Terminate Process` | ${process} |
+
+    ```robotframework
+    ${process} =    Start Process    ${command}
+    Log             PID: ${process.pid}
+    # Other keywords
+    ${result} =     Terminate Process    ${process}
+    ```
     """
     return value
 
@@ -352,83 +358,87 @@ class Process:
     The library has following main usages:
 
     - Running processes in system and waiting for their completion using
-      the `Run Process` keyword.
-    - Starting processes on background using the `Start Process` keyword.
-    - Waiting started process to complete using `Wait For Process` or
-      stopping them with `Terminate Process` or `Terminate All Processes`.
+      the [Run Process] keyword.
+    - Starting processes on background using the [Start Process] keyword.
+    - Waiting started process to complete using [Wait For Process] or
+      stopping them with [Terminate Process] or [Terminate All Processes].
 
-    This library provides various benefits over using ``Run`` and other similar
+    This library provides various benefits over using `Run` and other similar
     keywords in the
-    [http://robotframework.org/robotframework/latest/libraries/OperatingSystem.html|
-    OperatingSystem] library:
+    [OperatingSystem](http://robotframework.org/robotframework/latest/libraries/OperatingSystem.html)
+    library:
 
-    - Better `process configuration`.
-    - Convenient `result object` with all result information (rc, stdout, stderr).
+    - Better [process configuration].
+    - Convenient [result object] with all result information (rc, stdout, stderr).
     - Support for background processes, process termination, sending signals
       and so on.
 
     This library utilizes Python's
-    [http://docs.python.org/library/subprocess.html|subprocess]
+    [subprocess](http://docs.python.org/library/subprocess.html)
     module and its
-    [http://docs.python.org/library/subprocess.html#popen-constructor|Popen]
+    [Popen](http://docs.python.org/library/subprocess.html#popen-constructor)
     class.
 
-    == Table of contents ==
+    ## Table of contents
 
     %TOC%
 
-    = Specifying command and arguments =
+    # Specifying command and arguments
 
-    Both `Run Process` and `Start Process` accept the command to execute and
+    Both [Run Process] and [Start Process] accept the command to execute and
     all arguments passed to the command as separate arguments. This makes usage
     convenient and also allows these keywords to automatically escape possible
     spaces and other special characters in commands and arguments. Notice that
     if a command accepts options that themselves accept values, these options
     and their values must be given as separate arguments.
 
-    When `running processes in shell`, it is also possible to give the whole
+    When [running processes in shell], it is also possible to give the whole
     command to execute as a single string. The command can then contain
     multiple commands to be run together. When using this approach, the caller
     is responsible on escaping.
 
     Examples:
-    | `Run Process` | ${tools}${/}prog.py | argument | second arg with spaces |
-    | `Run Process` | java | -jar | ${jars}${/}example.jar | --option | value |
-    | `Run Process` | prog.py "one arg" && tool.sh | shell=yes | cwd=${tools} |
+
+    ```robotframework
+    Run Process    ${tools}${/}prog.py    argument    second arg with spaces
+    Run Process    java    -jar    ${jars}${/}example.jar    --option    value
+    Run Process    prog.py "one arg" && tool.sh    shell=yes    cwd=${tools}
+    ```
 
     Possible non-string arguments are converted to strings automatically.
 
-    = Process configuration =
+    # Process configuration
 
-    `Run Process` and `Start Process` keywords can be configured using
+    [Run Process] and [Start Process] keywords can be configured using
     optional configuration arguments. These arguments must be given
     after other arguments passed to these keywords and must use the
-    ``name=value`` syntax. Available configuration arguments are
+    `name=value` syntax. Available configuration arguments are
     listed below and discussed further in the subsequent sections.
 
-    |  = Name =   |                  = Explanation =                      |
-    | shell       | Specify whether to run the command in a shell or not. |
-    | cwd         | Specify the working directory.                        |
-    | env         | Specify environment variables given to the process.   |
-    | **env_extra | Override named environment variables using ``env:<name>=<value>`` syntax. |
-    | stdout      | Path to a file where to write standard output.        |
-    | stderr      | Path to a file where to write standard error.         |
-    | stdin       | Configure process standard input. New in RF 4.1.2.    |
-    | output_encoding | Encoding to use when reading command outputs.     |
-    | alias       | A custom name given to the process.                   |
+    | Name | Explanation |
+    |------|-------------|
+    | shell | Specify whether to run the command in a shell or not. |
+    | cwd | Specify the working directory. |
+    | env | Specify environment variables given to the process. |
+    | **env_extra | Override named environment variables using `env:<name>=<value>` syntax. |
+    | stdout | Path to a file where to write standard output. |
+    | stderr | Path to a file where to write standard error. |
+    | stdin | Configure process standard input. New in RF 4.1.2. |
+    | output_encoding | Encoding to use when reading command outputs. |
+    | alias | A custom name given to the process. |
 
-    Note that possible equal signs in other arguments passed to `Run Process`
-    and `Start Process` must be escaped with a backslash like ``name\\=value``.
-    See `Run Process` for an example.
+    Note that possible equal signs in other arguments passed to [Run Process]
+    and [Start Process] must be escaped with a backslash like `name\\=value`.
+    See [Run Process] for an example.
 
-    == Running processes in shell ==
+    ## Running processes in shell
 
-    The ``shell`` argument specifies whether to run the process in a shell or
+    The `shell` argument specifies whether to run the process in a shell or
     not. By default, shell is not used, which means that shell specific commands,
-    like ``copy`` and ``dir`` on Windows, are not available. You can, however,
+    like `copy` and `dir` on Windows, are not available. You can, however,
     run shell scripts and batch files without using a shell.
 
-    Giving the ``shell`` argument any non-false value, such as ``shell=True``,
+    Giving the `shell` argument any non-false value, such as `shell=True`,
     changes the program to be executed in a shell. It allows using the shell
     capabilities, but can also make the process invocation operating system
     dependent. Having a shell between the actually started process and this
@@ -437,39 +447,45 @@ class Process:
     to use the shell only when absolutely necessary.
 
     When using a shell it is possible to give the whole command to execute
-    as a single string. See `Specifying command and arguments` section for
+    as a single string. See [Specifying command and arguments] section for
     examples and more details in general.
 
-    == Current working directory ==
+    ## Current working directory
 
     By default, the child process will be executed in the same directory
     as the parent process, the process running Robot Framework, is executed. This
-    can be changed by giving an alternative location using the ``cwd`` argument.
+    can be changed by giving an alternative location using the `cwd` argument.
     Forward slashes in the given path are automatically converted to
     backslashes on Windows.
 
-    `Standard output and error streams`, when redirected to files,
+    [Standard output and error streams], when redirected to files,
     are also relative to the current working directory possibly set using
-    the ``cwd`` argument.
+    the `cwd` argument.
 
     Example:
-    | `Run Process` | prog.exe | cwd=${ROOT}/directory | stdout=stdout.txt |
 
-    == Environment variables ==
+    ```robotframework
+    Run Process    prog.exe    cwd=${ROOT}/directory    stdout=stdout.txt
+    ```
+
+    ## Environment variables
 
     The child process will get a copy of the parent process's environment
-    variables by default. The ``env`` argument can be used to give the
+    variables by default. The `env` argument can be used to give the
     child a custom environment as a Python dictionary. If there is a need
     to specify only certain environment variable, it is possible to use the
-    ``env:<name>=<value>`` format to set or override only that named variables.
+    `env:<name>=<value>` format to set or override only that named variables.
     It is also possible to use these two approaches together.
 
     Examples:
-    | `Run Process` | program | env=${environ} |
-    | `Run Process` | program | env:http_proxy=10.144.1.10:8080 | env:PATH=%{PATH}${:}${PROGDIR} |
-    | `Run Process` | program | env=${environ} | env:EXTRA=value |
 
-    == Standard output and error streams ==
+    ```robotframework
+    Run Process    program    env=${environ}
+    Run Process    program    env:http_proxy=10.144.1.10:8080    env:PATH=%{PATH}${:}${PROGDIR}
+    Run Process    program    env=${environ}    env:EXTRA=value
+    ```
+
+    ## Standard output and error streams
 
     By default, processes are run so that their standard output and standard
     error streams are kept in the memory. This typically works fine, but there
@@ -477,155 +493,174 @@ class Process:
     Robot Framework 7.3 the limit was smaller than nowadays and reaching it
     caused a deadlock.
 
-    To avoid the above-mentioned problems, it is possible to use ``stdout``
-    and ``stderr`` arguments to specify files on the file system where to
+    To avoid the above-mentioned problems, it is possible to use `stdout`
+    and `stderr` arguments to specify files on the file system where to
     redirect the output. This can also be useful if other processes or
     other keywords need to read or manipulate the output somehow.
 
-    Given ``stdout`` and ``stderr`` paths are relative to the `current working
-    directory`. Forward slashes in the given paths are automatically converted
+    Given `stdout` and `stderr` paths are relative to the [current working
+    directory]. Forward slashes in the given paths are automatically converted
     to backslashes on Windows.
 
     Regardless are outputs redirected to files or not, they are accessible
-    through the `result object` returned when the process ends. Commands are
-    expected to write outputs using the console encoding, but `output encoding`
-    can be configured using the ``output_encoding`` argument if needed.
+    through the [result object] returned when the process ends. Commands are
+    expected to write outputs using the console encoding, but [output encoding]
+    can be configured using the `output_encoding` argument if needed.
 
     As a special feature, it is possible to redirect the standard error to
-    the standard output by using ``stderr=STDOUT``.
+    the standard output by using `stderr=STDOUT`.
 
     If you are not interested in output at all, you can explicitly ignore it by
-    using a special value ``DEVNULL`` both with ``stdout`` and ``stderr``. For
-    example, ``stdout=DEVNULL`` is the same as redirecting output on console
-    with ``> /dev/null`` on UNIX-like operating systems or ``> NUL`` on Windows.
+    using a special value `DEVNULL` both with `stdout` and `stderr`. For
+    example, `stdout=DEVNULL` is the same as redirecting output on console
+    with `> /dev/null` on UNIX-like operating systems or `> NUL` on Windows.
     This way even a huge amount of output cannot cause problems, but naturally
     the output is not available after execution either.
 
     Examples:
-    | ${result} = | `Run Process` | program | stdout=${TEMPDIR}/stdout.txt | stderr=${TEMPDIR}/stderr.txt |
-    | `Log Many`  | stdout: ${result.stdout} | stderr: ${result.stderr} |
-    | ${result} = | `Run Process` | program | stderr=STDOUT |
-    | `Log`       | all output: ${result.stdout} |
-    | ${result} = | `Run Process` | program | stdout=DEVNULL | stderr=DEVNULL |
+
+    ```robotframework
+    ${result} =    Run Process    program    stdout=${TEMPDIR}/stdout.txt    stderr=${TEMPDIR}/stderr.txt
+    Log Many       stdout: ${result.stdout}    stderr: ${result.stderr}
+    ${result} =    Run Process    program    stderr=STDOUT
+    Log            all output: ${result.stdout}
+    ${result} =    Run Process    program    stdout=DEVNULL    stderr=DEVNULL
+    ```
 
     Note that the created output files are not automatically removed after
     execution. The user is responsible to remove them if needed.
 
-    == Standard input stream ==
+    ## Standard input stream
 
-    The ``stdin`` argument makes it possible to pass information to the standard
+    The `stdin` argument makes it possible to pass information to the standard
     input stream of the started process. How its value is interpreted is
     explained in the table below.
 
-    | = Value =        | = Explanation = |
-    | String ``NONE``  | Inherit stdin from the parent process. This is the default. |
-    | String ``PIPE``  | Make stdin a pipe that can be written to. |
-    | Path to a file   | Open the specified file and use it as the stdin. |
+    | Value | Explanation |
+    |-------|-------------|
+    | String `NONE` | Inherit stdin from the parent process. This is the default. |
+    | String `PIPE` | Make stdin a pipe that can be written to. |
+    | Path to a file | Open the specified file and use it as the stdin. |
     | Any other string | Create a temporary file with the text as its content and use it as the stdin. |
     | Any non-string value | Used as-is. Could be a file descriptor, stdout of another process, etc. |
 
-    Values ``PIPE`` and ``NONE`` are case-insensitive and internally mapped to
-    ``subprocess.PIPE`` and ``None``, respectively, when calling
-    [https://docs.python.org/3/library/subprocess.html#subprocess.Popen|subprocess.Popen].
+    Values `PIPE` and `NONE` are case-insensitive and internally mapped to
+    `subprocess.PIPE` and `None`, respectively, when calling
+    [subprocess.Popen](https://docs.python.org/3/library/subprocess.html#subprocess.Popen).
 
     Examples:
-    | `Run Process` | command | stdin=PIPE |
-    | `Run Process` | command | stdin=${CURDIR}/stdin.txt |
-    | `Run Process` | command | stdin=Stdin as text. |
 
-    The support to configure ``stdin`` is new in Robot Framework 4.1.2. Its default
-    value used to be ``PIPE`` until Robot Framework 7.0.
+    ```robotframework
+    Run Process    command    stdin=PIPE
+    Run Process    command    stdin=${CURDIR}/stdin.txt
+    Run Process    command    stdin=Stdin as text.
+    ```
 
-    == Output encoding ==
+    The support to configure `stdin` is new in Robot Framework 4.1.2. Its default
+    value used to be `PIPE` until Robot Framework 7.0.
+
+    ## Output encoding
 
     Executed commands are, by default, expected to write outputs to the
-    `standard output and error streams` using the encoding used by the
+    [standard output and error streams] using the encoding used by the
     system console. If the command uses some other encoding, that can be
-    configured using the ``output_encoding`` argument. This is especially
+    configured using the `output_encoding` argument. This is especially
     useful on Windows where the console uses a different encoding than rest
     of the system, and many commands use the general system encoding instead
     of the console encoding.
 
-    The value used with the ``output_encoding`` argument must be a valid
+    The value used with the `output_encoding` argument must be a valid
     encoding and must match the encoding actually used by the command. As a
-    convenience, it is possible to use strings ``CONSOLE`` and ``SYSTEM``
+    convenience, it is possible to use strings `CONSOLE` and `SYSTEM`
     to specify that the console or system encoding is used, respectively.
     If produced outputs use different encoding then configured, values got
-    through the `result object` will be invalid.
+    through the [result object] will be invalid.
 
     Examples:
-    | `Start Process` | program | output_encoding=UTF-8 |
-    | `Run Process`   | program | stdout=${path} | output_encoding=SYSTEM |
 
-    == Alias ==
+    ```robotframework
+    Start Process    program    output_encoding=UTF-8
+    Run Process      program    stdout=${path}    output_encoding=SYSTEM
+    ```
+
+    ## Alias
 
     A custom name given to the process that can be used when selecting the
-    `active process`.
+    [active process].
 
     Examples:
-    | `Start Process` | program | alias=example |
-    | `Run Process`   | python  | -c | print('hello') | alias=hello |
 
-    = Active process =
+    ```robotframework
+    Start Process    program    alias=example
+    Run Process      python     -c    print('hello')    alias=hello
+    ```
+
+    # Active process
 
     The library keeps record which of the started processes is currently active.
-    By default, it is the latest process started with `Start Process`,
-    but `Switch Process` can be used to activate a different process. Using
-    `Run Process` does not affect the active process.
+    By default, it is the latest process started with [Start Process],
+    but [Switch Process] can be used to activate a different process. Using
+    [Run Process] does not affect the active process.
 
     The keywords that operate on started processes will use the active process
     by default, but it is possible to explicitly select a different process
-    using the ``handle`` argument. The handle can be an ``alias`` explicitly
-    given to `Start Process` or the process object returned by it.
+    using the `handle` argument. The handle can be an `alias` explicitly
+    given to [Start Process] or the process object returned by it.
 
-    = Result object =
+    # Result object
 
-    `Run Process`, `Wait For Process` and `Terminate Process` keywords return a
+    [Run Process], [Wait For Process] and [Terminate Process] keywords return a
     result object that contains information about the process execution as its
     attributes. The same result object, or some of its attributes, can also
-    be get using `Get Process Result` keyword. Attributes available in the
+    be get using [Get Process Result] keyword. Attributes available in the
     object are documented in the table below.
 
-    | = Attribute = |             = Explanation =               |
-    | rc            | Return code of the process as an integer. |
-    | stdout        | Contents of the standard output stream.   |
-    | stderr        | Contents of the standard error stream.    |
-    | stdout_path   | Path where stdout was redirected or ``None`` if not redirected. |
-    | stderr_path   | Path where stderr was redirected or ``None`` if not redirected. |
+    | Attribute | Explanation |
+    |-----------|-------------|
+    | rc | Return code of the process as an integer. |
+    | stdout | Contents of the standard output stream. |
+    | stderr | Contents of the standard error stream. |
+    | stdout_path | Path where stdout was redirected or `None` if not redirected. |
+    | stderr_path | Path where stderr was redirected or `None` if not redirected. |
 
     Example:
-    | ${result} =            | `Run Process`         | program               |
-    | `Should Be Equal     ` | ${result.rc}          | 0 | type=int          |
-    | `Should Match`         | ${result.stdout}      | Some t?xt*            |
-    | `Should Be Empty`      | ${result.stderr}      |                       |
-    | ${stdout} =            | `Get File`            | ${result.stdout_path} |
-    | `Should Be Equal`      | ${stdout}             | ${result.stdout}      |
-    | `File Should Be Empty` | ${result.stderr_path} |                       |
 
-    Notice that in ``stdout`` and ``stderr`` content possible trailing newline
-    is removed and ``\\r\\n`` converted to ``\\n`` automatically. If you
+    ```robotframework
+    ${result} =            Run Process         program
+    Should Be Equal        ${result.rc}          0    type=int
+    Should Match           ${result.stdout}      Some t?xt*
+    Should Be Empty        ${result.stderr}
+    ${stdout} =            Get File            ${result.stdout_path}
+    Should Be Equal        ${stdout}             ${result.stdout}
+    File Should Be Empty   ${result.stderr_path}
+    ```
+
+    Notice that in `stdout` and `stderr` content possible trailing newline
+    is removed and `\\r\\n` converted to `\\n` automatically. If you
     need to see the original process output, redirect it to a file using
-    `process configuration` and read it from there.
+    [process configuration] and read it from there.
 
-    = Example =
+    # Example
 
-    | ***** Settings *****
-    | Library           Process
-    | Suite Teardown    `Terminate All Processes`    kill=True
-    |
-    | ***** Test Cases *****
-    | Example
-    |     `Start Process`    program    arg1    arg2    alias=First
-    |     ${handle} =    `Start Process`    command.sh arg | command2.sh    shell=True    cwd=/path
-    |     ${result} =    `Run Process`    ${CURDIR}/script.py
-    |     `Should Not Contain`    ${result.stdout}    FAIL
-    |     `Terminate Process`    ${handle}
-    |     ${result} =    `Wait For Process`    First
-    |     `Should Be Equal As Integers`    ${result.rc}    0
+    ```robotframework
+    *** Settings ***
+    Library           Process
+    Suite Teardown    Terminate All Processes    kill=True
+
+    *** Test Cases ***
+    Example
+        Start Process    program    arg1    arg2    alias=First
+        ${handle} =    Start Process    command.sh arg | command2.sh    shell=True    cwd=/path
+        ${result} =    Run Process    ${CURDIR}/script.py
+        Should Not Contain    ${result.stdout}    FAIL
+        Terminate Process    ${handle}
+        ${result} =    Wait For Process    First
+        Should Be Equal As Integers    ${result.rc}    0
     """
 
     ROBOT_LIBRARY_SCOPE = "GLOBAL"
     ROBOT_LIBRARY_VERSION = get_version()
+    ROBOT_LIBRARY_DOC_FORMAT = "Markdown"
     TERMINATE_TIMEOUT = 30
     KILL_TIMEOUT = 10
 
@@ -651,39 +686,61 @@ class Process:
     ) -> ProcessResult:
         """Runs a process and waits for it to complete.
 
-        ``command`` and ``arguments`` specify the command to execute and
-        arguments passed to it. See `Specifying command and arguments` for
+        `command` and `arguments` specify the command to execute and
+        arguments passed to it. See [Specifying command and arguments] for
         more details.
 
-        The started process can be configured using ``cwd``, ``shell``, ``stdout``,
-        ``stderr``, ``stdin``, ``output_encoding``, ``alias``, ``env`` and
-        ``env_extra`` parameters that are documented in the `Process configuration`
+        The started process can be configured using `cwd`, `shell`, `stdout`,
+        `stderr`, `stdin`, `output_encoding`, `alias`, `env` and
+        `env_extra` parameters that are documented in the [Process configuration]
         section.
 
-        Configuration related to waiting for processes consists of ``timeout``
-        and ``on_timeout`` parameters that have same semantics than with the
-        `Wait For Process` keyword.
+        Configuration related to waiting for processes consists of `timeout`
+        and `on_timeout` parameters that have same semantics than with the
+        [Wait For Process] keyword.
 
         Process outputs are, by default, written into in-memory buffers.
         This typically works fine, but there can be problems if the amount of
         output is large or unlimited. To avoid such problems, outputs can be
-        redirected to files using the ``stdout`` and ``stderr`` configuration
-        parameters. For more information see the `Standard output and error streams`
+        redirected to files using the `stdout` and `stderr` configuration
+        parameters. For more information see the [Standard output and error streams]
         section.
 
-        Returns a `result object` containing information about the execution.
+        Note that possible equal signs in `command` and `arguments` must
+        be escaped with a backslash (e.g. `name\\=value`).
 
-        Note that possible equal signs in ``command`` and ``arguments`` must
-        be escaped with a backslash (e.g. ``name\\=value``).
+        This keyword does not change the [active process].
+
+        Args:
+
+            command: Command to execute.
+            *arguments: Arguments passed to the command.
+            cwd: Working directory for the process.
+            shell: Whether to run the command in a shell.
+            stdout: Path to file for standard output.
+            stderr: Path to file for standard error.
+            stdin: Process standard input configuration.
+            output_encoding: Encoding for reading command outputs.
+            alias: Custom name for the process.
+            timeout: Maximum time to wait for the process.
+            on_timeout: Action when timeout occurs.
+            env: Environment variables as Python dictionary.
+            **env_extra: Override named environment variables using
+                `env:<name>=<value>` syntax.
+
+        Returns:
+
+            [result object] containing information about the execution.
 
         Examples:
-        | ${result} = | Run Process | python | -c | print('Hello, world!') |
-        | Should Be Equal | ${result.stdout} | Hello, world! |
-        | ${result} = | Run Process | ${command} | stdout=${CURDIR}/stdout.txt | stderr=STDOUT |
-        | ${result} = | Run Process | ${command} | timeout=1min | on_timeout=continue |
-        | ${result} = | Run Process | java -Dname\\=value Example | shell=True | cwd=${EXAMPLE} |
 
-        This keyword does not change the `active process`.
+        ```robotframework
+        ${result} =    Run Process    python    -c    print('Hello, world!')
+        Should Be Equal    ${result.stdout}    Hello, world!
+        ${result} =    Run Process    ${command}    stdout=${CURDIR}/stdout.txt    stderr=STDOUT
+        ${result} =    Run Process    ${command}    timeout=1min    on_timeout=continue
+        ${result} =    Run Process    java -Dname\\=value Example    shell=True    cwd=${EXAMPLE}
+        ```
         """
         current = self._processes.current
         try:
@@ -720,42 +777,69 @@ class Process:
     ) -> subprocess.Popen:
         """Starts a new process on background.
 
-        See `Specifying command and arguments` and `Process configuration` sections
-        for more information about the arguments, and `Run Process` keyword
+        See [Specifying command and arguments] and [Process configuration] sections
+        for more information about the arguments, and [Run Process] keyword
         for related examples. This includes information about redirecting
         process outputs to avoid process handing due to output buffers getting
         full.
 
-        Makes the started process new `active process`. Returns the created
-        [https://docs.python.org/3/library/subprocess.html#popen-objects |
-        subprocess.Popen] object which can be used later to activate this
-        process. ``Popen`` attributes like ``pid`` can also be accessed directly.
+        Makes the started process new [active process].
 
         Processes are started so that they create a new process group. This
         allows terminating and sending signals to possible child processes.
 
+        Returning a `subprocess.Popen` object is new in Robot Framework 5.0.
+        Earlier versions returned a generic handle and getting the process object
+        required using [Get Process Object] separately.
+
+        Args:
+
+            command: Command to execute.
+            *arguments: Arguments passed to the command.
+            cwd: Working directory for the process.
+            shell: Whether to run the command in a shell.
+            stdout: Path to file for standard output.
+            stderr: Path to file for standard error.
+            stdin: Process standard input configuration.
+            output_encoding: Encoding for reading command outputs.
+            alias: Custom name for the process.
+            env: Environment variables as Python dictionary.
+            **env_extra: Override named environment variables using
+                `env:<name>=<value>` syntax.
+
+        Returns:
+
+            Created [subprocess.Popen](https://docs.python.org/3/library/subprocess.html#popen-objects)
+            object which can be used later to activate this process. `Popen`
+            attributes like `pid` can also be accessed directly.
+
         Examples:
 
         Start process and wait for it to end later using an alias:
-        | `Start Process` | ${command} | alias=example |
-        | # Other keywords |
-        | ${result} = | `Wait For Process` | example |
 
-        Use returned ``Popen`` object:
-        | ${process} = | `Start Process` | ${command} |
-        | `Log` | PID: ${process.pid} |
-        | # Other keywords |
-        | ${result} = | `Terminate Process` | ${process} |
+        ```robotframework
+        Start Process    ${command}    alias=example
+        # Other keywords
+        ${result} =    Wait For Process    example
+        ```
+
+        Use returned `Popen` object:
+
+        ```robotframework
+        ${process} =    Start Process    ${command}
+        Log             PID: ${process.pid}
+        # Other keywords
+        ${result} =     Terminate Process    ${process}
+        ```
 
         Use started process in a pipeline with another process:
-        | ${process} = | `Start Process` | python | -c | print('Hello, world!') |
-        | ${result} = | `Run Process` | python | -c | import sys; print(sys.stdin.read().upper().strip()) | stdin=${process.stdout} |
-        | `Wait For Process` | ${process} |
-        | `Should Be Equal` | ${result.stdout} | HELLO, WORLD! |
 
-        Returning a ``subprocess.Popen`` object is new in Robot Framework 5.0.
-        Earlier versions returned a generic handle and getting the process object
-        required using `Get Process Object` separately.
+        ```robotframework
+        ${process} =    Start Process    python    -c    print('Hello, world!')
+        ${result} =     Run Process      python    -c    import sys; print(sys.stdin.read().upper().strip())    stdin=${process.stdout}
+        Wait For Process    ${process}
+        Should Be Equal     ${result.stdout}    HELLO, WORLD!
+        ```
         """
         config = ProcessConfiguration(
             cwd=cwd,
@@ -790,9 +874,14 @@ class Process:
     def is_process_running(self, handle: Handle = None) -> bool:
         """Checks is the process running or not.
 
-        If ``handle`` is not given, uses the current `active process`.
+        Args:
 
-        Returns ``True`` if the process is still running and ``False`` otherwise.
+            handle: Process handle or alias. Uses the current [active process]
+                if not given.
+
+        Returns:
+
+            `True` if the process is still running and `False` otherwise.
         """
         return self._processes[handle].poll() is None
 
@@ -803,9 +892,15 @@ class Process:
     ):
         """Verifies that the process is running.
 
-        If ``handle`` is not given, uses the current `active process`.
+        Args:
 
-        Fails if the process has stopped.
+            handle: Process handle or alias. Uses the current [active process]
+                if not given.
+            error_message: Message used if verification fails.
+
+        Raises:
+
+            AssertionError: If the process has stopped.
         """
         if not self.is_process_running(handle):
             raise AssertionError(error_message)
@@ -817,9 +912,15 @@ class Process:
     ):
         """Verifies that the process is not running.
 
-        If ``handle`` is not given, uses the current `active process`.
+        Args:
 
-        Fails if the process is still running.
+            handle: Process handle or alias. Uses the current [active process]
+                if not given.
+            error_message: Message used if verification fails.
+
+        Raises:
+
+            AssertionError: If the process is still running.
         """
         if self.is_process_running(handle):
             raise AssertionError(error_message)
@@ -833,51 +934,65 @@ class Process:
         """Waits for the process to complete or to reach the given timeout.
 
         The process to wait for must have been started earlier with
-        `Start Process`. If ``handle`` is not given, uses the current
-        `active process`.
+        [Start Process].
 
-        ``timeout`` defines the maximum time to wait for the process. It can be
+        `timeout` defines the maximum time to wait for the process. It can be
         given in
-        [http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#time-format|
-        various time formats] supported by Robot Framework, for example, ``42``,
-        ``42 s``, or ``1 minute 30 seconds``. The timeout is ignored if it is
-        ``None`` (default), zero or negative.
+        [various time formats](http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#time-format)
+        supported by Robot Framework, for example, `42`,
+        `42 s`, or `1 minute 30 seconds`. The timeout is ignored if it is
+        `None` (default), zero or negative.
 
-        ``on_timeout`` defines what to do if the timeout occurs. Possible values
+        `on_timeout` defines what to do if the timeout occurs. Possible values
         and corresponding actions are explained in the table below. Notice
         that reaching the timeout never fails the test.
 
-        | = Value = |               = Action =               |
-        | continue  | The process is left running (default). |
-        | terminate | The process is gracefully terminated.  |
-        | kill      | The process is forcefully stopped.     |
+        | Value | Action |
+        |-------|--------|
+        | continue | The process is left running (default). |
+        | terminate | The process is gracefully terminated. |
+        | kill | The process is forcefully stopped. |
 
-        See `Terminate Process` keyword for more details how processes are
+        See [Terminate Process] keyword for more details how processes are
         terminated and killed.
 
         If the process ends before the timeout, or it is terminated or killed,
-        this keyword returns a `result object` containing information about
-        the execution. If the process is left running, Python ``None`` is
+        this keyword returns a [result object] containing information about
+        the execution. If the process is left running, Python `None` is
         returned instead.
-
-        Examples:
-        | # Process ends cleanly      |                  |                  |
-        | ${result} =                 | Wait For Process | example          |
-        | Process Should Be Stopped   | example          |                  |
-        | Should Be Equal As Integers | ${result.rc}     | 0                |
-        | # Process does not end      |                  |                  |
-        | ${result} =                 | Wait For Process | timeout=42 secs  |
-        | Process Should Be Running   |                  |                  |
-        | Should Be Equal             | ${result}        | ${NONE}          |
-        | # Kill non-ending process   |                  |                  |
-        | ${result} =                 | Wait For Process | timeout=1min 30s | on_timeout=kill |
-        | Process Should Be Stopped   |                  |                  |
-        | Should Be Equal As Integers | ${result.rc}     | -9               |
 
         Note: If Robot Framework's test or keyword timeout is exceeded while
         this keyword is waiting for the process to end, the process is killed
         to avoid leaving it running on the background. This is new in Robot
         Framework 7.3.
+
+        Args:
+
+            handle: Process handle or alias. Uses the current [active process]
+                if not given.
+            timeout: Maximum time to wait for the process.
+            on_timeout: Action when timeout occurs.
+
+        Returns:
+
+            [result object] if the process ends, or `None` if it is left running.
+
+        Examples:
+
+        ```robotframework
+        # Process ends cleanly
+        ${result} =                 Wait For Process    example
+        Process Should Be Stopped   example
+        Should Be Equal As Integers    ${result.rc}     0
+        # Process does not end
+        ${result} =                 Wait For Process    timeout=42 secs
+        Process Should Be Running
+        Should Be Equal             ${result}        ${NONE}
+        # Kill non-ending process
+        ${result} =                 Wait For Process    timeout=1min 30s    on_timeout=kill
+        Process Should Be Stopped
+        Should Be Equal As Integers    ${result.rc}     -9
+        ```
         """
         process = self._processes[handle]
         logger.info("Waiting for process to complete.")
@@ -930,31 +1045,47 @@ class Process:
     ) -> ProcessResult:
         """Stops the process gracefully or forcefully.
 
-        If ``handle`` is not given, uses the current `active process`.
-
         By default, first tries to stop the process gracefully. If the process
-        does not stop in 30 seconds, or the ``kill`` argument is given a true
+        does not stop in 30 seconds, or the `kill` argument is given a true
         value, kills the process forcefully. Stops also all the child processes
         of the originally started process.
 
-        Waits for the process to stop after terminating it. Returns a `result
-        object` containing information about the execution similarly as `Wait
-        For Process`.
+        Waits for the process to stop after terminating it. Returns a [result
+        object] containing information about the execution similarly as [Wait
+        For Process].
 
-        On Unix-like machines graceful termination is done using ``TERM (15)``
-        signal and forceful kill using ``KILL (9)``. Use `Send Signal To Process`
+        On Unix-like machines graceful termination is done using `TERM (15)`
+        signal and forceful kill using `KILL (9)`. Use [Send Signal To Process]
         instead if you just want to send either of these signals without
         waiting for the process to stop.
 
-        On Windows graceful termination is done using ``CTRL_BREAK_EVENT``
-        event and forceful kill using Win32 API function ``TerminateProcess()``.
+        On Windows graceful termination is done using `CTRL_BREAK_EVENT`
+        event and forceful kill using Win32 API function `TerminateProcess()`.
         In this case forceful kill only stops the main process, not possible
         child processes.
 
+        Args:
+
+            handle: Process handle or alias. Uses the current [active process]
+                if not given.
+            kill: Whether to forcefully kill the process.
+
+        Returns:
+
+            [result object] containing information about the execution.
+
+        Raises:
+
+            RuntimeError: If terminating processes is not supported by this
+                Python version, or if forceful kill fails.
+
         Examples:
-        | ${result} =                 | Terminate Process |     |
-        | Should Be Equal As Integers | ${result.rc}      | -15 | # On Unixes |
-        | Terminate Process           | myproc            | kill=true |
+
+        ```robotframework
+        ${result} =                 Terminate Process
+        Should Be Equal As Integers    ${result.rc}      -15    # On Unixes
+        Terminate Process           myproc            kill=true
+        ```
         """
         process = self._processes[handle]
         if not hasattr(process, "terminate"):
@@ -997,11 +1128,15 @@ class Process:
         """Terminates all still running processes started by this library.
 
         This keyword can be used in suite teardown or elsewhere to make
-        sure that all processes are stopped,
+        sure that all processes are stopped.
 
         Tries to terminate processes gracefully by default, but can be
-        configured to forcefully kill them immediately. See `Terminate Process`
+        configured to forcefully kill them immediately. See [Terminate Process]
         that this keyword uses internally for more details.
+
+        Args:
+
+            kill: Whether to forcefully kill processes.
         """
         for process in self._processes:
             if self.is_process_running(process):
@@ -1014,31 +1149,41 @@ class Process:
         handle: Handle = None,
         group: bool = False,
     ):
-        """Sends the given ``signal`` to the specified process.
-
-        If ``handle`` is not given, uses the current `active process`.
+        """Sends the given `signal` to the specified process.
 
         Signal can be specified either as an integer as a signal name. In the
-        latter case it is possible to give the name both with or without ``SIG``
+        latter case it is possible to give the name both with or without `SIG`
         prefix, but names are case-sensitive. For example, all the examples
-        below send signal ``INT (2)``:
+        below send signal `INT (2)`:
 
-        | Send Signal To Process | 2      |        | # Send to active process |
-        | Send Signal To Process | INT    |        |                          |
-        | Send Signal To Process | SIGINT | myproc | # Send to named process  |
+        ```robotframework
+        Send Signal To Process    2
+        Send Signal To Process    INT
+        Send Signal To Process    SIGINT    myproc
+        ```
 
         This keyword is only supported on Unix-like machines, not on Windows.
         What signals are supported depends on the system. For a list of
         existing signals on your system, see the Unix man pages related to
-        signal handling (typically ``man signal`` or ``man 7 signal``).
+        signal handling (typically `man signal` or `man 7 signal`).
 
         By default, sends the signal only to the parent process, not to possible
-        child processes started by it. Notice that when `running processes in
-        shell`, the shell is the parent process, and it depends on the system
+        child processes started by it. Notice that when [running processes in
+        shell], the shell is the parent process, and it depends on the system
         does the shell propagate the signal to the actual started process.
 
-        To send the signal to the whole process group, give the ``group``
-        argument a true value.
+        Args:
+
+            signal: Signal to send, either as an integer or signal name.
+            handle: Process handle or alias. Uses the current [active process]
+                if not given.
+            group: Whether to send the signal to the whole process group.
+
+        Raises:
+
+            RuntimeError: If used on Windows, if sending signals is not
+                supported by this Python version, or if the signal name is
+                unsupported.
         """
         if os.sep == "\\":
             raise RuntimeError("This keyword does not work on Windows.")
@@ -1071,22 +1216,36 @@ class Process:
     def get_process_id(self, handle: Handle = None) -> int:
         """Returns the process ID (pid) of the process as an integer.
 
-        If ``handle`` is not given, uses the current `active process`.
-
         Starting from Robot Framework 5.0, it is also possible to directly access
-        the ``pid`` attribute of the ``subprocess.Popen`` object returned by
-        `Start Process` like ``${process.pid}``.
+        the `pid` attribute of the `subprocess.Popen` object returned by
+        [Start Process] like `${process.pid}`.
+
+        Args:
+
+            handle: Process handle or alias. Uses the current [active process]
+                if not given.
+
+        Returns:
+
+            Process ID as an integer.
         """
         return self._processes[handle].pid
 
     def get_process_object(self, handle: Handle = None) -> subprocess.Popen:
-        """Return the underlying ``subprocess.Popen`` object.
+        """Return the underlying `subprocess.Popen` object.
 
-        If ``handle`` is not given, uses the current `active process`.
-
-        Starting from Robot Framework 5.0, `Start Process` returns the created
-        ``subprocess.Popen`` object, not a generic handle, making this keyword
+        Starting from Robot Framework 5.0, [Start Process] returns the created
+        `subprocess.Popen` object, not a generic handle, making this keyword
         mostly redundant.
+
+        Args:
+
+            handle: Process handle or alias. Uses the current [active process]
+                if not given.
+
+        Returns:
+
+            The underlying `subprocess.Popen` object.
         """
         return self._processes[handle]
 
@@ -1099,42 +1258,64 @@ class Process:
         stdout_path: bool = False,
         stderr_path: bool = False,
     ) -> "ProcessResult | int | str | tuple[int | str, ...]":
-        """Returns the specified `result object` or some of its attributes.
+        """Returns the specified [result object] or some of its attributes.
 
-        The given ``handle`` specifies the process whose results should be
-        returned. If no ``handle`` is given, results of the current `active
-        process` are returned. In either case, the process must have been
+        The given `handle` specifies the process whose results should be
+        returned. If no `handle` is given, results of the current [active
+        process] are returned. In either case, the process must have been
         finishes before this keyword can be used. In practice this means
-        that processes started with `Start Process` must be finished either
-        with `Wait For Process` or `Terminate Process` before using this
+        that processes started with [Start Process] must be finished either
+        with [Wait For Process] or [Terminate Process] before using this
         keyword.
 
-        If no other arguments than the optional ``handle`` are given, a whole
-        `result object` is returned. If one or more of the other arguments
+        If no other arguments than the optional `handle` are given, a whole
+        [result object] is returned. If one or more of the other arguments
         are given any true value, only the specified attributes of the
-        `result object` are returned. These attributes are always returned
+        [result object] are returned. These attributes are always returned
         in the same order as arguments are specified in the keyword signature.
-
-        Examples:
-        | Run Process           | python             | -c            | print('Hello, world!') | alias=myproc |
-        | # Get result object   |                    |               |
-        | ${result} =           | Get Process Result | myproc        |
-        | Should Be Equal       | ${result.rc}       | ${0}          |
-        | Should Be Equal       | ${result.stdout}   | Hello, world! |
-        | Should Be Empty       | ${result.stderr}   |               |
-        | # Get one attribute   |                    |               |
-        | ${stdout} =           | Get Process Result | myproc        | stdout=true |
-        | Should Be Equal       | ${stdout}          | Hello, world! |
-        | # Multiple attributes |                    |               |
-        | ${stdout}             | ${stderr} =        | Get Process Result |  myproc | stdout=yes | stderr=yes |
-        | Should Be Equal       | ${stdout}          | Hello, world! |
-        | Should Be Empty       | ${stderr}          |               |
 
         Although getting results of a previously executed process can be handy
         in general, the main use case for this keyword is returning results
         over the remote library interface. The remote interface does not
         support returning the whole result object, but individual attributes
         can be returned without problems.
+
+        Args:
+
+            handle: Process handle or alias. Uses the current [active process]
+                if not given.
+            rc: If true, return return code.
+            stdout: If true, return standard output.
+            stderr: If true, return standard error.
+            stdout_path: If true, return stdout path.
+            stderr_path: If true, return stderr path.
+
+        Returns:
+
+            Whole [result object], a single attribute, or a tuple of attributes
+            depending on which arguments are given.
+
+        Raises:
+
+            RuntimeError: If results of an unfinished process are requested.
+
+        Examples:
+
+        ```robotframework
+        Run Process           python             -c            print('Hello, world!')    alias=myproc
+        # Get result object
+        ${result} =           Get Process Result    myproc
+        Should Be Equal       ${result.rc}       ${0}
+        Should Be Equal       ${result.stdout}   Hello, world!
+        Should Be Empty       ${result.stderr}
+        # Get one attribute
+        ${stdout} =           Get Process Result    myproc        stdout=true
+        Should Be Equal       ${stdout}          Hello, world!
+        # Multiple attributes
+        ${stdout}             ${stderr} =        Get Process Result    myproc    stdout=yes    stderr=yes
+        Should Be Equal       ${stdout}          Hello, world!
+        Should Be Empty       ${stderr}
+        ```
         """
         result = self._results[self._processes[handle]]
         if result.rc is None:
@@ -1161,17 +1342,24 @@ class Process:
         return tuple(attr for attr, incl in zip(attributes, includes) if incl)
 
     def switch_process(self, handle: Handle):
-        """Makes the specified process the current `active process`.
+        """Makes the specified process the current [active process].
 
-        The handle can be an identifier returned by `Start Process` or
-        the ``alias`` given to it explicitly.
+        The handle can be an identifier returned by [Start Process] or
+        the `alias` given to it explicitly.
+
+        Args:
+
+            handle: Process handle or alias to activate.
 
         Example:
-        | Start Process  | prog1    | alias=process1 |
-        | Start Process  | prog2    | alias=process2 |
-        | # currently active process is process2 |
-        | Switch Process | process1 |
-        | # now active process is process1 |
+
+        ```robotframework
+        Start Process    prog1    alias=process1
+        Start Process    prog2    alias=process2
+        # currently active process is process2
+        Switch Process    process1
+        # now active process is process1
+        ```
         """
         self._processes.switch(handle)
 
@@ -1188,14 +1376,26 @@ class Process:
         String is split from spaces, but argument surrounded in quotes may
         contain spaces in them.
 
-        If ``escaping`` is given a true value, then backslash is treated as
+        If `escaping` is given a true value, then backslash is treated as
         an escape character. It can escape unquoted spaces, quotes inside
         quotes, and so on, but it also requires doubling backslashes
         in Windows paths and elsewhere.
 
+        Args:
+
+            command: Command line string to split.
+            escaping: Whether to treat backslash as an escape character.
+
+        Returns:
+
+            List of command line arguments.
+
         Examples:
-        | @{cmd} = | Split Command Line | --option "value with spaces" |
-        | Should Be True | $cmd == ['--option', 'value with spaces'] |
+
+        ```robotframework
+        @{cmd} =    Split Command Line    --option "value with spaces"
+        Should Be True    $cmd == ['--option', 'value with spaces']
+        ```
         """
         return cmdline2list(command, escaping=escaping)
 
@@ -1208,14 +1408,31 @@ class Process:
 
         Command to join can be given as individual arguments or as a list.
 
+        Args:
+
+            *command: Arguments to join, either as individual strings or as
+                a list.
+
+        Returns:
+
+            Joined command line string.
+
+        Examples:
+
         Giving command as individual arguments:
-        | ${cmd} =        | Join Command Line | --option | value with spaces |
-        | Should Be Equal | ${cmd}            | --option "value with spaces" |
+
+        ```robotframework
+        ${cmd} =        Join Command Line    --option    value with spaces
+        Should Be Equal    ${cmd}            --option "value with spaces"
+        ```
 
         Giving command as a list:
-        | VAR             | @{arguments}      | --option | value with spaces |
-        | ${cmd} =        | Join Command Line | ${arguments}                 |
-        | Should Be Equal | ${cmd}            | --option "value with spaces" |
+
+        ```robotframework
+        VAR             @{arguments}      --option    value with spaces
+        ${cmd} =        Join Command Line    ${arguments}
+        Should Be Equal    ${cmd}            --option "value with spaces"
+        ```
         """
         parts = []
         for part in command:

--- a/src/robot/libraries/Process.py
+++ b/src/robot/libraries/Process.py
@@ -515,8 +515,7 @@ class Process:
     redirect the output. This can also be useful if other processes or
     other keywords need to read or manipulate the output somehow.
 
-    Given `stdout` and `stderr` paths are relative to the [current working
-    directory]. Forward slashes in the given paths are automatically converted
+    Given `stdout` and `stderr` paths are relative to the [current working directory]. Forward slashes in the given paths are automatically converted
     to backslashes on Windows.
 
     Regardless are outputs redirected to files or not, they are accessible
@@ -680,7 +679,6 @@ class Process:
     Suite Teardown    Terminate All Processes    kill=True
 
     *** Test Cases ***
-    Library
     Example
         Start Process    program    arg1    arg2    alias=First
         ${handle} =    Start Process    command.sh arg | command2.sh    shell=True    cwd=/path
@@ -689,6 +687,7 @@ class Process:
         Terminate Process    ${handle}
         ${result} =    Wait For Process    First
         Should Be Equal As Integers    ${result.rc}    0
+    ```
 
     [OperatingSystem]: http://robotframework.org/robotframework/latest/libraries/OperatingSystem.html "OperatingSystem"
 
@@ -771,13 +770,14 @@ class Process:
 
         Examples:
 
-
-    ```robotframework
-        ${result} =    Run Process    python    -c    print('Hello, world!')
-        Should Be Equal    ${result.stdout}    Hello, world!
-        ${result} =    Run Process    ${command}    stdout=${CURDIR}/stdout.txt    stderr=STDOUT
-        ${result} =    Run Process    ${command}    timeout=1min    on_timeout=continue
-        ${result} =    Run Process    java -Dname\\=value Example    shell=True    cwd=${EXAMPLE}
+        ```robotframework
+        *** Test Cases ***
+        Run process
+            ${result} =    Run Process    python    -c    print('Hello, world!')
+            Should Be Equal    ${result.stdout}    Hello, world!
+            ${result} =    Run Process    ${command}    stdout=${CURDIR}/stdout.txt    stderr=STDOUT
+            ${result} =    Run Process    ${command}    timeout=1min    on_timeout=continue
+            ${result} =    Run Process    java -Dname\\=value Example    shell=True    cwd=${EXAMPLE}
         ```
         """
         current = self._processes.current
@@ -1092,9 +1092,7 @@ class Process:
         value, kills the process forcefully. Stops also all the child processes
         of the originally started process.
 
-        Waits for the process to stop after terminating it. Returns a [result
-        object] containing information about the execution similarly as [Wait
-        For Process].
+        Waits for the process to stop after terminating it. Returns a [result object] containing information about the execution similarly as [Wait For Process].
 
         On Unix-like machines graceful termination is done using `TERM (15)`
         signal and forceful kill using `KILL (9)`. Use [Send Signal To Process]
@@ -1212,8 +1210,7 @@ class Process:
         signal handling (typically `man signal` or `man 7 signal`).
 
         By default, sends the signal only to the parent process, not to possible
-        child processes started by it. Notice that when [running processes in
-        shell], the shell is the parent process, and it depends on the system
+        child processes started by it. Notice that when [running processes in shell], the shell is the parent process, and it depends on the system
         does the shell propagate the signal to the actual started process.
 
         Args:
@@ -1299,8 +1296,7 @@ class Process:
         """Returns the specified [result object] or some of its attributes.
 
         The given `handle` specifies the process whose results should be
-        returned. If no `handle` is given, results of the current [active
-        process] are returned. In either case, the process must have been
+        returned. If no `handle` is given, results of the current [active process] are returned. In either case, the process must have been
         finishes before this keyword can be used. In practice this means
         that processes started with [Start Process] must be finished either
         with [Wait For Process] or [Terminate Process] before using this

--- a/src/robot/libraries/Process.py
+++ b/src/robot/libraries/Process.py
@@ -55,13 +55,16 @@ class ProcessResult:
     Example:
 
     ```robotframework
-    ${result} =            Run Process         program
-    Should Be Equal        ${result.rc}          0    type=int
-    Should Match           ${result.stdout}      Some t?xt*
-    Should Be Empty        ${result.stderr}
-    ${stdout} =            Get File            ${result.stdout_path}
-    Should Be Equal        ${stdout}             ${result.stdout}
-    File Should Be Empty   ${result.stderr_path}
+    *** Test Cases ***
+    Run process
+        ${result} =            Run Process         program
+        Should Be Equal        ${result.rc}          0    type=int
+        Should Match           ${result.stdout}      Some t?xt*
+        Should Be Empty        ${result.stderr}
+        ${stdout} =            Get File            ${result.stdout_path}
+        Should Be Equal        ${stdout}             ${result.stdout}
+        File Should Be Empty   ${result.stderr_path}
+
     ```
 
     Notice that in `stdout` and `stderr` content possible trailing newline
@@ -327,7 +330,7 @@ env:     {env}"""
 
 # Dummy argument converter for providing type documentation to Popen.
 def _popen_documentation(value):
-    """[subprocess.Popen](https://docs.python.org/library/subprocess.html#popen-objects) object.
+    """[subprocess.Popen] object.
 
     Returned by [Start Process]. Can be used as a `handle` with keywords
     like [Wait For Process] when working with multiple concurrent processes.
@@ -336,11 +339,16 @@ def _popen_documentation(value):
     Examples:
 
     ```robotframework
-    ${process} =    Start Process    ${command}
-    Log             PID: ${process.pid}
-    # Other keywords
-    ${result} =     Terminate Process    ${process}
+    *** Test Cases ***
+    Start process
+        ${process} =    Start Process    ${command}
+        Log             PID: ${process.pid}
+        # Other keywords
+        ${result} =     Terminate Process    ${process}
+
     ```
+
+    [subprocess.Popen]: https://docs.python.org/3/library/subprocess.html#popen-objects "subprocess.Popen"
     """
     return value
 
@@ -365,7 +373,7 @@ class Process:
 
     This library provides various benefits over using `Run` and other similar
     keywords in the
-    [OperatingSystem](http://robotframework.org/robotframework/latest/libraries/OperatingSystem.html)
+    [OperatingSystem]
     library:
 
     - Better [process configuration].
@@ -374,9 +382,9 @@ class Process:
       and so on.
 
     This library utilizes Python's
-    [subprocess](http://docs.python.org/library/subprocess.html)
+    [subprocess]
     module and its
-    [Popen](http://docs.python.org/library/subprocess.html#popen-constructor)
+    [Popen]
     class.
 
     ### Table of contents
@@ -400,9 +408,12 @@ class Process:
     Examples:
 
     ```robotframework
-    Run Process    ${tools}${/}prog.py    argument    second arg with spaces
-    Run Process    java    -jar    ${jars}${/}example.jar    --option    value
-    Run Process    prog.py "one arg" && tool.sh    shell=yes    cwd=${tools}
+    *** Test Cases ***
+    Specifying command and arguments
+        Run Process    ${tools}${/}prog.py    argument    second arg with spaces
+        Run Process    java    -jar    ${jars}${/}example.jar    --option    value
+        Run Process    prog.py "one arg" && tool.sh    shell=yes    cwd=${tools}
+
     ```
 
     Possible non-string arguments are converted to strings automatically.
@@ -465,7 +476,10 @@ class Process:
     Example:
 
     ```robotframework
-    Run Process    prog.exe    cwd=${ROOT}/directory    stdout=stdout.txt
+    *** Test Cases ***
+    Current working directory
+        Run Process    prog.exe    cwd=${ROOT}/directory    stdout=stdout.txt
+
     ```
 
     ## Environment variables
@@ -480,9 +494,12 @@ class Process:
     Examples:
 
     ```robotframework
-    Run Process    program    env=${environ}
-    Run Process    program    env:http_proxy=10.144.1.10:8080    env:PATH=%{PATH}${:}${PROGDIR}
-    Run Process    program    env=${environ}    env:EXTRA=value
+    *** Test Cases ***
+    Environment variables
+        Run Process    program    env=${environ}
+        Run Process    program    env:http_proxy=10.144.1.10:8080    env:PATH=%{PATH}${:}${PROGDIR}
+        Run Process    program    env=${environ}    env:EXTRA=value
+
     ```
 
     ## Standard output and error streams
@@ -520,11 +537,14 @@ class Process:
     Examples:
 
     ```robotframework
-    ${result} =    Run Process    program    stdout=${TEMPDIR}/stdout.txt    stderr=${TEMPDIR}/stderr.txt
-    Log Many       stdout: ${result.stdout}    stderr: ${result.stderr}
-    ${result} =    Run Process    program    stderr=STDOUT
-    Log            all output: ${result.stdout}
-    ${result} =    Run Process    program    stdout=DEVNULL    stderr=DEVNULL
+    *** Test Cases ***
+    Run process
+        ${result} =    Run Process    program    stdout=${TEMPDIR}/stdout.txt    stderr=${TEMPDIR}/stderr.txt
+        Log Many       stdout: ${result.stdout}    stderr: ${result.stderr}
+        ${result} =    Run Process    program    stderr=STDOUT
+        Log            all output: ${result.stdout}
+        ${result} =    Run Process    program    stdout=DEVNULL    stderr=DEVNULL
+
     ```
 
     Note that the created output files are not automatically removed after
@@ -546,14 +566,17 @@ class Process:
 
     Values `PIPE` and `NONE` are case-insensitive and internally mapped to
     `subprocess.PIPE` and `None`, respectively, when calling
-    [subprocess.Popen](https://docs.python.org/3/library/subprocess.html#subprocess.Popen).
+    [subprocess.Popen].
 
     Examples:
 
     ```robotframework
-    Run Process    command    stdin=PIPE
-    Run Process    command    stdin=${CURDIR}/stdin.txt
-    Run Process    command    stdin=Stdin as text.
+    *** Test Cases ***
+    Run process
+        Run Process    command    stdin=PIPE
+        Run Process    command    stdin=${CURDIR}/stdin.txt
+        Run Process    command    stdin=Stdin as text.
+
     ```
 
     The support to configure `stdin` is new in Robot Framework 4.1.2. Its default
@@ -579,8 +602,11 @@ class Process:
     Examples:
 
     ```robotframework
-    Start Process    program    output_encoding=UTF-8
-    Run Process      program    stdout=${path}    output_encoding=SYSTEM
+    *** Test Cases ***
+    Start process
+        Start Process    program    output_encoding=UTF-8
+        Run Process      program    stdout=${path}    output_encoding=SYSTEM
+
     ```
 
     ## Alias
@@ -591,8 +617,11 @@ class Process:
     Examples:
 
     ```robotframework
-    Start Process    program    alias=example
-    Run Process      python     -c    print('hello')    alias=hello
+    *** Test Cases ***
+    Alias
+        Start Process    program    alias=example
+        Run Process      python     -c    print('hello')    alias=hello
+
     ```
 
     # Active process
@@ -626,13 +655,16 @@ class Process:
     Example:
 
     ```robotframework
-    ${result} =            Run Process         program
-    Should Be Equal        ${result.rc}          0    type=int
-    Should Match           ${result.stdout}      Some t?xt*
-    Should Be Empty        ${result.stderr}
-    ${stdout} =            Get File            ${result.stdout_path}
-    Should Be Equal        ${stdout}             ${result.stdout}
-    File Should Be Empty   ${result.stderr_path}
+    *** Test Cases ***
+    Result object
+        ${result} =            Run Process         program
+        Should Be Equal        ${result.rc}          0    type=int
+        Should Match           ${result.stdout}      Some t?xt*
+        Should Be Empty        ${result.stderr}
+        ${stdout} =            Get File            ${result.stdout_path}
+        Should Be Equal        ${stdout}             ${result.stdout}
+        File Should Be Empty   ${result.stderr_path}
+
     ```
 
     Notice that in `stdout` and `stderr` content possible trailing newline
@@ -648,6 +680,7 @@ class Process:
     Suite Teardown    Terminate All Processes    kill=True
 
     *** Test Cases ***
+    Library
     Example
         Start Process    program    arg1    arg2    alias=First
         ${handle} =    Start Process    command.sh arg | command2.sh    shell=True    cwd=/path
@@ -656,6 +689,12 @@ class Process:
         Terminate Process    ${handle}
         ${result} =    Wait For Process    First
         Should Be Equal As Integers    ${result.rc}    0
+
+    [OperatingSystem]: http://robotframework.org/robotframework/latest/libraries/OperatingSystem.html "OperatingSystem"
+
+    [subprocess]: http://docs.python.org/library/subprocess.html "subprocess"
+
+    [Popen]: http://docs.python.org/library/subprocess.html#popen-constructor "Popen"
     """
 
     ROBOT_LIBRARY_SCOPE = "GLOBAL"
@@ -712,7 +751,6 @@ class Process:
         This keyword does not change the [active process].
 
         Args:
-
             command: Command to execute.
             *arguments: Arguments passed to the command.
             cwd: Working directory for the process.
@@ -729,12 +767,12 @@ class Process:
                 `env:<name>=<value>` syntax.
 
         Returns:
-
             [result object] containing information about the execution.
 
         Examples:
 
-        ```robotframework
+
+    ```robotframework
         ${result} =    Run Process    python    -c    print('Hello, world!')
         Should Be Equal    ${result.stdout}    Hello, world!
         ${result} =    Run Process    ${command}    stdout=${CURDIR}/stdout.txt    stderr=STDOUT
@@ -793,7 +831,6 @@ class Process:
         required using [Get Process Object] separately.
 
         Args:
-
             command: Command to execute.
             *arguments: Arguments passed to the command.
             cwd: Working directory for the process.
@@ -808,8 +845,7 @@ class Process:
                 `env:<name>=<value>` syntax.
 
         Returns:
-
-            Created [subprocess.Popen](https://docs.python.org/3/library/subprocess.html#popen-objects)
+            Created [subprocess.Popen]
             object which can be used later to activate this process. `Popen`
             attributes like `pid` can also be accessed directly.
 
@@ -818,27 +854,36 @@ class Process:
         Start process and wait for it to end later using an alias:
 
         ```robotframework
-        Start Process    ${command}    alias=example
-        # Other keywords
-        ${result} =    Wait For Process    example
+        *** Test Cases ***
+        Start process
+            Start Process    ${command}    alias=example
+            # Other keywords
+            ${result} =    Wait For Process    example
+
         ```
 
         Use returned `Popen` object:
 
         ```robotframework
-        ${process} =    Start Process    ${command}
-        Log             PID: ${process.pid}
-        # Other keywords
-        ${result} =     Terminate Process    ${process}
+        *** Test Cases ***
+        Start process
+            ${process} =    Start Process    ${command}
+            Log             PID: ${process.pid}
+            # Other keywords
+            ${result} =     Terminate Process    ${process}
+
         ```
 
         Use started process in a pipeline with another process:
 
         ```robotframework
-        ${process} =    Start Process    python    -c    print('Hello, world!')
-        ${result} =     Run Process      python    -c    import sys; print(sys.stdin.read().upper().strip())    stdin=${process.stdout}
-        Wait For Process    ${process}
-        Should Be Equal     ${result.stdout}    HELLO, WORLD!
+        *** Test Cases ***
+        Start process
+            ${process} =    Start Process    python    -c    print('Hello, world!')
+            ${result} =     Run Process      python    -c    import sys; print(sys.stdin.read().upper().strip())    stdin=${process.stdout}
+            Wait For Process    ${process}
+            Should Be Equal     ${result.stdout}    HELLO, WORLD!
+
         ```
         """
         config = ProcessConfiguration(
@@ -875,12 +920,10 @@ class Process:
         """Checks is the process running or not.
 
         Args:
-
             handle: Process handle or alias. Uses the current [active process]
                 if not given.
 
         Returns:
-
             `True` if the process is still running and `False` otherwise.
         """
         return self._processes[handle].poll() is None
@@ -893,13 +936,11 @@ class Process:
         """Verifies that the process is running.
 
         Args:
-
             handle: Process handle or alias. Uses the current [active process]
                 if not given.
             error_message: Message used if verification fails.
 
         Raises:
-
             AssertionError: If the process has stopped.
         """
         if not self.is_process_running(handle):
@@ -913,13 +954,11 @@ class Process:
         """Verifies that the process is not running.
 
         Args:
-
             handle: Process handle or alias. Uses the current [active process]
                 if not given.
             error_message: Message used if verification fails.
 
         Raises:
-
             AssertionError: If the process is still running.
         """
         if self.is_process_running(handle):
@@ -938,7 +977,7 @@ class Process:
 
         `timeout` defines the maximum time to wait for the process. It can be
         given in
-        [various time formats](http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#time-format)
+        [various time formats]
         supported by Robot Framework, for example, `42`,
         `42 s`, or `1 minute 30 seconds`. The timeout is ignored if it is
         `None` (default), zero or negative.
@@ -967,32 +1006,35 @@ class Process:
         Framework 7.3.
 
         Args:
-
             handle: Process handle or alias. Uses the current [active process]
                 if not given.
             timeout: Maximum time to wait for the process.
             on_timeout: Action when timeout occurs.
 
         Returns:
-
             [result object] if the process ends, or `None` if it is left running.
 
         Examples:
 
         ```robotframework
-        # Process ends cleanly
-        ${result} =                 Wait For Process    example
-        Process Should Be Stopped   example
-        Should Be Equal As Integers    ${result.rc}     0
-        # Process does not end
-        ${result} =                 Wait For Process    timeout=42 secs
-        Process Should Be Running
-        Should Be Equal             ${result}        ${NONE}
-        # Kill non-ending process
-        ${result} =                 Wait For Process    timeout=1min 30s    on_timeout=kill
-        Process Should Be Stopped
-        Should Be Equal As Integers    ${result.rc}     -9
+        *** Test Cases ***
+        Wait for process
+            # Process ends cleanly
+            ${result} =                 Wait For Process    example
+            Process Should Be Stopped   example
+            Should Be Equal As Integers    ${result.rc}     0
+            # Process does not end
+            ${result} =                 Wait For Process    timeout=42 secs
+            Process Should Be Running
+            Should Be Equal             ${result}        ${NONE}
+            # Kill non-ending process
+            ${result} =                 Wait For Process    timeout=1min 30s    on_timeout=kill
+            Process Should Be Stopped
+            Should Be Equal As Integers    ${result.rc}     -9
+
         ```
+
+        [various time formats]: http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#time-format "various time formats"
         """
         process = self._processes[handle]
         logger.info("Waiting for process to complete.")
@@ -1065,26 +1107,26 @@ class Process:
         child processes.
 
         Args:
-
             handle: Process handle or alias. Uses the current [active process]
                 if not given.
             kill: Whether to forcefully kill the process.
 
         Returns:
-
             [result object] containing information about the execution.
 
         Raises:
-
             RuntimeError: If terminating processes is not supported by this
                 Python version, or if forceful kill fails.
 
         Examples:
 
         ```robotframework
-        ${result} =                 Terminate Process
-        Should Be Equal As Integers    ${result.rc}      -15    # On Unixes
-        Terminate Process           myproc            kill=true
+        *** Test Cases ***
+        Terminate process
+            ${result} =                 Terminate Process
+            Should Be Equal As Integers    ${result.rc}      -15    # On Unixes
+            Terminate Process           myproc            kill=true
+
         ```
         """
         process = self._processes[handle]
@@ -1135,7 +1177,6 @@ class Process:
         that this keyword uses internally for more details.
 
         Args:
-
             kill: Whether to forcefully kill processes.
         """
         for process in self._processes:
@@ -1157,9 +1198,12 @@ class Process:
         below send signal `INT (2)`:
 
         ```robotframework
-        Send Signal To Process    2
-        Send Signal To Process    INT
-        Send Signal To Process    SIGINT    myproc
+        *** Test Cases ***
+        Send signal to process
+            Send Signal To Process    2
+            Send Signal To Process    INT
+            Send Signal To Process    SIGINT    myproc
+
         ```
 
         This keyword is only supported on Unix-like machines, not on Windows.
@@ -1173,14 +1217,12 @@ class Process:
         does the shell propagate the signal to the actual started process.
 
         Args:
-
             signal: Signal to send, either as an integer or signal name.
             handle: Process handle or alias. Uses the current [active process]
                 if not given.
             group: Whether to send the signal to the whole process group.
 
         Raises:
-
             RuntimeError: If used on Windows, if sending signals is not
                 supported by this Python version, or if the signal name is
                 unsupported.
@@ -1221,12 +1263,10 @@ class Process:
         [Start Process] like `${process.pid}`.
 
         Args:
-
             handle: Process handle or alias. Uses the current [active process]
                 if not given.
 
         Returns:
-
             Process ID as an integer.
         """
         return self._processes[handle].pid
@@ -1239,12 +1279,10 @@ class Process:
         mostly redundant.
 
         Args:
-
             handle: Process handle or alias. Uses the current [active process]
                 if not given.
 
         Returns:
-
             The underlying `subprocess.Popen` object.
         """
         return self._processes[handle]
@@ -1281,7 +1319,6 @@ class Process:
         can be returned without problems.
 
         Args:
-
             handle: Process handle or alias. Uses the current [active process]
                 if not given.
             rc: If true, return return code.
@@ -1291,30 +1328,31 @@ class Process:
             stderr_path: If true, return stderr path.
 
         Returns:
-
             Whole [result object], a single attribute, or a tuple of attributes
             depending on which arguments are given.
 
         Raises:
-
             RuntimeError: If results of an unfinished process are requested.
 
         Examples:
 
         ```robotframework
-        Run Process           python             -c            print('Hello, world!')    alias=myproc
-        # Get result object
-        ${result} =           Get Process Result    myproc
-        Should Be Equal       ${result.rc}       ${0}
-        Should Be Equal       ${result.stdout}   Hello, world!
-        Should Be Empty       ${result.stderr}
-        # Get one attribute
-        ${stdout} =           Get Process Result    myproc        stdout=true
-        Should Be Equal       ${stdout}          Hello, world!
-        # Multiple attributes
-        ${stdout}             ${stderr} =        Get Process Result    myproc    stdout=yes    stderr=yes
-        Should Be Equal       ${stdout}          Hello, world!
-        Should Be Empty       ${stderr}
+        *** Test Cases ***
+        Get process result
+            Run Process           python             -c            print('Hello, world!')    alias=myproc
+            # Get result object
+            ${result} =           Get Process Result    myproc
+            Should Be Equal       ${result.rc}       ${0}
+            Should Be Equal       ${result.stdout}   Hello, world!
+            Should Be Empty       ${result.stderr}
+            # Get one attribute
+            ${stdout} =           Get Process Result    myproc        stdout=true
+            Should Be Equal       ${stdout}          Hello, world!
+            # Multiple attributes
+            ${stdout}             ${stderr} =        Get Process Result    myproc    stdout=yes    stderr=yes
+            Should Be Equal       ${stdout}          Hello, world!
+            Should Be Empty       ${stderr}
+
         ```
         """
         result = self._results[self._processes[handle]]
@@ -1348,17 +1386,19 @@ class Process:
         the `alias` given to it explicitly.
 
         Args:
-
             handle: Process handle or alias to activate.
 
         Example:
 
         ```robotframework
-        Start Process    prog1    alias=process1
-        Start Process    prog2    alias=process2
-        # currently active process is process2
-        Switch Process    process1
-        # now active process is process1
+        *** Test Cases ***
+        Switch process
+            Start Process    prog1    alias=process1
+            Start Process    prog2    alias=process2
+            # currently active process is process2
+            Switch Process    process1
+            # now active process is process1
+
         ```
         """
         self._processes.switch(handle)
@@ -1382,19 +1422,20 @@ class Process:
         in Windows paths and elsewhere.
 
         Args:
-
             command: Command line string to split.
             escaping: Whether to treat backslash as an escape character.
 
         Returns:
-
             List of command line arguments.
 
         Examples:
 
         ```robotframework
-        @{cmd} =    Split Command Line    --option "value with spaces"
-        Should Be True    $cmd == ['--option', 'value with spaces']
+        *** Test Cases ***
+        Split command line
+            @{cmd} =    Split Command Line    --option "value with spaces"
+            Should Be True    $cmd == ['--option', 'value with spaces']
+
         ```
         """
         return cmdline2list(command, escaping=escaping)
@@ -1409,12 +1450,10 @@ class Process:
         Command to join can be given as individual arguments or as a list.
 
         Args:
-
             *command: Arguments to join, either as individual strings or as
                 a list.
 
         Returns:
-
             Joined command line string.
 
         Examples:
@@ -1422,16 +1461,22 @@ class Process:
         Giving command as individual arguments:
 
         ```robotframework
-        ${cmd} =        Join Command Line    --option    value with spaces
-        Should Be Equal    ${cmd}            --option "value with spaces"
+        *** Test Cases ***
+        Join command line
+            ${cmd} =        Join Command Line    --option    value with spaces
+            Should Be Equal    ${cmd}            --option "value with spaces"
+
         ```
 
         Giving command as a list:
 
         ```robotframework
-        VAR             @{arguments}      --option    value with spaces
-        ${cmd} =        Join Command Line    ${arguments}
-        Should Be Equal    ${cmd}            --option "value with spaces"
+        *** Test Cases ***
+        Join command line
+            VAR             @{arguments}      --option    value with spaces
+            ${cmd} =        Join Command Line    ${arguments}
+            Should Be Equal    ${cmd}            --option "value with spaces"
+
         ```
         """
         parts = []

--- a/src/robot/libraries/Process.py
+++ b/src/robot/libraries/Process.py
@@ -379,7 +379,7 @@ class Process:
     [Popen](http://docs.python.org/library/subprocess.html#popen-constructor)
     class.
 
-    ## Table of contents
+    ### Table of contents
 
     %TOC%
 


### PR DESCRIPTION
## What

- Convert Process library and keyword documentation to Markdown.
- Add structured Args/Returns for keywords.
- Align examples and formatting with maintainer style from merged library doc PRs.

## Why

Process-only part of #5709.

## Testing

- `py_compile` on Process.py
- Libdoc HTML generation succeeds (`MARKDOWN`)