### PR TITLE
Fix invalid section header default-name error

### DIFF
--- a/src/robot/parsing/model/statements.py
+++ b/src/robot/parsing/model/statements.py
@@ -323,6 +323,8 @@ class SectionHeader(Statement):
         eol: str = EOL,
     ) -> "SectionHeader":
         if not name:
+            if type == Token.INVALID_HEADER:
+                raise ValueError("Invalid header requires an explicit name.")
             names = (
                 "Settings",
                 "Variables",

--- a/utest/parsing/test_statements.py
+++ b/utest/parsing/test_statements.py
@@ -111,6 +111,12 @@ class TestCreateStatementsFromParams(unittest.TestCase):
                 tokens, SectionHeader, type=token_type, name=f"*** {name} ***"
             )
 
+    def test_invalid_section_header_requires_name(self):
+        with self.assertRaisesRegex(
+            ValueError, "Invalid header requires an explicit name"
+        ):
+            SectionHeader.from_params(Token.INVALID_HEADER)
+
     def test_SuiteSetup(self):
         # Suite Setup    Setup Keyword    ${arg1}    ${arg2}
         tokens = [


### PR DESCRIPTION
Closes #5723

`SectionHeader.from_params()` now raises a descriptive `ValueError` when an invalid header omits its required explicit name, instead of leaking an internal `KeyError`. The existing explicit-name path remains unchanged, and a regression covers the missing-name case.
