### PR TITLE
Change Finnish translation of "Tags"

### DIFF
--- a/doc/userguide/src/Appendices/Translations.rst
+++ b/doc/userguide/src/Appendices/Translations.rst
@@ -856,13 +856,13 @@ Settings
     * - Task Timeout
       - Tehtävän Aikaraja
     * - Test Tags
-      - Testin Tagit
+      - Testin Tunnisteet
     * - Task Tags
-      - Tehtävän Tagit
+      - Tehtävän Tunnisteet
     * - Keyword Tags
-      - Avainsanan Tagit
+      - Avainsanan Tunnisteet
     * - Tags
-      - Tagit
+      - Tunnisteet
     * - Setup
       - Alustus
     * - Teardown
@@ -911,6 +911,31 @@ Boolean strings
       - Tosi, Kyllä, Päällä
     * - False
       - Epätosi, Ei, Pois
+
+Deprecations
+~~~~~~~~~~~~
+
+.. list-table::
+    :class: tabular
+    :width: 40em
+    :widths: 2 2 1
+    :header-rows: 1
+
+    * - Old term
+      - New term
+      - Deprecated
+    * - Tagit
+      - Tunnisteet
+      - RF 7.5
+    * - Avainsanan Tagit
+      - Avainsanan Tunnisteet
+      - RF 7.5
+    * - Testin Tagit
+      - Testin Tunnisteet
+      - RF 7.5
+    * - Tehtävän Tagit
+      - Tehtävän Tunnisteet
+      - RF 7.5
 
 French (fr)
 -----------

--- a/src/robot/conf/languages.py
+++ b/src/robot/conf/languages.py
@@ -598,10 +598,10 @@ class Fi(Language):
     task_template_setting = "Tehtävän Malli"
     test_timeout_setting = "Testin Aikaraja"
     task_timeout_setting = "Tehtävän Aikaraja"
-    test_tags_setting = "Testin Tagit"
-    task_tags_setting = "Tehtävän Tagit"
-    keyword_tags_setting = "Avainsanan Tagit"
-    tags_setting = "Tagit"
+    test_tags_setting = "Testin Tunnisteet"
+    task_tags_setting = "Tehtävän Tunnisteet"
+    keyword_tags_setting = "Avainsanan Tunnisteet"
+    tags_setting = "Tunnisteet"
     setup_setting = "Alustus"
     teardown_setting = "Alasajo"
     template_setting = "Malli"
@@ -614,6 +614,11 @@ class Fi(Language):
     but_prefixes = ["Mutta"]
     true_strings = ["Tosi", "Kyllä", "Päällä"]
     false_strings = ["Epätosi", "Ei", "Pois"]
+    deprecations = {"Tagit": ("Tunnisteet", "7.5"),
+                    "Avainsanan Tagit": ("Avainsanan Tunnisteet", "7.5"),
+                    "Testin Tagit": ("Testin Tunnisteet", "7.5"),
+                    "Tehtävän Tagit": ("Tehtävän Tunnisteet", "7.5")
+                    }
 
 
 class Fr(Language):


### PR DESCRIPTION
Implementation for #5726.

"Tagit" is not proper Finnish. This PR deprecates Finnish translations for Tags, Keyword Tags, Test Tags, and Task Tags to use the word "Tunnisteet", which is the proper Finnish word.