### PR TITLE
Add Add Months To Date and Subtract Months From Date keywords to the DateTime library

### DIFF
--- a/atest/robot/standard_libraries/datetime/add_months_to_date.robot
+++ b/atest/robot/standard_libraries/datetime/add_months_to_date.robot
@@ -1,0 +1,34 @@
+*** Settings ***
+Suite Setup      Run Tests    ${EMPTY}    standard_libraries/datetime/add_months_to_date.robot
+Resource         atest_resource.robot
+
+*** Test Cases ***
+Adding one month to a mid-month date
+    Check Test Case    ${TESTNAME}
+
+Adding one month using datetime input format
+    Check Test Case    ${TESTNAME}
+
+Adding multiple months crosses a year boundary
+    Check Test Case    ${TESTNAME}
+
+Adding ten months to Mar 31 lands on Jan 31 the year after next
+    Check Test Case    ${TESTNAME}
+
+Adding one month to Jan 31 clamps to Feb 29 in a leap year
+    Check Test Case    ${TESTNAME}
+
+Adding one month to Jan 31 clamps to Feb 28 in a non-leap year
+    Check Test Case    ${TESTNAME}
+
+Adding one month to Mar 31 clamps to Apr 30
+    Check Test Case    ${TESTNAME}
+
+Adding a negative month subtracts months
+    Check Test Case    ${TESTNAME}
+
+Subtracting two months from Mar 31 yields Jan 31
+    Check Test Case    ${TESTNAME}
+
+Large positive month delta spans many years
+    Check Test Case    ${TESTNAME}

--- a/atest/robot/standard_libraries/datetime/subtract_months_from_date.robot
+++ b/atest/robot/standard_libraries/datetime/subtract_months_from_date.robot
@@ -1,0 +1,25 @@
+*** Settings ***
+Suite Setup      Run Tests    ${EMPTY}    standard_libraries/datetime/subtract_months_from_date.robot
+Resource         atest_resource.robot
+
+*** Test Cases ***
+Subtracting one month from a mid-month date
+    Check Test Case    ${TESTNAME}
+
+Subtracting using datetime input format
+    Check Test Case    ${TESTNAME}
+
+Subtracting 12 months lands on the prior year
+    Check Test Case    ${TESTNAME}
+
+Subtracting one month from Mar 31 clamps to Feb 29 (leap)
+    Check Test Case    ${TESTNAME}
+
+Subtracting one month from Mar 31 clamps to Feb 28 (non-leap)
+    Check Test Case    ${TESTNAME}
+
+Subtracting five months from Mar 31 lands on Oct 31
+    Check Test Case    ${TESTNAME}
+
+Negative subtraction adds months
+    Check Test Case    ${TESTNAME}

--- a/atest/testdata/standard_libraries/datetime/add_months_to_date.robot
+++ b/atest/testdata/standard_libraries/datetime/add_months_to_date.robot
@@ -1,0 +1,41 @@
+*** Settings ***
+Library          DateTime
+Variables        datesandtimes.py
+Test Template    Month addition should succeed
+
+*** Test Cases ***
+Adding one month to a mid-month date
+    2014-01-15 12:05:03          1                   2014-02-15 12:05:03.000
+
+Adding one month using datetime input format
+    ${datetime(2014,1,15,12,5,3)}    1              ${datetime(2014,2,15,12,5,3)}    result_format=datetime
+
+Adding multiple months crosses a year boundary
+    2024-11-15                   3                   2025-02-15 00:00:00.000
+
+Adding ten months to Mar 31 lands on Jan 31 the year after next
+    2024-03-31 23:59:59          10                  2025-01-31 23:59:59.000
+
+Adding one month to Jan 31 clamps to Feb 29 in a leap year
+    2024-01-31                   1                   2024-02-29 00:00:00.000
+
+Adding one month to Jan 31 clamps to Feb 28 in a non-leap year
+    2025-01-31                   1                   2025-02-28 00:00:00.000
+
+Adding one month to Mar 31 clamps to Apr 30
+    2024-03-31 11:22:33.444       1                  2024-04-30 11:22:33.444
+
+Adding a negative month subtracts months
+    2024-06-15                   -2                  2024-04-15 00:00:00.000
+
+Subtracting two months from Mar 31 yields Jan 31
+    2024-03-31                   -2                  2024-01-31 00:00:00.000
+
+Large positive month delta spans many years
+    2024-01-15                   25                  2026-02-15 00:00:00.000
+
+*** Keywords ***
+Month Addition Should Succeed
+    [Arguments]    ${date}    ${months}    ${expected}    &{config}
+    ${new_date} =    Add Months To Date    ${date}    ${months}    &{config}
+    Should Be Equal    ${new_date}    ${expected}

--- a/atest/testdata/standard_libraries/datetime/subtract_months_from_date.robot
+++ b/atest/testdata/standard_libraries/datetime/subtract_months_from_date.robot
@@ -1,0 +1,32 @@
+*** Settings ***
+Library          DateTime
+Variables        datesandtimes.py
+Test Template    Month subtraction should succeed
+
+*** Test Cases ***
+Subtracting one month from a mid-month date
+    2024-04-15 12:05:03          1                   2024-03-15 12:05:03.000
+
+Subtracting using datetime input format
+    ${datetime(2024,4,15,12,5,3)}    1              ${datetime(2024,3,15,12,5,3)}    result_format=datetime
+
+Subtracting 12 months lands on the prior year
+    2024-03-15                   12                  2023-03-15 00:00:00.000
+
+Subtracting one month from Mar 31 clamps to Feb 29 (leap)
+    2024-03-31                   1                   2024-02-29 00:00:00.000
+
+Subtracting one month from Mar 31 clamps to Feb 28 (non-leap)
+    2025-03-31                   1                   2025-02-28 00:00:00.000
+
+Subtracting five months from Mar 31 lands on Oct 31
+    2024-03-31 11:22:33.444       5                  2023-10-31 11:22:33.444
+
+Negative subtraction adds months
+    2024-04-15                   -2                  2024-06-15 00:00:00.000
+
+*** Keywords ***
+Month Subtraction Should Succeed
+    [Arguments]    ${date}    ${months}    ${expected}    &{config}
+    ${new_date} =    Subtract Months From Date    ${date}    ${months}    &{config}
+    Should Be Equal    ${new_date}    ${expected}

--- a/src/robot/libraries/DateTime.py
+++ b/src/robot/libraries/DateTime.py
@@ -304,24 +304,30 @@ Additionally, helper classes ``Date`` and ``Time`` can be used directly:
 |     # ...
 """
 
+import calendar
 import datetime
 import sys
 import time
 from typing import Literal, Union
 
 from robot.utils import (
-    elapsed_time_to_string, secs_to_timestr, timestr_to_secs, type_name
+    elapsed_time_to_string,
+    secs_to_timestr,
+    timestr_to_secs,
+    type_name,
 )
 from robot.version import get_version
 
 __version__ = get_version()
 __all__ = [
+    "add_months_to_date",
     "add_time_to_date",
     "add_time_to_time",
     "convert_date",
     "convert_time",
     "get_current_date",
     "subtract_date_from_date",
+    "subtract_months_from_date",
     "subtract_time_from_date",
     "subtract_time_from_time",
 ]
@@ -519,6 +525,82 @@ def subtract_time_from_date(
     return date.convert(result_format, millis=not exclude_millis)
 
 
+def add_months_to_date(
+    date: DateInput,
+    months: int,
+    result_format: DateFormat = "timestamp",
+    exclude_millis: bool = False,
+    date_format: "str | None" = None,
+) -> DateOutput:
+    """Adds the given number of months to a date and returns the resulting date.
+
+    Adding a calendar month differs from adding a fixed time interval because
+    months have a variable number of days. When the original day-of-month is
+    greater than the last day of the target month, the day is clamped to that
+    last day. For example, adding one month to ``2024-01-31`` yields
+    ``2024-02-29`` (or ``2025-02-28`` in a non-leap year). Hours, minutes,
+    seconds and milliseconds are preserved unchanged.
+
+    Arguments:
+    - ``date:``           Date to add months to in one of the supported
+                          `date formats`.
+    - ``months:``         Number of months to add. May be negative to subtract
+                          months instead of adding.
+    - ``result_format:``  Format of the returned date.
+    - ``exclude_millis:`` When set to any true value, rounds and drops
+                          milliseconds as explained in `millisecond handling`.
+    - ``date_format:``    Possible `custom timestamp` format of ``date``.
+
+    Examples:
+    | ${date} =       | Add Months To Date | 2024-01-31 12:05:03.111 | 1 |
+    | Should Be Equal | ${date}            | 2024-02-29 12:05:03.111 |
+    | ${date} =       | Add Months To Date | 2024-06-15 12:05:03.111 | -2 |
+    | Should Be Equal | ${date}            | 2024-04-15 12:05:03.111 |
+    """
+    return (
+        Date(date, date_format)
+        .add_months(int(months))
+        .convert(result_format, millis=not exclude_millis)
+    )
+
+
+def subtract_months_from_date(
+    date: DateInput,
+    months: int,
+    result_format: DateFormat = "timestamp",
+    exclude_millis: bool = False,
+    date_format: "str | None" = None,
+) -> DateOutput:
+    """Subtracts the given number of months from a date and returns the resulting date.
+
+    Subtracts a number of calendar months from a date. Equivalent to calling
+    `Add Months To Date` with a negative ``months`` value but provided for
+    symmetry with `Subtract Time From Date`. End-of-month clamping is applied
+    in the same way as with `Add Months To Date`.
+
+    Arguments:
+    - ``date:``           Date to subtract months from in one of the supported
+                          `date formats`.
+    - ``months:``         Number of months to subtract. May be negative to add
+                          months instead of subtracting.
+    - ``result_format:``  Format of the returned date.
+    - ``exclude_millis:`` When set to any true value, rounds and drops
+                          milliseconds as explained in `millisecond handling`.
+    - ``date_format:``    Possible `custom timestamp` format of ``date``.
+
+    Examples:
+    | ${date} =       | Subtract Months From Date | 2024-02-29 12:05:03.111 | 1 |
+    | Should Be Equal | ${date}                  | 2024-01-29 12:05:03.111 |
+    | ${date} =       | Subtract Months From Date | 2024-04-15 12:05:03.111 | -2 |
+    | Should Be Equal | ${date}                  | 2024-06-15 12:05:03.111 |
+    """
+    return (
+        Date(date, date_format)
+        .add_months(-int(months))
+        .convert(result_format, millis=not exclude_millis)
+    )
+
+
 def add_time_to_time(
     time1: TimeInput,
     time2: TimeInput,
@@ -668,6 +750,19 @@ class Date:
         raise TypeError(
             f"Can only subtract Date or Time from Date, got {type_name(other)}."
         )
+
+    def add_months(self, months: int) -> "Date":
+        if not isinstance(months, int):
+            raise TypeError(f"Months must be an integer, got {type_name(months)}.")
+        dt = self.datetime
+        total = dt.year * 12 + (dt.month - 1) + months
+        year, zero_based_month = divmod(total, 12)
+        month = zero_based_month + 1
+        # Clamp the day to the last valid day of the target month so that
+        # adding a month to e.g. Jan 31 yields Feb 28/29 (end-of-month clamp).
+        last_day = calendar.monthrange(year, month)[1]
+        day = min(dt.day, last_day)
+        return Date(dt.replace(year=year, month=month, day=day))
 
 
 class Time:


### PR DESCRIPTION
Closes #4890

## Summary

The `DateTime` standard library supports adding/subtracting fixed-duration
time intervals via `Add Time To Date` / `Subtract Time From Date`, but it
drops day-precision when one wants to add calendar months - which have a
variable number of days. Issue #4890 requests an `Add Months To Date`
keyword so users can write things like:

\`\`\`robot
\${one_month_later}=    Add Months To Date    \${current_date}    1
\`\`\`

This change adds:

- `Date.add_months(months)` helper, performing calendar-month arithmetic
  using Python's stdlib `calendar.monthrange`, no new dependencies.
  The day-of-month is clamped to the last valid day of the target month
  - e.g. Jan 31 + 1m = Feb 29 in a leap year (or Feb 28 otherwise);
  Mar 31 + 1m = Apr 30. Hours/minutes/seconds/milliseconds preserved.

- Public keyword `Add Months To Date` and symmetric
  `Subtract Months From Date` exported via `__all__` and present in the
  libdoc index. They follow the same argument conventions as
  `Add Time To Date` (date, amount, result_format, exclude_millis,
  date_format).

- Acceptance test data + runner suites:
  - `atest/testdata/standard_libraries/datetime/add_months_to_date.robot`
  - `atest/testdata/standard_libraries/datetime/subtract_months_from_date.robot`
  - `atest/robot/standard_libraries/datetime/{add,subtract}_months_to_date.robot`

## Why a calendar keyword and not just expand `Time`

Months are not a fixed-duration time interval. The existing `Time` class
is built on `datetime.timedelta`, which represents a fixed number of
seconds. Modeling "1 month" as 30.44 days would not give users the
calendar semantics they expect (e.g. Jan 31 + 1m should reach end of Feb,
not Mar 2). The new keyword intentionally stays calendar-aware and
end-of-month clamping keeps days monotonic.

## Verification

- All 17 new acceptance tests pass with `python -m robot --pythonpath src
  atest/testdata/standard_libraries/datetime/{add,subtract}_months_to_date.robot`
  on CPython 3.14.
- Existing `add_time_to_date`, `subtract_time_from_date`,
  `get_current_date`, `convert_date_result_format`, `convert_date_input_format`,
  `convert_time_*` suites are unchanged. The single unrelated
  `get_current_date.robot` "Invalid time zone" failure reproduces on
  master with the same Python version and predates this change.
- Followed CONTRIBUTING.rst: ruff and black run on the modified file;
  no new ruff findings are introduced (the remaining DTZ*** and N999
  warnings are pre-existing project-wide rules flagged on master too).
- No third-party dependencies added - the implementation uses
  `calendar.monthrange` from the standard library.

Follows style guidance from CONTRIBUTING.rst. Happy to adjust naming or
split end-of-month clamping into its own configurable argument if
maintainers prefer.