### PR TITLE
DateTime: support calendar units in date arithmetic

### DIFF
--- a/atest/robot/standard_libraries/datetime/add_time_to_date.robot
+++ b/atest/robot/standard_libraries/datetime/add_time_to_date.robot
@@ -8,3 +8,6 @@ Time addition to date should succeed
 
 Time addition to date over DST boundary
     Check Test Case    ${TESTNAME}
+
+Calendar time addition to date should succeed
+    Check Test Case    ${TESTNAME}

--- a/atest/robot/standard_libraries/datetime/subtract_time_from_date.robot
+++ b/atest/robot/standard_libraries/datetime/subtract_time_from_date.robot
@@ -8,3 +8,6 @@ Time subtraction from date should succeed
 
 Time subtraction over DST boundary
     Check Test Case    ${TESTNAME}
+
+Calendar time subtraction from date should succeed
+    Check Test Case    ${TESTNAME}

--- a/atest/testdata/standard_libraries/datetime/add_time_to_date.robot
+++ b/atest/testdata/standard_libraries/datetime/add_time_to_date.robot
@@ -20,6 +20,14 @@ Time addition to date over DST boundary
     20151001 02:03:04.005      31 days            2015-11-01 02:03:04.005
     ${datetime(2015,10,25)}    ${timedelta(1)}    ${datetime(2015,10,26)}    result_format=datetime
 
+Calendar time addition to date should succeed
+    2024-01-31 12:34:56.789      1 month                     2024-02-29 12:34:56.789
+    2023-01-31                   1 month 1 day               2023-03-01 00:00:00.000
+    2024-02-29                   1 year                      2025-02-28 00:00:00.000
+    2023-11-30                   1 year 2 months 1 day       2025-01-31 00:00:00.000
+    2025-03-31                   - 1 month 1 day             2025-02-27 00:00:00.000
+    ${datetime(2024,1,31,12)}    1 month                     ${datetime(2024,2,29,12)}    result_format=datetime
+
 *** Keywords ***
 Addition Should Succeed
     [Arguments]    ${date}    ${time}    ${expected}     &{config}

--- a/atest/testdata/standard_libraries/datetime/subtract_time_from_date.robot
+++ b/atest/testdata/standard_libraries/datetime/subtract_time_from_date.robot
@@ -18,6 +18,13 @@ Time subtraction over DST boundary
     2015-10-26                1 day                    2015-10-25 00:00:00.000    timestamp
     ${datetime(2015,11,1)}    ${timedelta(days=31)}    ${datetime(2015,10,1)}     datetime
 
+Calendar time subtraction from date should succeed
+    2025-03-31                   1 month              2025-02-28 00:00:00.000    timestamp
+    2024-03-31                   1 month 1 day        2024-02-28 00:00:00.000    timestamp
+    2024-02-29                   1 year               2023-02-28 00:00:00.000    timestamp
+    2025-01-31                   - 1 month            2025-02-28 00:00:00.000    timestamp
+    ${datetime(2024,3,31,12)}    1 month              ${datetime(2024,2,29,12)}    datetime
+
 *** Keywords ***
 Time Subtraction Should Succeed
     [Arguments]    ${date}    ${time}    ${expected}    ${result_format}    ${date_format}=${NONE}

--- a/src/robot/libraries/DateTime.py
+++ b/src/robot/libraries/DateTime.py
@@ -237,6 +237,14 @@ times. The available time specifiers are:
 - `microseconds`, `microsecond`, `us`, `μs` (new in RF 6.0)
 - `nanoseconds`, `nanosecond`, `ns` (new in RF 6.0)
 
+Starting from Robot Framework 7.6, [Add Time To Date] and
+[Subtract Time From Date] also accept integer calendar units `years`, `year`,
+`yrs`, `yr`, `months` and `month`. These units can be combined with the fixed
+units above, such as `1 year 2 months 3 days`. Because their exact duration
+depends on the starting date, they are not supported by other keywords. If the
+original day does not exist in the target month, it is limited to the last day
+of that month.
+
 When returning a time string, it is possible to select between `verbose`
 and `compact` representations using `result_format` argument. The verbose
 format uses long specifiers like `week` and `day`, and adds `s` at the end
@@ -581,6 +589,8 @@ def add_time_to_date(
     Args:
         date: Date to add time to in one of the supported [date formats].
         time: Time that is added in one of the supported [time formats].
+            Starting from Robot Framework 7.6, this can also contain integer
+            calendar years and months.
         result_format: Format of the returned date.
         exclude_millis: When set to a true value, rounds and drops
             milliseconds as explained in the [Millisecond handling] section.
@@ -596,11 +606,15 @@ def add_time_to_date(
     Add time to date
         ${date} =    Add Time To Date    2014-05-28 12:05:03.111    7 days
         Should Be Equal    ${date}    2014-06-04 12:05:03.111
+        ${date} =    Add Time To Date    2024-01-31    1 month 1 day
+        Should Be Equal    ${date}    2024-03-01 00:00:00.000
         ${date} =    Add Time To Date    2014-05-28 12:05:03.111    01:02:03:004
         Should Be Equal    ${date}    2014-05-28 13:07:06.115
     ```
     """
-    date = Date(date, date_format) + Time(time)
+    date = Date(date, date_format)
+    seconds = timestr_to_secs(time, round_to=None, start_date=date.datetime)
+    date += Time(seconds)
     return date.convert(result_format, millis=not exclude_millis)
 
 
@@ -616,6 +630,8 @@ def subtract_time_from_date(
     Args:
         date: Date to subtract time from in one of the supported [date formats].
         time: Time that is subtracted in one of the supported [time formats].
+            Starting from Robot Framework 7.6, this can also contain integer
+            calendar years and months.
         result_format: Format of the returned date.
         exclude_millis: When set to any true value, rounds and drops
             milliseconds as explained in the [Millisecond handling] section.
@@ -631,12 +647,33 @@ def subtract_time_from_date(
     Subtract time from date
         ${date} =    Subtract Time From Date    2014-06-04 12:05:03.111    7 days
         Should Be Equal    ${date}    2014-05-28 12:05:03.111
+        ${date} =    Subtract Time From Date    2025-03-31    1 month
+        Should Be Equal    ${date}    2025-02-28 00:00:00.000
         ${date} =    Subtract Time From Date    2014-05-28 13:07:06.115    01:02:03:004
         Should Be Equal    ${date}    2014-05-28 12:05:03.111
     ```
     """
-    date = Date(date, date_format) - Time(time)
+    date = Date(date, date_format)
+    if isinstance(time, str):
+        original = time
+        time = _negate_time_string(time)
+        try:
+            seconds = timestr_to_secs(time, round_to=None, start_date=date.datetime)
+        except ValueError:
+            raise ValueError(f"Invalid time string '{original}'.")
+        date += Time(seconds)
+    else:
+        date -= Time(time)
     return date.convert(result_format, millis=not exclude_millis)
+
+
+def _negate_time_string(time: str) -> str:
+    time = time.strip()
+    if time.startswith("-"):
+        return time[1:].lstrip()
+    if time.startswith("+"):
+        return "-" + time[1:].lstrip()
+    return "-" + time
 
 
 def add_time_to_time(

--- a/src/robot/utils/robottime.py
+++ b/src/robot/utils/robottime.py
@@ -16,7 +16,8 @@
 import re
 import time
 import warnings
-from datetime import datetime, timedelta
+from calendar import monthrange
+from datetime import date, datetime, timedelta
 
 from .misc import plural_or_not as s
 from .normalizing import normalize
@@ -41,6 +42,7 @@ def _float_secs_to_secs_and_millis(secs):
 def timestr_to_secs(
     timestr: "timedelta | int | float | str",
     round_to: "int | None" = 3,
+    start_date: "date | datetime | None" = None,
 ) -> float:
     """Parses time strings like '1h 10s', '01:00:10' and '42' and returns seconds.
 
@@ -49,13 +51,20 @@ def timestr_to_secs(
 
     The result is rounded according to the `round_to` argument.
     Use `round_to=None` to disable rounding altogether.
+
+    Starting from RF 7.6, time strings can contain integer years and months if
+    `start_date` is given. Their duration is calculated from that date using
+    calendar arithmetic.
     """
     if isinstance(timestr, (str, int, float)):
-        converters = [_number_to_secs, _timer_to_secs, _time_string_to_secs]
+        converters = [_number_to_secs, _timer_to_secs]
         for converter in converters:
             secs = converter(timestr)
             if secs is not None:
                 return secs if round_to is None else round(secs, round_to)
+        secs = _time_string_to_secs(timestr, start_date)
+        if secs is not None:
+            return secs if round_to is None else round(secs, round_to)
     if isinstance(timestr, timedelta):
         return timestr.total_seconds()
     raise ValueError(f"Invalid time string '{timestr}'.")
@@ -83,12 +92,13 @@ def _timer_to_secs(number):
     return seconds
 
 
-def _time_string_to_secs(timestr):
+def _time_string_to_secs(timestr, start_date=None):
     try:
         timestr = _normalize_timestr(timestr)
     except ValueError:
         return None
-    nanos = micros = millis = secs = mins = hours = days = weeks = 0
+    years = months = weeks = days = hours = mins = secs = millis = micros = nanos = 0
+    has_calendar_units = False
     if timestr[0] == "-":
         sign = -1
         timestr = timestr[1:]
@@ -96,12 +106,20 @@ def _time_string_to_secs(timestr):
         sign = 1
     temp = []
     for c in timestr:
-        if c in ("n", "u", "M", "s", "m", "h", "d", "w"):
+        if c in ("n", "u", "M", "s", "m", "h", "d", "w", "O", "Y"):
             try:
                 value = float("".join(temp))
             except ValueError:
                 return None
-            if c == "n":
+            if c in ("O", "Y") and not value.is_integer():
+                return None
+            if c == "Y":
+                years = int(value)
+                has_calendar_units = True
+            elif c == "O":
+                months = int(value)
+                has_calendar_units = True
+            elif c == "n":
                 nanos = value
             elif c == "u":
                 micros = value
@@ -122,7 +140,7 @@ def _time_string_to_secs(timestr):
             temp.append(c)
     if temp:
         return None
-    return sign * (
+    fixed_seconds = sign * (
         nanos / 1e9
         + micros / 1e6
         + millis / 1e3
@@ -132,6 +150,31 @@ def _time_string_to_secs(timestr):
         + days * 60 * 60 * 24
         + weeks * 60 * 60 * 24 * 7
     )
+    if not has_calendar_units:
+        return fixed_seconds
+    calendar_seconds = _calendar_time_to_secs(
+        start_date,
+        sign * (years * 12 + months),
+    )
+    if calendar_seconds is None:
+        return None
+    return calendar_seconds + fixed_seconds
+
+
+def _calendar_time_to_secs(start_date, months):
+    if not isinstance(start_date, date):
+        return None
+    year, month = divmod(
+        start_date.year * 12 + start_date.month - 1 + months,
+        12,
+    )
+    month += 1
+    try:
+        day = min(start_date.day, monthrange(year, month)[1])
+        end_date = start_date.replace(year=year, month=month, day=day)
+    except (OverflowError, ValueError):
+        return None
+    return (end_date - start_date).total_seconds()
 
 
 def _normalize_timestr(timestr):
@@ -140,6 +183,8 @@ def _normalize_timestr(timestr):
         raise ValueError
     seen = []
     for specifier, aliases in [
+        ("Y", ["year", "yr"]),
+        ("O", ["month"]),
         ("n", ["nanosecond", "ns"]),
         ("u", ["microsecond", "us", "μs"]),
         ("M", ["millisecond", "millisec", "millis", "msec", "ms"]),

--- a/utest/utils/test_robottime.py
+++ b/utest/utils/test_robottime.py
@@ -2,7 +2,7 @@ import re
 import time
 import unittest
 import warnings
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 
 from robot.utils.asserts import (
     assert_equal, assert_not_none, assert_raises_with_msg, assert_true
@@ -117,6 +117,55 @@ class TestTime(unittest.TestCase):
             ("11w 5d 3h", 11 * 7 * 60 * 60 * 24 + 5 * 24 * 60 * 60 + 3 * 60 * 60),
         ]:
             assert_equal(timestr_to_secs(inp), exp, inp)
+
+    def test_timestr_to_secs_with_calendar_units_and_start_date(self):
+        for start, value, expected in [
+            (
+                datetime(2024, 1, 31, 12, 30),
+                "1 month",
+                datetime(2024, 2, 29, 12, 30),
+            ),
+            (
+                datetime(2025, 3, 31, 12, 30),
+                "- 1 month 1 day",
+                datetime(2025, 2, 27, 12, 30),
+            ),
+            (
+                datetime(2024, 2, 29, 12, 30),
+                "1 year 1 month 2 days",
+                datetime(2025, 3, 31, 12, 30),
+            ),
+            (
+                datetime(2023, 11, 30),
+                "1yr 2months 1day",
+                datetime(2025, 1, 31),
+            ),
+            (date(2024, 1, 31), "1 month", date(2024, 2, 29)),
+        ]:
+            expected = (expected - start).total_seconds()
+            assert_equal(timestr_to_secs(value, start_date=start), expected, value)
+
+    def test_calendar_units_require_start_date_and_integer_values(self):
+        for value in ["1 month", "2 years"]:
+            assert_raises_with_msg(
+                ValueError,
+                f"Invalid time string '{value}'.",
+                timestr_to_secs,
+                value,
+            )
+        for value in [
+            "1.5 months",
+            "1 year 2 years",
+            "1 month 2 months",
+            "1e100 months",
+        ]:
+            assert_raises_with_msg(
+                ValueError,
+                f"Invalid time string '{value}'.",
+                timestr_to_secs,
+                value,
+                start_date=datetime(2024, 1, 1),
+            )
 
     def test_timestr_to_secs_with_time_string_ns_accuracy(self):
         for input, expected in [


### PR DESCRIPTION
## Summary

- extend `timestr_to_secs()` with an optional start date and support integer calendar years and months alongside existing fixed units
- apply calendar components with end-of-month clamping before fixed-duration components, preserving the original time of day
- use the calendar-aware conversion in `Add Time To Date` and `Subtract Time From Date`, including correct backward arithmetic and negative inputs
- document the Robot Framework 7.6 behavior and add unit and acceptance coverage for leap years, year boundaries, mixed units, and invalid values

## Validation

- `.venv/bin/python utest/run.py` — 2403 passed
- `.venv/bin/python atest/run.py atest/robot/standard_libraries/datetime` — 60 passed
- `.venv/bin/invoke library-docs DateTime`

Fixes #4890
