### PR TITLE
documentation for test case metadata

### DIFF
--- a/doc/userguide/src/Appendices/AvailableSettings.rst
+++ b/doc/userguide/src/Appendices/AvailableSettings.rst
@@ -87,6 +87,8 @@ Exactly same settings are available when `creating tasks`_ in the Task section.
    +=================+========================================================+
    | [Documentation] | Used for specifying a `test case documentation`_.      |
    +-----------------+--------------------------------------------------------+
+   | [Metadata]      | Used for setting `free test metadata`_.                |
+   +-----------------+--------------------------------------------------------+
    | [Tags]          | Used for `tagging test cases`_.                        |
    +-----------------+--------------------------------------------------------+
    | [Setup]         | Used for specifying a `test setup`_.                   |

--- a/doc/userguide/src/CreatingTestData/CreatingTestCases.rst
+++ b/doc/userguide/src/CreatingTestData/CreatingTestCases.rst
@@ -78,6 +78,9 @@ below and explained later in this section.
 `[Documentation]`:setting:
     Used for specifying a `test case documentation`_.
 
+`[Metadata]`:setting:
+    Used for setting `free test metadata`_ as name-value pairs.
+
 `[Setup]`:setting:, `[Teardown]`:setting:
    Specify `test setup and teardown`_.
 
@@ -575,8 +578,45 @@ in that case they normally do not need any documentation. If the logic
 of the test case needs documenting, it is often a sign that keywords
 in the test case need better names and they are to be enhanced,
 instead of adding extra documentation. Finally, metadata, such as the
-environment and user information in the last example above, is often
-better specified using tags_.
+environment and user information in the last example above, can also
+be specified as `free test metadata`_ or using tags_, depending on the
+use case.
+
+Free test metadata
+------------------
+
+In addition to documentation, test cases can also have free metadata. This
+metadata is defined as name-value pairs using the :setting:`[Metadata]`
+setting in the test case, similarly as `free suite metadata`_ is defined
+for test suites.
+
+Name of the metadata is the first argument given to the :setting:`[Metadata]`
+setting and the remaining arguments specify its value. The value is handled
+similarly as `test case documentation`_, which means that it supports
+`HTML formatting`_ and variables_, and that longer values can be `split into
+multiple rows`__. A test case can have any number of :setting:`[Metadata]`
+settings, and each of them adds one name-value pair.
+
+__ `Dividing data to several rows`_
+
+.. sourcecode:: robotframework
+
+   *** Test Cases ***
+   Example
+       [Metadata]    Owner              John Doe
+       [Metadata]    Environment        Staging
+       [Metadata]    Longer Value
+       ...           Longer metadata values can be split into multiple
+       ...           rows. Also *simple* _formatting_ is supported.
+       No Operation
+
+Test metadata is shown in reports and logs similarly as test documentation.
+
+.. note:: Unlike `free suite metadata`_, test metadata does not have a
+          keyword for setting or updating it during execution, and there
+          is no dedicated automatic variable or command line option for it.
+
+.. note:: :setting:`[Metadata]` is new in Robot Framework 7.5.
 
 .. _test case tags:
 

--- a/doc/userguide/src/CreatingTestData/CreatingTestCases.rst
+++ b/doc/userguide/src/CreatingTestData/CreatingTestCases.rst
@@ -578,8 +578,43 @@ in that case they normally do not need any documentation. If the logic
 of the test case needs documenting, it is often a sign that keywords
 in the test case need better names and they are to be enhanced,
 instead of adding extra documentation. Finally, metadata, such as the
-environment and user information in the last example above, is often
-better specified using tags_.
+environment and user information in the last example above, can also
+be specified as `free test metadata`_ or using tags_, depending on the
+use case.
+
+Free test metadata
+------------------
+
+In addition to documentation, test cases can also have free metadata. This
+metadata is defined as name-value pairs using the :setting:`[Metadata]`
+setting in the test case, similarly as `free suite metadata`_ is defined
+for test suites.
+
+Name of the metadata is the first argument given to the :setting:`[Metadata]`
+setting and the remaining arguments specify its value. The value is handled
+similarly as `test case documentation`_, which means that it supports
+`HTML formatting`_ and variables_, and that longer values can be `split into
+multiple rows`__. A test case can have any number of :setting:`[Metadata]`
+settings, and each of them adds one name-value pair.
+
+__ `Dividing data to several rows`_
+
+.. sourcecode:: robotframework
+
+   *** Test Cases ***
+   Example
+       [Metadata]    Owner              John Doe
+       [Metadata]    Environment        Staging
+       [Metadata]    Longer Value
+       ...           Longer metadata values can be split into multiple
+       ...           rows. Also *simple* _formatting_ is supported.
+       No Operation
+
+Test metadata is shown in reports and logs similarly as test documentation.
+It is also stored in `output files`_ and is available to `listeners`_
+and other tools that process execution results.
+
+.. note:: :setting:`[Metadata]` is new in Robot Framework 7.5.
 
 .. _test case tags:
 

--- a/doc/userguide/src/CreatingTestData/CreatingTestCases.rst
+++ b/doc/userguide/src/CreatingTestData/CreatingTestCases.rst
@@ -611,10 +611,8 @@ __ `Dividing data to several rows`_
        No Operation
 
 Test metadata is shown in reports and logs similarly as test documentation.
-
-.. note:: Unlike `free suite metadata`_, test metadata does not have a
-          keyword for setting or updating it during execution, and there
-          is no dedicated automatic variable or command line option for it.
+It is also stored in `output files`_ and is available to `listeners`_
+and other tools that process execution results.
 
 .. note:: :setting:`[Metadata]` is new in Robot Framework 7.5.
 

--- a/doc/userguide/src/CreatingTestData/CreatingTestSuites.rst
+++ b/doc/userguide/src/CreatingTestData/CreatingTestSuites.rst
@@ -218,6 +218,9 @@ the command line with the :option:`--metadata` option.
 
 __ `Setting free suite metadata`_
 
+Individual test cases can have similar free metadata of their own, see
+`free test metadata`_ for more information.
+
 Suite setup and teardown
 ------------------------
 

--- a/doc/userguide/src/ExtendingRobotFramework/ListenerInterface.rst
+++ b/doc/userguide/src/ExtendingRobotFramework/ListenerInterface.rst
@@ -170,6 +170,8 @@ it. If that is needed, `listener version 3`_ can be used instead.
    |                  |                  |   unresolved. New in RF 3.2.                                   |
    |                  |                  | * `doc`: Test documentation.                                   |
    |                  |                  | * `tags`: Test tags as a list of strings.                      |
+   |                  |                  | * `metadata`: `Free test metadata`_ as a dictionary.           |
+   |                  |                  |   New in RF 7.5.                                               |
    |                  |                  | * `template`: The name of the template used for the test.      |
    |                  |                  |   An empty string if the test not templated.                   |
    |                  |                  | * `source`: An absolute path of the test case source file.     |
@@ -187,6 +189,7 @@ it. If that is needed, `listener version 3`_ can be used instead.
    |                  |                  | * `originalname`: Same as in `start_test`.                     |
    |                  |                  | * `doc`: Same as in `start_test`.                              |
    |                  |                  | * `tags`: Same as in `start_test`.                             |
+   |                  |                  | * `metadata`: Same as in `start_test`.                         |
    |                  |                  | * `template`: Same as in `start_test`.                         |
    |                  |                  | * `source`: Same as in `start_test`.                           |
    |                  |                  | * `lineno`: Same as in `start_test`.                           |

--- a/src/robot/model/metadata.py
+++ b/src/robot/model/metadata.py
@@ -19,7 +19,7 @@ from robot.utils import NormalizedDict
 
 
 class Metadata(NormalizedDict[str]):
-    """Free suite metadata as a mapping.
+    """Free suite or test metadata as a mapping.
 
     Keys are case, space, and underscore insensitive.
     """

--- a/src/robot/model/testcase.py
+++ b/src/robot/model/testcase.py
@@ -83,7 +83,10 @@ class TestCase(ModelObject, Generic[KW]):
 
     @setter
     def metadata(self, metadata: "Mapping[str, str] | None") -> Metadata:
-        """Test metadata as a :class:`~.model.metadata.Metadata` object."""
+        """Test metadata as a :class:`~.model.metadata.Metadata` object.
+
+        New in Robot Framework 7.5.
+        """
         return Metadata(metadata)
 
     @property


### PR DESCRIPTION
This pull request adds documentation for free metadata on test cases and updates the documentation and listener interface accordingly. The changes describe that test case metadata can be set, accessed, and is available in listener APIs, with documentation updated to show these new capabilities.

**Documentation Updates:**

* Updated user guide sections to document the new `[Metadata]` setting for test cases and explain its usage, including how to specify and access free test metadata.

**Listener Interface:**

* Extended the listener interface so that test case metadata is available in the arguments of relevant listener methods, with documentation specifying the new `metadata` field for test cases.