### PR TITLE
feat: added &{TEST METADATA} variable and Set Test Metadata

### DIFF
--- a/atest/robot/output/listener_interface/listener_v3.robot
+++ b/atest/robot/output/listener_interface/listener_v3.robot
@@ -79,7 +79,7 @@ Syslog messages can be changed
     Syslog Should Contain Match    2015-12-16 15:51:20.141000 | INFO \ | TESTS EXECUTION ENDED. STATISTICS:
 
 Library import
-    Stdout Should Contain    Imported library 'BuiltIn' with 107 keywords.
+    Stdout Should Contain    Imported library 'BuiltIn' with 109 keywords.
     Stdout Should Contain    Imported library 'String' with 32 keywords.
     ${tc} =   Get Test Case    Pass [start suite]
     Check Keyword Data    ${tc[0, 0]}    BuiltIn.Log    doc=Changed!    args=Hello says "\${who}"!, \${LEVEL1}

--- a/atest/robot/standard_libraries/builtin/log_variables.robot
+++ b/atest/robot/standard_libraries/builtin/log_variables.robot
@@ -86,10 +86,11 @@ Log Variables In Test
     Check Variable Message    \${SUITE_SOURCE} = *    pattern=yes
     Check Variable Message    \${TEMPDIR} = *    pattern=yes
     Check Variable Message    \${TEST_DOCUMENTATION} =
+    Check Variable Message    \&{TEST_METADATA} = { }
     Check Variable Message    \${TEST_NAME} = Log Variables
     Check Variable Message    \@{TEST_TAGS} = [ ]
     Check Variable Message    \${True} = *    pattern=yes
-    Length Should Be    ${kw.messages}    41
+    Length Should Be    ${kw.messages}    42
 
 Log Variables After Setting New Variables
     ${test} =    Check Test Case    Log Variables
@@ -133,11 +134,12 @@ Log Variables After Setting New Variables
     Check Variable Message    \${SUITE_SOURCE} = *    DEBUG    pattern=yes
     Check Variable Message    \${TEMPDIR} = *    DEBUG    pattern=yes
     Check Variable Message    \${TEST_DOCUMENTATION} =    DEBUG
+    Check Variable Message    \&{TEST_METADATA} = { }    DEBUG
     Check Variable Message    \${TEST_NAME} = Log Variables    DEBUG
     Check Variable Message    \@{TEST_TAGS} = [ ]    DEBUG
     Check Variable Message    \${True} = *    DEBUG    pattern=yes
     Check Variable Message    \${var} = Hello    DEBUG
-    Length Should Be    ${kw.messages}    44
+    Length Should Be    ${kw.messages}    45
 
 Log Variables In User Keyword
     ${test} =    Check Test Case    Log Variables
@@ -179,11 +181,12 @@ Log Variables In User Keyword
     Check Variable Message    \${SUITE_SOURCE} = *    pattern=yes
     Check Variable Message    \${TEMPDIR} = *    pattern=yes
     Check Variable Message    \${TEST_DOCUMENTATION} =
+    Check Variable Message    \&{TEST_METADATA} = { }
     Check Variable Message    \${TEST_NAME} = Log Variables
     Check Variable Message    \@{TEST_TAGS} = [ ]
     Check Variable Message    \${True} = *    pattern=yes
     Check Variable Message    \${ukvar} = Value of an uk variable
-    Length Should Be    ${kw.messages}    42
+    Length Should Be    ${kw.messages}    43
 
 List and dict variables failing during iteration
     Check Test Case    ${TEST NAME}

--- a/atest/robot/standard_libraries/builtin/set_test_metadata.robot
+++ b/atest/robot/standard_libraries/builtin/set_test_metadata.robot
@@ -1,0 +1,67 @@
+*** Settings ***
+Suite Setup       Run Tests    ${EMPTY}    standard_libraries/builtin/set_test_metadata.robot
+Resource          atest_resource.robot
+
+*** Test Cases ***
+Set new value
+    Metadata should have value    New metadata    Set in test
+    ${tc} =    Check Test Case    ${TESTNAME}
+    Check Log Message    ${tc[0, 0]}
+    ...    Set test metadata 'New metadata' to value 'Set in test'.
+
+Override existing value
+    Metadata should have value    Initial    New value
+    ${tc} =    Check Test Case    ${TESTNAME}
+    Check Log Message    ${tc[0, 0]}
+    ...    Set test metadata 'Initial' to value 'New value'.
+
+Names are case and space insensitive
+    Metadata should have value    My Name    final value
+    ${tc} =    Check Test Case    ${TESTNAME}
+    Check Log Message    ${tc[1, 0]}
+    ...    Set test metadata 'MYname' to value 'final value'.
+
+Append to value
+    Metadata should have value    To Append    Original is continued \n\ntwice!
+    Metadata should have value    Version    1.0/2.0/3.0
+    ${tc} =    Check Test Case    ${TESTNAME}
+    Check Log Message    ${tc[0, 0]}
+    ...    Set test metadata 'To Append' to value 'Original'.
+    Check Log Message    ${tc[4, 0]}
+    ...    Set test metadata 'TOAPPEND' to value 'Original is continued \n\ntwice!'.
+    Check Log Message    ${tc[10, 0]}
+    ...    Set test metadata 'ver sion' to value '1.0/2.0/3.0'.
+
+Non-ASCII and non-string names and values
+    Metadata should have value    42    1 päivä
+    ${tc} =    Check Test Case    ${TESTNAME}
+    Check Log Message    ${tc[0, 0]}
+    ...    Set test metadata '42' to value '1'.
+    Check Log Message    ${tc[2, 0]}
+    ...    Set test metadata '42' to value '1 päivä'.
+
+Modifying \${TEST METADATA} has no effect also after setting metadata
+    Check Test Case    ${TESTNAME}
+    Metadata should have value    Cannot be    set otherwise
+
+Set Task Metadata as alias for Set Test Metadata
+    Metadata should have value    Task    Value is continued
+    ${tc} =    Check Test Case    ${TESTNAME}
+    Check Log Message    ${tc[0, 0]}
+    ...    Set test metadata 'Task' to value 'Value'.
+
+Set in test setup
+    Metadata should have value    Setup    Value
+
+Set in test teardown
+    Metadata should have value    Teardown    Another value
+
+Metadata is test specific
+    ${tc} =    Check Test Case    ${TESTNAME}
+    Should Be Empty    ${tc.metadata}
+
+*** Keywords ***
+Metadata should have value
+    [Arguments]    ${name}    ${value}
+    ${tc} =    Check Test Case    ${TESTNAME}
+    Should Be Equal    ${tc.metadata['${name}']}    ${value}

--- a/atest/robot/variables/automatic_variables.robot
+++ b/atest/robot/variables/automatic_variables.robot
@@ -15,6 +15,16 @@ Test Documentation
     ${tc} =    Check Test Case    ${TEST NAME}
     Should Be Equal    ${tc.doc}    My doc.\nIn 2 lines! And with variable value!!
 
+Test Metadata
+    ${tc} =    Check Test Case    ${TEST NAME}
+    Should Be Equal    ${tc.metadata}[TeSt1]    Value
+    Should Be Equal    ${tc.metadata}[test2]    variable value
+
+Modifying \&{TEST METADATA} does not affect actual metadata test has
+    ${tc} =    Check Test Case    ${TEST NAME}
+    Should Be Equal    ${tc.metadata}[TeSt1]    Value
+    Dictionary Should Not Contain Key    ${tc.metadata}    NotSet
+
 Test Tags
     Check Test Tags    ${TEST NAME}    Force 1    Hello, world!    id-42    include this test    variable value
 

--- a/atest/testdata/standard_libraries/builtin/set_test_metadata.robot
+++ b/atest/testdata/standard_libraries/builtin/set_test_metadata.robot
@@ -1,0 +1,65 @@
+*** Settings ***
+Library           Collections
+
+*** Test Cases ***
+Set new value
+    Set Test Metadata    New metadata    Set in test
+    Metadata variable should have value    New metadata    Set in test
+
+Override existing value
+    [Metadata]    Initial    Value
+    Set Test Metadata    Initial    New value
+    Metadata variable should have value    Initial    New value
+
+Names are case and space insensitive
+    Set Test Metadata    My Name    overwritten
+    Set Test Metadata    MYname    final value
+    Metadata variable should have value    My Name    final value
+
+Append to value
+    Set Test Metadata    To Append    Original    append please
+    Metadata variable should have value    To Append    Original
+    Set Test Metadata    toappend    is continued    append please
+    Metadata variable should have value    To Append    Original is continued
+    Set Test Metadata    TOAPPEND    \n\ntwice!    append=please
+    Metadata variable should have value    To Append    Original is continued \n\ntwice!
+    Set Test Metadata    Version    1.0    append please    separator=,
+    Metadata variable should have value    Version    1.0
+    Set Test Metadata    version    2.0    append please    separator=/
+    Metadata variable should have value    Version    1.0/2.0
+    Set Test Metadata    ver sion    3.0    append please    separator=/
+    Metadata variable should have value    Version    1.0/2.0/3.0
+
+Non-ASCII and non-string names and values
+    Set Test Metadata    ${42}    ${1}
+    Metadata variable should have value    42    1
+    Set Test Metadata    42    päivä    append=kyllä
+    Metadata variable should have value    42    1 päivä
+
+Modifying \${TEST METADATA} has no effect also after setting metadata
+    [Documentation]    The variable changes but actual metadata does not
+    Set Test Metadata    Cannot be    set otherwise
+    Set To Dictionary    ${TEST METADATA}    Cannot be    really set this way
+    Metadata variable should have value    Cannot be    really set this way
+
+Set Task Metadata as alias for Set Test Metadata
+    Set Task Metadata    Task    Value
+    Metadata variable should have value    Task    Value
+    Set Task Metadata    task    is continued    append=yes
+    Metadata variable should have value    Task    Value is continued
+
+Set in test setup
+    [Setup]    Set Test Metadata    Setup    Value
+    Metadata variable should have value    Setup    Value
+
+Set in test teardown
+    No Operation
+    [Teardown]    Set Test Metadata    Teardown    Another value
+
+Metadata is test specific
+    Should Be Empty    ${TEST METADATA}
+
+*** Keywords ***
+Metadata variable should have value
+    [Arguments]    ${name}    ${value}
+    Should Be Equal    ${TEST METADATA['${name}']}    ${value}

--- a/atest/testdata/variables/automatic_variables/auto1.robot
+++ b/atest/testdata/variables/automatic_variables/auto1.robot
@@ -17,7 +17,8 @@ ${VARIABLE}          variable value
 ${EXP_SUITE_NAME}    Automatic Variables.Auto1
 ${EXP_SUITE_DOC}     This is suite documentation. With ${VARIABLE}.
 ${EXP_SUITE_META}    {'MeTa1': 'Value', 'meta2': '${VARIABLE}'}
-${EXP_SUITE_STATS}   17 tests, 15 passed, 2 failed
+${EXP_TEST_META}     {'TeSt1': 'Value', 'test2': '${VARIABLE}'}
+${EXP_SUITE_STATS}   19 tests, 17 passed, 2 failed
 @{LAST_TEST}         \&{OPTIONS}    PASS
 
 *** Test Cases ***
@@ -35,6 +36,25 @@ Test Documentation
     [Setup]       Should Be Equal    ${TEST DOCUMENTATION}    My doc.\nIn 2 lines! And with ${VARIABLE}!!
                   Should Be Equal    ${TEST DOCUMENTATION}    My doc.\nIn 2 lines! And with ${VARIABLE}!!
     [Teardown]    Should Be Equal    ${TEST DOCUMENTATION}    My doc.\nIn 2 lines! And with ${VARIABLE}!!
+
+Test Metadata
+    [Metadata]    TeSt1    Value
+    [Metadata]    test2    ${VARIABLE}
+    [Setup]    Test Metadata Should Be Correct    ${EXP_TEST_META}
+    Test Metadata Should Be Correct    ${EXP_TEST_META}
+    ${expected} =    Evaluate    ${EXP_TEST_META}
+    Should Be Equal    ${TEST METADATA}    ${expected}
+    ${result} =    Create Dictionary    &{TEST METADATA}
+    Should Be Equal    ${result}    ${expected}
+    [Teardown]    Test Metadata Should Be Correct    ${EXP_TEST_META}
+
+Modifying \&{TEST METADATA} does not affect actual metadata test has
+    [Documentation]    The variable is changed but not "real" metadata
+    [Metadata]    TeSt1    Value
+    Set To Dictionary    ${TEST METADATA}    Test1     not really set
+    Set To Dictionary    ${TEST METADATA}    NotSet    not really set
+    Test Metadata Should Be Correct
+    ...    {'TeSt1': 'not really set', 'NotSet': 'not really set'}
 
 Test Tags
     [Tags]    id-${42}    Hello, world!    ${VARIABLE}

--- a/atest/testdata/variables/automatic_variables/resource.robot
+++ b/atest/testdata/variables/automatic_variables/resource.robot
@@ -22,6 +22,7 @@ Check Variables In Suite Teardown
 
 Check Test Variables Do Not Exist
     Variable Should Not Exist    $TEST_NAME
+    Variable Should Not Exist    $TEST_METADATA
     Variable Should Not Exist    $TEST_STATUS
     Variable Should Not Exist    $TEST_MESSAGE
 
@@ -47,3 +48,8 @@ Suite Metadata Should Be Correct
     [Arguments]    ${expected}
     ${expected} =    Evaluate    ${expected}
     Dictionaries Should Be Equal    ${SUITE METADATA}    ${expected}
+
+Test Metadata Should Be Correct
+    [Arguments]    ${expected}
+    ${expected} =    Evaluate    ${expected}
+    Dictionaries Should Be Equal    ${TEST METADATA}    ${expected}

--- a/doc/userguide/src/CreatingTestData/Variables.rst
+++ b/doc/userguide/src/CreatingTestData/Variables.rst
@@ -1594,6 +1594,10 @@ can be changed dynamically using keywords from the `BuiltIn`_ library.
    |                        | dynamically using using :name:`Set Test Documentation`|            |
    |                        | keyword.                                              |            |
    +------------------------+-------------------------------------------------------+------------+
+   | &{TEST METADATA}       | The free metadata of the current test case. Can be    | Test case  |
+   |                        | set using :name:`Set Test Metadata` keyword.          |            |
+   |                        | New in Robot Framework 7.5.                           |            |
+   +------------------------+-------------------------------------------------------+------------+
    | ${TEST STATUS}         | The status of the current test case, either PASS or   | `Test      |
    |                        | FAIL.                                                 | teardown`_ |
    +------------------------+-------------------------------------------------------+------------+

--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -4855,6 +4855,8 @@ class _Misc(_BuiltInBase):
         `${SUITE METADATA}` in a Python dictionary. Notice that modifying this
         variable directly has no effect on the actual metadata the suite has.
 
+        See [Set Test Metadata] if you want to set metadata for a single test.
+
         The `separator` argument is new in Robot Framework 7.2.
         """
         if not isinstance(name, str):

--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -4734,6 +4734,75 @@ class _Misc(_BuiltInBase):
         self._variables.set_test("${TEST_DOCUMENTATION}", test.doc)
         logger.info(f"Set test documentation to:\n{test.doc}")
 
+    def set_test_metadata(
+        self,
+        name: str,
+        value: str,
+        append: bool = False,
+        separator: str = " ",
+    ):
+        """Sets metadata for the current test case.
+
+        Args:
+            name: The name of the metadata to set.
+            value: The metadata value.
+            append: If true, the given `value` is added after the earlier
+              value instead of overwriting it.
+            separator: The separator to use between the old and the new
+              value when appending.
+
+        The metadata of the current test is available as a built-in variable
+        `${TEST METADATA}` in a Python dictionary. Notice that modifying this
+        variable directly has no effect on the actual metadata the test has.
+
+        Metadata names are case, space, and underscore insensitive. This
+        keyword can not be used in suite setup or suite teardown.
+
+        When creating automated tasks, not tests, it is possible to use
+        [Set Task Metadata]. See also [Set Suite Metadata].
+
+        New in Robot Framework 7.5.
+        """
+        test = self._context.test
+        if not test:
+            raise RuntimeError(
+                "'Set Test Metadata' keyword cannot be used in "
+                "suite setup or teardown."
+            )
+        if not isinstance(name, str):
+            name = str(name)
+        metadata = test.metadata
+        original = metadata.get(name, "")
+        metadata[name] = self._get_new_text(
+            original, value, append, separator=separator
+        )
+        self._variables.set_test("${TEST_METADATA}", metadata.copy())
+        logger.info(f"Set test metadata '{name}' to value '{metadata[name]}'.")
+
+    def set_task_metadata(
+        self,
+        name: str,
+        value: str,
+        append: bool = False,
+        separator: str = " ",
+    ):
+        """Sets metadata for the current task.
+
+        Args:
+            name: The name of the metadata to set.
+            value: The metadata value.
+            append: If true, the given `value` is added after the earlier
+              value instead of overwriting it.
+            separator: The separator to use between the old and the new
+              value when appending.
+
+        This is an alias for [Set Test Metadata] that is more applicable when
+        creating tasks, not tests.
+
+        New in Robot Framework 7.5.
+        """
+        self.set_test_metadata(name, value, append, separator)
+
     def set_suite_documentation(
         self,
         doc: str,

--- a/src/robot/running/context.py
+++ b/src/robot/running/context.py
@@ -269,6 +269,7 @@ class _ExecutionContext:
         self.namespace.start_test()
         self.variables.set_test("${TEST_NAME}", result.name)
         self.variables.set_test("${TEST_DOCUMENTATION}", result.doc)
+        self.variables.set_test("${TEST_METADATA}", result.metadata.copy())
         self.variables.set_test("@{TEST_TAGS}", list(result.tags))
         self.output.start_test(data, result)
 


### PR DESCRIPTION
This pull request adds the built-in variable `${TEST_METADATA}` and the keywords `Set Test Metadata` and `Set Task Metadata` to Robot Framework. These changes allow users to set and access test-specific metadata dynamically during test execution.

The most important changes are:

### New Features

* Added the `${TEST_METADATA}` variable, which exposes the current test's metadata as a dictionary and is updated at test start and when metadata changes.
* Introduced the `Set Test Metadata` and `Set Task Metadata` keywords in `BuiltIn.py` to allow setting and appending metadata for the current test/task, with options for case/space/underscore-insensitive names and custom separators.

### Documentation

* Documented the new `${TEST_METADATA}` variable and its usage in the user guide, including its availability and the new keywords.