### PR TITLE
Add ${EXECUTION ID} automatic variable and --executionid option (#2743)

### DIFF
--- a/atest/robot/variables/builtin_variables.robot
+++ b/atest/robot/variables/builtin_variables.robot
@@ -53,3 +53,6 @@ $CURDIR
 
 \${LOG LEVEL}
     Check Test Case    ${TESTNAME}
+
+\${EXECUTION ID}
+    Check Test Case    ${TESTNAME}

--- a/atest/testdata/variables/builtin_variables.robot
+++ b/atest/testdata/variables/builtin_variables.robot
@@ -126,3 +126,8 @@ $CURDIR
     Set Log Level    NONE
     Should Be Equal    ${LOG_LEVEL}    NONE
     [Teardown]    Set Log Level    INFO
+
+\${EXECUTION ID}
+    Should Not Be Empty    ${EXECUTION ID}
+    Should Match Regexp    ${EXECUTION ID}    (?i)^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$
+    Should Be Equal    ${EXECUTION ID}    ${SUITE METADATA}[Execution ID]

--- a/doc/userguide/src/CreatingTestData/Variables.rst
+++ b/doc/userguide/src/CreatingTestData/Variables.rst
@@ -1651,6 +1651,11 @@ can be changed dynamically using keywords from the `BuiltIn`_ library.
    | ${DEBUG FILE}          | An absolute path to the `debug file`_ as a string or  | Everywhere |
    |                        | a string `NONE` if the debug file is not created.     |            |
    +------------------------+-------------------------------------------------------+------------+
+   | ${EXECUTION ID}        | Unique ID for the current execution. Same value as    | Everywhere |
+   |                        | the ``Execution ID`` suite metadata. Given with the   |            |
+   |                        | :option:`--executionid` option or, by default, a      |            |
+   |                        | generated UUID. New in RF 7.5.                        |            |
+   +------------------------+-------------------------------------------------------+------------+
    | &{OPTIONS}             | A dictionary exposing command line options. The       | Everywhere |
    |                        | dictionary keys match the command line options and    |            |
    |                        | can be accessed both like `${OPTIONS}[key]` and       |            |

--- a/src/robot/conf/settings.py
+++ b/src/robot/conf/settings.py
@@ -21,6 +21,7 @@ import sys
 import warnings
 from datetime import datetime
 from pathlib import Path
+from uuid import uuid4
 
 from robot.errors import DataError, FrameworkError
 from robot.output import LOGGER, LogLevel
@@ -502,8 +503,10 @@ class RobotSettings(_BaseSettings):
         "ConsoleMarkers"     : ("consolemarkers", "AUTO"),
         "DebugFile"          : ("debugfile", None),
         "Language"           : ("language", []),
+        "ExecutionId"        : ("executionid", None),
     }  # fmt: skip
     _languages = None
+    _execution_id = None
 
     def get_rebot_settings(self):
         settings = RebotSettings()
@@ -552,6 +555,18 @@ class RobotSettings(_BaseSettings):
             except DataError as err:
                 self._raise_invalid("Language", err)
         return self._languages
+
+    @property
+    def execution_id(self):
+        """Unique ID for the current execution.
+
+        Given with the ``--executionid`` option or, by default, a generated
+        UUID. The value is generated only once and cached so that it stays the
+        same throughout the execution.
+        """
+        if self._execution_id is None:
+            self._execution_id = self["ExecutionId"] or str(uuid4())
+        return self._execution_id
 
     @property
     def suite_config(self):

--- a/src/robot/run.py
+++ b/src/robot/run.py
@@ -118,6 +118,12 @@ Options
  -M --metadata name:value *  Set metadata of the top level suite. Value can
                           contain formatting and be read from a file similarly
                           as --doc. Example: --metadata Version:1.2
+    --executionid id      Unique ID for the current execution. By default a
+                          random UUID is generated. The ID is available during
+                          execution as the automatic variable ${EXECUTION ID}
+                          and is set as metadata `Execution ID` of the top level
+                          suite so that it is visible in logs and reports and
+                          stored in the output file.
  -G --settag tag *        Sets given tag(s) to all executed tests.
  -t --test name *         Select tests by name or by long name containing also
                           parent suite name like `Parent.Test`. Name is case
@@ -485,6 +491,11 @@ class RobotFramework(Application):
             )
             suite.visit(modifier)
         suite.configure(**settings.suite_config)
+        # Expose the execution ID as top level suite metadata so that it is
+        # visible in logs and reports and stored in the output file. An explicit
+        # `--metadata` with the same name (set above) takes precedence.
+        if "Execution ID" not in suite.metadata:
+            suite.metadata["Execution ID"] = settings.execution_id
         settings.rpa = suite.validate_execution_mode()
         with pyloggingconf.robot_handler_enabled(settings.log_level):
             old_max_error_lines = text.MAX_ERROR_LINES

--- a/src/robot/variables/scopes.py
+++ b/src/robot/variables/scopes.py
@@ -246,6 +246,7 @@ class GlobalVariables(Variables):
             ("${LOG_FILE}", str(settings.log or "NONE")),
             ("${DEBUG_FILE}", str(settings.debug_file or "NONE")),
             ("${LOG_LEVEL}", settings.log_level),
+            ("${EXECUTION_ID}", settings.execution_id),
             ("${PREV_TEST_NAME}", ""),
             ("${PREV_TEST_STATUS}", ""),
             ("${PREV_TEST_MESSAGE}", ""),

--- a/utest/conf/test_settings.py
+++ b/utest/conf/test_settings.py
@@ -2,6 +2,7 @@ import re
 import unittest
 from os.path import abspath, dirname, join, normpath
 from pathlib import Path
+from uuid import UUID
 
 from robot.conf.settings import _BaseSettings, RebotSettings, RobotSettings
 from robot.errors import DataError
@@ -211,6 +212,23 @@ class TestRobotAndRebotSettings(unittest.TestCase):
 
     def _verify_invalid_log_level(self, input):
         self.assertRaises(DataError, RobotSettings, {"loglevel": input})
+
+
+class TestExecutionId(unittest.TestCase):
+
+    def test_default_is_generated_uuid(self):
+        # UUID(...) raises ValueError if the value is not a valid UUID.
+        UUID(RobotSettings().execution_id)
+
+    def test_can_be_given_from_command_line(self):
+        assert_equal(RobotSettings(executionid="my-id").execution_id, "my-id")
+
+    def test_is_cached(self):
+        settings = RobotSettings()
+        assert_equal(settings.execution_id, settings.execution_id)
+
+    def test_generated_ids_are_unique(self):
+        assert_true(RobotSettings().execution_id != RobotSettings().execution_id)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements #2743.

Adds a unique **execution ID** to each Robot Framework run.

## What it does
- Exposes the ID as the `${EXECUTION ID}` automatic variable.
- Stores it as `Execution ID` metadata on the top level suite, so it is visible in logs and reports and saved in `output.xml` (and carried over to `rebot` generated reports).
- By default the ID is a random UUID (`uuid.uuid4()`).
- Adds a `--executionid` option to set the ID explicitly, e.g. to share a common ID across parallel executions (pabot) or to use an application specific scheme.

```robotframework
*** Test Cases ***
Example
    Log    Current execution: ${EXECUTION ID}
```

```
robot --executionid 20260818-build-42 tests/
```

## Design
This follows the design @pekkaklarck outlined in #2743: generate a UUID, allow overriding it from the command line, add it as top level suite metadata, and expose it as a global variable. Exposing the existing internal test/suite IDs as automatic variables — also proposed in that issue — is intentionally left out of scope and can be handled separately.

An explicit `--metadata "Execution ID:..."` still takes precedence over the automatically added metadata.

## Tests & docs
- Unit tests for the new setting and `execution_id` property (`utest/conf/test_settings.py`).
- Acceptance test for the variable and the suite metadata (`atest/testdata|robot/variables/builtin_variables.robot`).
- User Guide: documented the new `${EXECUTION ID}` automatic variable; the `--executionid` option is documented in `--help`.

Happy to adjust the variable/metadata naming, the default ID scheme, or the scope based on your feedback.
