### PR TITLE
Add Listener API v3 pre-import callbacks

### DIFF
--- a/atest/robot/output/listener_interface/listening_imports.robot
+++ b/atest/robot/output/listener_interface/listening_imports.robot
@@ -12,6 +12,7 @@ All imports are usable
 
 Listen Imports
     Init Expect
+    Start Expect    Library    BuiltIn    []
     Expect
     ...    Library
     ...    BuiltIn
@@ -19,11 +20,14 @@ Listen Imports
     ...    importer: None
     ...    originalname: BuiltIn
     ...    source: //BuiltIn.py
+    Start Expect    Resource    resource_with_imports.robot    []
+    Start Expect    Resource    another_resource.robot    []
     Expect
     ...    Resource
     ...    another_resource
     ...    importer: //resource_with_imports.robot
     ...    source: //another_resource.robot
+    Start Expect    Library    Process    []
     Expect
     ...    Library
     ...    Process
@@ -36,6 +40,7 @@ Listen Imports
     ...    resource_with_imports
     ...    importer: //imports.robot
     ...    source: //resource_with_imports.robot
+    Start Expect    Library    String    []
     Expect
     ...    Library
     ...    String
@@ -43,6 +48,7 @@ Listen Imports
     ...    importer: //imports.robot
     ...    originalname: String
     ...    source: //String.py
+    Start Expect    Library    local_lib.py    [\${2}]
     Expect
     ...    Library
     ...    Aliased
@@ -50,6 +56,7 @@ Listen Imports
     ...    importer: //imports.robot
     ...    originalname: local_lib
     ...    source: //local_lib.py
+    Start Expect    Library    pythonmodule    []
     Expect
     ...    Library
     ...    pythonmodule
@@ -57,18 +64,25 @@ Listen Imports
     ...    importer: //imports.robot
     ...    originalname: pythonmodule
     ...    source: //pythonmodule/__init__.py
+    Start Expect    Variables    vars.py    [name, value]
     Expect
     ...    Variables
     ...    vars.py
     ...    args: [name, value]
     ...    importer: //imports.robot
     ...    source: //vars.py
+    Start Expect    Variables    vars.py    [name, value]
+    Start Expect    Variables    vars.py    []
     Expect
     ...    Variables
     ...    vars.py
     ...    args: []
     ...    importer: //imports.robot
     ...    source: //vars.py
+    Start Expect    Resource    resource that does not exist and fails    []
+    Start Expect    Library    LibraryThatDoesNotExist    []
+    Start Expect    Variables    variables which dont exist.py    []
+    Start Expect    Library    OperatingSystem    []
     Expect
     ...    Library
     ...    OperatingSystem
@@ -76,11 +90,13 @@ Listen Imports
     ...    importer: //imports.robot
     ...    originalname: OperatingSystem
     ...    source: //OperatingSystem.py
+    Start Expect    Resource    //imports/dynamically_imported_resource.robot    []
     Expect
     ...    Resource
     ...    dynamically_imported_resource
     ...    importer: //imports.robot
     ...    source: //dynamically_imported_resource.robot
+    Start Expect    Variables    //imports/vars.py    [new, args]
     Expect
     ...    Variables
     ...    vars.py
@@ -109,6 +125,14 @@ Expect
     ...    Imported ${type}
     ...    name: ${name}
     ...    @{attrs}
+    Set test variable    @{EXPECTED}    @{EXPECTED}    ${entry}
+
+Start Expect
+    [Arguments]    ${type}    ${name}    ${args}
+    ${entry} =    Catenate    SEPARATOR=\n\t
+    ...    Started ${type}
+    ...    name: ${name}
+    ...    args: ${args}
     Set test variable    @{EXPECTED}    @{EXPECTED}    ${entry}
 
 Verify Expected

--- a/atest/testresources/listeners/ListenImports.py
+++ b/atest/testresources/listeners/ListenImports.py
@@ -2,19 +2,56 @@ import os
 
 
 class ListenImports:
-    ROBOT_LISTENER_API_VERSION = 2
+    ROBOT_LISTENER_API_VERSION = 3
 
     def __init__(self, imports):
         self.imports = open(imports, "w", encoding="UTF-8")
 
-    def library_import(self, name, attrs):
-        self._imported("Library", name, attrs)
+    def start_library_import(self, importer):
+        self._started("Library", importer)
 
-    def resource_import(self, name, attrs):
-        self._imported("Resource", name, attrs)
+    def start_resource_import(self, importer):
+        self._started("Resource", importer)
 
-    def variables_import(self, name, attrs):
-        self._imported("Variables", name, attrs)
+    def start_variables_import(self, importer):
+        self._started("Variables", importer)
+
+    def library_import(self, library, importer):
+        self._imported(
+            "Library",
+            library.name,
+            {
+                "args": list(importer.args),
+                "importer": str(importer.source),
+                "originalname": library.real_name,
+                "source": str(library.source or ""),
+            },
+        )
+
+    def resource_import(self, resource, importer):
+        self._imported(
+            "Resource",
+            resource.name,
+            {"importer": str(importer.source), "source": str(resource.source)},
+        )
+
+    def variables_import(self, attrs, importer):
+        self._imported(
+            "Variables",
+            attrs["name"],
+            {
+                "args": list(attrs["args"]),
+                "importer": str(importer.source),
+                "source": str(attrs["source"]),
+            },
+        )
+
+    def _started(self, import_type, importer):
+        self.imports.write(
+            f"Started {import_type}\n"
+            f"\tname: {self._pretty(importer.name)}\n"
+            f"\targs: {self._pretty(list(importer.args))}\n"
+        )
 
     def _imported(self, import_type, name, attrs):
         self.imports.write(f"Imported {import_type}\n\tname: {name}\n")

--- a/src/robot/api/interfaces.py
+++ b/src/robot/api/interfaces.py
@@ -959,6 +959,33 @@ class ListenerV3:
         if it is enabled.
         """
 
+    def start_library_import(self, importer: running.Import):
+        """Called before a library is imported.
+
+        ``importer`` contains information about the library to be imported and
+        can be modified to change its name, arguments, or alias.
+
+        New in Robot Framework 7.6.
+        """
+
+    def start_resource_import(self, importer: running.Import):
+        """Called before a resource file is imported.
+
+        ``importer`` contains information about the resource file to be
+        imported and can be modified to change its name before importing.
+
+        New in Robot Framework 7.6.
+        """
+
+    def start_variables_import(self, importer: running.Import):
+        """Called before a variable file is imported.
+
+        ``importer`` contains information about the variable file to be
+        imported and can be modified to change its name or arguments.
+
+        New in Robot Framework 7.6.
+        """
+
     def library_import(self, library: running.TestLibrary, importer: running.Import):
         """Called after a library has been imported.
 

--- a/src/robot/output/listeners.py
+++ b/src/robot/output/listeners.py
@@ -267,6 +267,9 @@ class ListenerV3Facade(ListenerFacade):
         self._log_message = get("log_message")
         self.message = get("message")
         # Imports
+        self.start_library_import = get("start_library_import")
+        self.start_resource_import = get("start_resource_import")
+        self.start_variables_import = get("start_variables_import")
         self.library_import = get("library_import")
         self.resource_import = get("resource_import")
         self.variables_import = get("variables_import")

--- a/src/robot/output/logger.py
+++ b/src/robot/output/logger.py
@@ -420,6 +420,18 @@ class Logger(AbstractLogger):
         for logger in self.end_loggers:
             logger.end_error(data, result)
 
+    def start_library_import(self, importer):
+        for logger in self.start_loggers:
+            logger.start_library_import(importer)
+
+    def start_resource_import(self, importer):
+        for logger in self.start_loggers:
+            logger.start_resource_import(importer)
+
+    def start_variables_import(self, importer):
+        for logger in self.start_loggers:
+            logger.start_variables_import(importer)
+
     def library_import(self, library, importer):
         for logger in self:
             logger.library_import(library, importer)

--- a/src/robot/output/loggerapi.py
+++ b/src/robot/output/loggerapi.py
@@ -249,6 +249,15 @@ class LoggerApi:
     def imported(self, import_type: str, name: str, attrs):
         pass
 
+    def start_library_import(self, importer: "running.Import"):
+        pass
+
+    def start_resource_import(self, importer: "running.Import"):
+        pass
+
+    def start_variables_import(self, importer: "running.Import"):
+        pass
+
     def library_import(
         self,
         library: "running.TestLibrary",

--- a/src/robot/running/namespace.py
+++ b/src/robot/running/namespace.py
@@ -94,6 +94,7 @@ class Namespace:
         return owner, owner.lineno
 
     def _import_resource(self, import_, overwrite=False):
+        LOGGER.start_resource_import(import_)
         path = self._resolve_name(import_)
         self._validate_not_importing_init_file(path)
         if overwrite or path not in self._kw_store.resources:
@@ -119,6 +120,7 @@ class Namespace:
         self._import_variables(import_, overwrite=overwrite)
 
     def _import_variables(self, import_, overwrite=False):
+        LOGGER.start_variables_import(import_)
         path = self._resolve_name(import_)
         args = self._resolve_args(import_)
         if overwrite or (path, args) not in self._imported_variable_files:
@@ -140,6 +142,8 @@ class Namespace:
         self._import_library(import_)
 
     def _import_library(self, import_, notify=True):
+        if notify:
+            LOGGER.start_library_import(import_)
         name = self._resolve_name(import_)
         lib = IMPORTER.import_library(name, import_.args, import_.alias, self.variables)
         if lib.name in self._kw_store.libraries:

--- a/src/robot/utils/text.py
+++ b/src/robot/utils/text.py
@@ -134,11 +134,19 @@ def split_args_from_name_or_path(name):
     The separator can be either colon ``:`` or semicolon ``;``. If both are used,
     the first one is considered to be the separator.
     """
-    if os.path.exists(name):
-        return os.path.abspath(name), []
     if isinstance(name, Path):
         name = str(name)
     index = _get_arg_separator_index_from_name_or_path(name)
+    windows_path_with_args = (
+        os.sep == "\\"
+        and len(name) > 2
+        and name[1] == ":"
+        and name[2:3] in ("/", "\\")
+        and index > 1
+        and name[index] == ":"
+    )
+    if os.path.exists(name) and not windows_path_with_args:
+        return os.path.abspath(name), []
     if index == -1:
         return name, []
     args = name[index + 1 :].split(name[index])

--- a/utest/output/test_listeners_issue5667.py
+++ b/utest/output/test_listeners_issue5667.py
@@ -1,0 +1,53 @@
+import unittest
+
+from robot.output.listeners import ListenerFacade
+from robot.output.logger import Logger
+from robot.output.loggerapi import LoggerApi
+from robot.running.resourcemodel import Import
+
+
+class TestPreImportListenerFacade(unittest.TestCase):
+
+    def test_listener_v3_exposes_pre_import_events_with_importer(self):
+        class Listener:
+            ROBOT_LISTENER_API_VERSION = 3
+
+            def start_library_import(self, importer):
+                importer.name = "ChangedLibrary"
+
+            def start_resource_import(self, importer):
+                importer.name = "changed.resource"
+
+            def start_variables_import(self, importer):
+                importer.args = ("changed",)
+
+        listener = ListenerFacade.create(Listener())
+        library = Import(Import.LIBRARY, "OriginalLibrary")
+        resource = Import(Import.RESOURCE, "original.resource")
+        variables = Import(Import.VARIABLES, "original.py", ("original",))
+
+        listener.start_library_import(library)
+        listener.start_resource_import(resource)
+        listener.start_variables_import(variables)
+
+        assert library.name == "ChangedLibrary"
+        assert resource.name == "changed.resource"
+        assert variables.args == ("changed",)
+
+
+class TestLoggerPreImport(unittest.TestCase):
+
+    def test_logger_forwards_pre_import_event_to_registered_logger(self):
+        received = []
+
+        class LoggerUnderTest(LoggerApi):
+            def start_library_import(self, importer):
+                received.append(importer)
+
+        logger = Logger(register_console_logger=False)
+        logger.register_logger(LoggerUnderTest())
+        importer = Import(Import.LIBRARY, "Library")
+
+        logger.start_library_import(importer)
+
+        self.assertEqual(received, [importer])

--- a/utest/running/test_namespace_issue5667.py
+++ b/utest/running/test_namespace_issue5667.py
@@ -1,0 +1,139 @@
+import unittest
+
+from robot.running import namespace
+from robot.running.namespace import Namespace
+from robot.running.resourcemodel import Import
+
+
+class FakeVariables:
+
+    def replace_string(self, value):
+        return value
+
+    def replace_list(self, values):
+        return list(values)
+
+    def set_from_variable_section(self, variables, overwrite):
+        pass
+
+    def set_from_file(self, path, args, overwrite):
+        pass
+
+
+class FakeKeywordStore:
+
+    def __init__(self):
+        self.libraries = {}
+        self.resources = {}
+
+
+class FakeScopeManager:
+
+    def start_suite(self):
+        pass
+
+
+class FakeLibrary:
+
+    name = "ImportedLibrary"
+    real_name = "OriginalLibrary"
+    source = None
+
+    def __init__(self):
+        self.init = type("Init", (), {"positional": (), "named": {}})()
+        self.scope_manager = FakeScopeManager()
+
+
+class FakeResource:
+
+    name = "changed.resource"
+    source = None
+    variables = ()
+    imports = ()
+
+
+class FakeImporter:
+
+    def __init__(self, events):
+        self.events = events
+
+    def import_library(self, name, args, alias, variables):
+        self.events.append(("library", name, tuple(args), alias))
+        return FakeLibrary()
+
+    def import_resource(self, path, languages):
+        self.events.append(("resource", path))
+        return FakeResource()
+
+
+class PreImportLogger:
+
+    def __init__(self, events):
+        self.events = events
+
+    def start_library_import(self, importer):
+        self.events.append("start_library")
+        importer.name = "ChangedLibrary"
+        importer.args = ("changed-arg",)
+        importer.alias = "ChangedAlias"
+
+    def start_resource_import(self, importer):
+        self.events.append("start_resource")
+        importer.name = "changed.resource"
+
+    def start_variables_import(self, importer):
+        self.events.append("start_variables")
+        importer.name = "changed.py"
+        importer.args = ("changed-arg",)
+
+    def library_import(self, library, importer):
+        self.events.append("end_library")
+
+    def resource_import(self, resource, importer):
+        self.events.append("end_resource")
+
+    def variables_import(self, variables, importer):
+        self.events.append("end_variables")
+
+
+def _namespace(events):
+    ns = Namespace.__new__(Namespace)
+    ns.variables = FakeVariables()
+    ns.languages = object()
+    ns._kw_store = FakeKeywordStore()
+    ns._imported_variable_files = namespace.ImportCache()
+    ns._suite_name = "suite"
+    ns._running_test = False
+    ns._resolve_name = lambda import_: import_.name
+    ns._resolve_args = lambda import_: tuple(import_.args)
+    return ns
+
+
+class TestNamespacePreImport(unittest.TestCase):
+
+    def test_pre_import_events_mutate_all_import_types_before_import(self):
+        events = []
+        original_logger = namespace.LOGGER
+        original_importer = namespace.IMPORTER
+        namespace.LOGGER = PreImportLogger(events)
+        namespace.IMPORTER = FakeImporter(events)
+        try:
+            ns = _namespace(events)
+
+            ns._import_library(Import(Import.LIBRARY, "OriginalLibrary", ("original",), "OriginalAlias"))
+            ns._import_resource(Import(Import.RESOURCE, "original.resource"))
+            ns._import_variables(Import(Import.VARIABLES, "original.py", ("original",)))
+
+            self.assertEqual(events, [
+                "start_library",
+                ("library", "ChangedLibrary", ("changed-arg",), "ChangedAlias"),
+                "end_library",
+                "start_resource",
+                ("resource", "changed.resource"),
+                "end_resource",
+                "start_variables",
+                "end_variables",
+            ])
+        finally:
+            namespace.LOGGER = original_logger
+            namespace.IMPORTER = original_importer

--- a/utest/utils/test_text.py
+++ b/utest/utils/test_text.py
@@ -339,6 +339,33 @@ class TestSplitArgsFromNameOrPath(unittest.TestCase):
         finally:
             os.remove(path)
 
+    def test_existing_windows_path_with_args(self):
+        if os.sep != "\\":
+            return
+        root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+        path = os.path.join(root, "atest", "testresources", "consoles", "CustomConsole.py")
+        path_with_parent_segments = os.path.join(
+            root,
+            "utest",
+            "output",
+            "..",
+            "..",
+            "atest",
+            "testresources",
+            "consoles",
+            "CustomConsole.py",
+        )
+        self.verify(path_with_parent_segments + ":arg", (path, ["arg"]))
+
+        path_with_semicolon = os.path.join(
+            root, "robot-framework-unit-test-file-12q3405909qasf;part.py"
+        )
+        open(path_with_semicolon, "w", encoding="ASCII").close()
+        try:
+            self.verify(path_with_semicolon, (path_with_semicolon, []))
+        finally:
+            os.remove(path_with_semicolon)
+
     def test_existing_path_with_colons(self):
         # Colons aren't allowed in Windows paths (other than in "c:")
         if os.sep == "\\":


### PR DESCRIPTION
## Summary

- Add Listener API v3 `start_*_import` callbacks for libraries, resources, and variable files.
- Pass the mutable import model before name/argument resolution so listeners can change the import target, arguments, and library alias.
- Fix Windows path-plus-arguments parsing when an existing path contains parent segments; this restores the custom-console logger regression.

## Tests

- `python -m pytest utest\\output utest\\running\\test_namespace.py utest\\utils\\test_text.py -q` — 181 passed, 3 existing collection warnings.
- `python -m unittest utest.output.test_listeners_issue5667 utest.running.test_namespace_issue5667` — 3 passed.
- `atest/run.py --exclude no-ci atest/robot/output/listener_interface/listening_imports.robot` — 3 passed.
- `python -m compileall` on changed sources and tests — passed.
- Ruff on new tests and parser regression — passed.

The implementation follows Option 1 described in #5667 and leaves existing
after-import events unchanged.

Closes #5667
