### PR TITLE
Report: Rework test details table layout 

### DIFF
--- a/src/robot/htmldata/rebot/log.css
+++ b/src/robot/htmldata/rebot/log.css
@@ -208,6 +208,15 @@
 .metadata td {
     vertical-align: top;
 }
+.metadata .tags {
+    display: flex;
+    flex-wrap: wrap;
+}
+.metadata .tags .label {
+    margin: 0 0.3em 0.3em 0;
+    font-size: 1em;
+    letter-spacing: normal;
+}
 .keyword-metadata {
     font-size: 0.9em;
 }

--- a/src/robot/htmldata/rebot/log.html
+++ b/src/robot/htmldata/rebot/log.html
@@ -102,10 +102,6 @@ function popFromIterator(iterator, upTo) {
     return result;
 }
 
-function tagList(tags) {
-    return typeof tags === 'string' ? tags.split(', ') : tags;
-}
-
 function makeElementVisible(id) {
     window.testdata.ensureLoaded(id, function (ids) {
         util.map(ids, expandElementWithId);
@@ -346,10 +342,10 @@ function addExecutionLog(main) {
           <td class="doc">{{html doc()}}</td>
         </tr>
         {{/if}}
-        {{if tags}}
+        {{if tags.length}}
         <tr>
           <th>Tags:</th>
-          <td><div class="tags">{{each tagList(tags)}}<span class="label">{{html $value}}</span>{{/each}}</div></td>
+          <td><div class="tags">{{each tags}}<span class="label">{{html $value}}</span>{{/each}}</div></td>
         </tr>
         {{/if}}
         {{if timeout}}

--- a/src/robot/htmldata/rebot/log.html
+++ b/src/robot/htmldata/rebot/log.html
@@ -289,7 +289,7 @@ function addExecutionLog(main) {
         {{if tags.length}}
         <tr>
           <th>Tags:</th>
-          <td>{{html tags.join(', ')}}</td>
+          <td><div class="tags">{{each tags}}<span class="label">{{html $value}}</span>{{/each}}</div></td>
         </tr>
         {{/if}}
         {{if timeout}}
@@ -345,7 +345,7 @@ function addExecutionLog(main) {
         {{if tags}}
         <tr>
           <th>Tags:</th>
-          <td>{{html tags}}</td>
+          <td><div class="tags">{{each tags}}<span class="label">{{html $value}}</span>{{/each}}</div></td>
         </tr>
         {{/if}}
         {{if timeout}}

--- a/src/robot/htmldata/rebot/log.html
+++ b/src/robot/htmldata/rebot/log.html
@@ -102,6 +102,10 @@ function popFromIterator(iterator, upTo) {
     return result;
 }
 
+function tagList(tags) {
+    return typeof tags === 'string' ? tags.split(', ') : tags;
+}
+
 function makeElementVisible(id) {
     window.testdata.ensureLoaded(id, function (ids) {
         util.map(ids, expandElementWithId);
@@ -345,7 +349,7 @@ function addExecutionLog(main) {
         {{if tags}}
         <tr>
           <th>Tags:</th>
-          <td><div class="tags">{{each tags}}<span class="label">{{html $value}}</span>{{/each}}</div></td>
+          <td><div class="tags">{{each tagList(tags)}}<span class="label">{{html $value}}</span>{{/each}}</div></td>
         </tr>
         {{/if}}
         {{if timeout}}

--- a/src/robot/htmldata/rebot/report.css
+++ b/src/robot/htmldata/rebot/report.css
@@ -233,6 +233,16 @@ input[type='submit']:hover, input[type='button']:hover {
 .details-col-tags {
     min-width: 10em;
 }
+.details-col-tags .tags {
+    display: flex;
+    flex-wrap: wrap;
+    align-content: flex-start;
+}
+.details-col-tags .label {
+    margin: 0 0.3em 0.3em 0;
+    font-size: 1em;
+    letter-spacing: normal;
+}
 .details-col-crit {
     width: 3.5em;
     text-align: center;

--- a/src/robot/htmldata/rebot/report.html
+++ b/src/robot/htmldata/rebot/report.html
@@ -841,7 +841,7 @@ function hideHiddenDetailsColumns(elem) {
   {{/if}}
     <td class="details-col-doc"><div class="doc details-limited">{{html doc()}}</div></td>
     <td class="details-col-metadata"><div class="details-limited">{{if metadata.length}}<table class="metadata">{{each metadata}}<tr><th>{{html $value[0]}}:</th><td class="doc">{{html $value[1]}}</td></tr>{{/each}}</table>{{/if}}</div></td>
-    <td class="details-col-tags"><div>{{html tags.join(', ')}}</div></td>
+    <td class="details-col-tags"><div class="tags">{{each tags}}<span class="label">{{html $value}}</span>{{/each}}</div></td>
     <td class="details-col-status"><div><span class="label ${status.toLowerCase()}">${status}</span></div></td>
     <td class="details-col-msg"><div class="message details-limited">{{html message()}}</div></td>
     <td class="details-col-elapsed"><div>${times.elapsedTime}</div></td>

--- a/src/robot/htmldata/rebot/testdata.js
+++ b/src/robot/htmldata/rebot/testdata.js
@@ -68,7 +68,7 @@ window.testdata = function () {
             timeout: strings.get(element[3]),
             args: strings.get(element[5]),
             assign: strings.get(element[6]),
-            tags: strings.get(element[7]),
+            tags: tags(element[7], strings),
             doc: function () {
                 var doc = strings.get(element[4]);
                 this.doc = function () { return doc; };

--- a/src/robot/reporting/jsmodelbuilders.py
+++ b/src/robot/reporting/jsmodelbuilders.py
@@ -214,7 +214,7 @@ class BodyItemBuilder(Builder):
             kw.doc,
             "    ".join(kw.args),
             "    ".join(kw.assign),
-            ", ".join(kw.tags),
+            kw.tags,
             body,
             split=split,
         )
@@ -228,7 +228,7 @@ class BodyItemBuilder(Builder):
         doc="",
         args="",
         assign="",
-        tags="",
+        tags=(),
         body=None,
         split=False,
     ):
@@ -242,7 +242,7 @@ class BodyItemBuilder(Builder):
             self._html(doc),
             self._string(args),
             self._string(assign),
-            self._string(tags),
+            tuple(self._string(t) for t in tags),
             self._get_status(item, note_only=True),
             self._build_body(body, split),
         )

--- a/utest/reporting/test_jsmodelbuilders.py
+++ b/utest/reporting/test_jsmodelbuilders.py
@@ -157,7 +157,7 @@ class TestBuildTestSuite(unittest.TestCase):
             '<a href="http://doc">http://doc</a>',
             "arg1    arg2",
             "${v1}    ${v2}",
-            "tag1, tag2",
+            ("tag1", "tag2"),
             "1 second",
             0,
             0,
@@ -290,11 +290,11 @@ class TestBuildTestSuite(unittest.TestCase):
         test.body[0].body.create_branch(BodyItem.ELSE_IF, "$x < 0", status="PASS")
         test.body[0].body.create_branch(BodyItem.ELSE, status="NOT RUN")
         test.body[0].body[-1].body.create_keyword("z")
-        exp_if = (5, "$x &gt; 0", "", "", "", "", "", "", (3, None, 0), ())
-        exp_else_if = (6, "$x &lt; 0", "", "", "", "", "", "", (1, None, 0), ())
+        exp_if = (5, "$x &gt; 0", "", "", "", "", "", (), (3, None, 0), ())
+        exp_else_if = (6, "$x &lt; 0", "", "", "", "", "", (), (1, None, 0), ())
         exp_else = (
-            7, '', '', '', '', '', '', '', (3, None, 0),
-            ((0, 'z', '', '', '', '', '', '', (0, None, 0), ()),)
+            7, '', '', '', '', '', '', (), (3, None, 0),
+            ((0, 'z', '', '', '', '', '', (), (0, None, 0), ()),)
         )  # fmt: skip
         self._verify_test(test, body=(exp_if, exp_else_if, exp_else))
 
@@ -342,7 +342,7 @@ class TestBuildTestSuite(unittest.TestCase):
         test.body.create_message("Hi from test again", "WARN")
         exp_m1 = (None, 2, "Hi from test")
         exp_kw = (
-            0, '', '', '', '', '', '', '', (0, None, 0),
+            0, '', '', '', '', '', '', (), (0, None, 0),
             ((None, 2, 'Hi from keyword'),)
         )  # fmt: skip
         exp_m3 = (None, 3, "Hi from test again")
@@ -421,7 +421,7 @@ class TestBuildTestSuite(unittest.TestCase):
         doc="",
         args="",
         assign="",
-        tags="",
+        tags=(),
         timeout="",
         status=0,
         start=None,


### PR DESCRIPTION
- Render test metadata as a table instead of a flat list
- Show tags as wrapping pills in `report.html` and `log.html`
